### PR TITLE
Change breadx dependency to crates.io

### DIFF
--- a/burrito-fg/Cargo.toml
+++ b/burrito-fg/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gdnative = "0.9"
-breadx = {git="https://github.com/royalmustard/breadx"}
+breadx = "2"


### PR DESCRIPTION
as my changes have been merged and the new diagnostics for connecting were added, there is no more reason to use my repo for this