### PR TITLE
Added gdnative script to set X11 transient_for property

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,11 @@ jobs:
       # Runs a single command using the runners shell
       - name: Create the Output Directory
         run: mkdir output
-
+      
+      - name: Build X11_FG
+        run: |
+            cd burrito-fg
+            cargo build
 
       - name: Build Burrito Link
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .import/
 build/*
+burrito-fg/target/*
+burrito-fg/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .import/
 build/*
 burrito-fg/target/*
-burrito-fg/Cargo.lock

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -45,9 +45,12 @@ var compass_corner2
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	get_tree().get_root().set_transparent_background(true)
-	#ProjectSettings.set_setting("display/window/size/always_on_top", true)
-	#OS.set_window_always_on_top(true)
-
+	print("pre")
+	var x11 = X11_FG.new()
+	print("post init")
+	var wid = OS.get_native_handle(OS.WINDOW_HANDLE)
+	x11.set_transient_for(wid)
+	print("PT")
 	OS.window_maximized = false
 	OS.window_size = Vector2(1920, 1080)
 	set_minimal_mouse_block()

--- a/Spatial.gdns
+++ b/Spatial.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://libburrito.tres" type="GDNativeLibrary" id=1]
+
+[resource]
+class_name = "X11_FG"
+library = ExtResource( 1 )
+script_class_name = "X11_FG"

--- a/burrito-fg/Cargo.toml
+++ b/burrito-fg/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "burrito-fg"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gdnative = "0.9"
+breadx = {git="https://github.com/royalmustard/breadx"}

--- a/burrito-fg/src/lib.rs
+++ b/burrito-fg/src/lib.rs
@@ -1,0 +1,91 @@
+use breadx::{
+    auto::xproto::ATOM_WM_TRANSIENT_FOR,
+    traits::{PropMode, PropertyFormat, PropertyType, ATOM_WM_NAME},
+    Display, DisplayBase, DisplayConnection, Window,
+};
+use gdnative::prelude::*;
+
+#[derive(NativeClass)]
+#[inherit(Node)]
+pub struct X11_FG;
+// Function that registers all exposed classes to Godot
+fn init(handle: InitHandle) {
+    handle.add_class::<X11_FG>();
+}
+
+impl X11_FG {
+    /// The "constructor" of the class.
+    fn new(_owner: &Node) -> Self {
+        X11_FG
+    }
+}
+
+#[methods]
+impl X11_FG {
+    #[export]
+    fn _ready(&self, _owner: &Node) {
+        godot_print!("Hello,X11!");
+        return;
+    }
+
+    #[export]
+    fn set_transient_for(&self, _owner: &Node, burrito_id: i32) {
+        godot_print!("Setting transient for");
+        let mut dpy = DisplayConnection::create(None, None).unwrap();
+        let gw2 = get_window_from_name(&mut dpy, String::from("Guild Wars 2"));
+        if let None = gw2 {
+            godot_print!("Failed to get gw2 window");
+            return;
+        }
+        godot_print!("{:?}", gw2);
+        let burrito = Window::const_from_xid(burrito_id as u32);
+        burrito
+            .change_property(
+                &mut dpy,
+                ATOM_WM_TRANSIENT_FOR,
+                PropertyType::Window,
+                PropertyFormat::ThirtyTwo,
+                PropMode::Replace,
+                &[gw2.unwrap()],
+            )
+            .unwrap();
+    }
+}
+
+fn get_window_from_name<D: Display>(dpy: &mut D, name: String) -> Option<Window> {
+    let root = dpy.default_root();
+    //TODO: Thread, that tries acquiring the window handle repeatedly until successful or terminated
+    return search_window_from_name(dpy, &name, root);
+}
+
+fn search_window_from_name<D: Display>(
+    dpy: &mut D,
+    name: &String,
+    current: Window,
+) -> Option<Window> {
+    let tree = current.query_tree_immediate(dpy).unwrap();
+    let cur_name: String = current
+        .get_property_immediate(dpy, ATOM_WM_NAME, PropertyType::String, false)
+        .unwrap()
+        .unwrap();
+    if cur_name == *name {
+        return Some(current);
+    }
+    //only need to look at children since we start at root
+    for child in tree.children.iter() {
+        if let Some(window) = search_window_from_name(dpy, &name, *child) {
+            return Some(window);
+        }
+    }
+    None
+}
+
+// Macro that creates the entry-points of the dynamic library.
+godot_init!(init);
+
+#[test]
+fn test_search() {
+    let mut dpy = DisplayConnection::create(None, None).unwrap();
+    let _gw2 = get_window_from_name(&mut dpy, String::from("Guild Wars 2"));
+    println!("{:?}", _gw2)
+}

--- a/libburrito.tres
+++ b/libburrito.tres
@@ -1,0 +1,7 @@
+[gd_resource type="GDNativeLibrary" format=2]
+
+[resource]
+entry/X11.64 = "res://burrito-fg/target/debug/libburrito_fg.so"
+entry/X11.32 = "res://burrito-fg/target/debug/libburrito_fg.so"
+dependency/X11.64 = [  ]
+dependency/X11.32 = [  ]

--- a/project.godot
+++ b/project.godot
@@ -8,8 +8,14 @@
 
 config_version=4
 
-_global_script_classes=[  ]
+_global_script_classes=[ {
+"base": "Node",
+"class": "X11_FG",
+"language": "NativeScript",
+"path": "res://Spatial.gdns"
+} ]
 _global_script_class_icons={
+"X11_FG": ""
 }
 
 [application]
@@ -30,6 +36,11 @@ window/size/always_on_top=true
 window/vsync/use_vsync=false
 window/per_pixel_transparency/allowed=true
 window/per_pixel_transparency/enabled=true
+
+[global]
+
+logg=true
+logging=true
 
 [rendering]
 


### PR DESCRIPTION
This pr adds a gdnative library (written in rust) to solve #25.
The library exposes a method which takes Burritos X Window id from godot.
It then acquires the GW2 window Id by searching for a window with the name "Guild Wars 2". Because of that burrito needs to be launched after GW2 is already running.
Finally, it sets the WM_TRANSIENT_FOR property of the Burrito window.