### PR TITLE
Dynamic screen size

### DIFF
--- a/Spatial.gd
+++ b/Spatial.gd
@@ -230,6 +230,7 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	var x11_window_id_gw2 = spb.get_32()
 	if !is_transient:
 		is_transient = x11_fg.set_transient_for(x11_window_id_burrito, x11_window_id_gw2)
+
 	var identity_length: int = spb.get_32()
 	var identity_str = spb.get_utf8_string(identity_length)
 	var identity = JSON.parse(identity_str).result

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -230,7 +230,6 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	var x11_window_id_gw2 = spb.get_32()
 	if !is_transient:
 		is_transient = x11_fg.set_transient_for(x11_window_id_burrito, x11_window_id_gw2)
-
 	var identity_length: int = spb.get_32()
 	var identity_str = spb.get_utf8_string(identity_length)
 	var identity = JSON.parse(identity_str).result

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -52,9 +52,9 @@ func _ready():
 	x11_fg = X11_FG.new()
 	x11_window_id_burrito = OS.get_native_handle(OS.WINDOW_HANDLE)
 	OS.window_maximized = false
-	var size_tuple = x11_fg.get_gw2_geometry()
-	OS.window_size = Vector2(size_tuple[0], size_tuple[1])
-	# Postion window in center of screen
+	# Start off with a small size before GW2 client is up
+	OS.window_size = Vector2(800, 600)
+	# Postion at top left corner
 	OS.set_window_position(Vector2(0,0))
 	set_minimal_mouse_block()
 	server.listen(4242)
@@ -104,9 +104,7 @@ func _process(delta):
 			if packet_type == 1:
 				decode_frame_packet(spb)
 			elif packet_type == 2:
-				decode_context_packet(spb)
-	var size_tuple = x11_fg.get_gw2_geometry()
-	OS.window_size = Vector2(size_tuple[0], size_tuple[1])
+				decode_context_packet(spb)	
 	return
 
 
@@ -230,6 +228,8 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	var x11_window_id_gw2 = spb.get_32()
 	if !is_transient:
 		is_transient = x11_fg.set_transient_for(x11_window_id_burrito, x11_window_id_gw2)
+	var size_tuple = x11_fg.get_window_geometry(x11_window_id_gw2)
+	OS.window_size = Vector2(size_tuple[0], size_tuple[1])
 	var identity_length: int = spb.get_32()
 	var identity_str = spb.get_utf8_string(identity_length)
 	var identity = JSON.parse(identity_str).result

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -52,7 +52,9 @@ func _ready():
 	x11_fg = X11_FG.new()
 	x11_window_id_burrito = OS.get_native_handle(OS.WINDOW_HANDLE)
 	OS.window_maximized = false
-	OS.window_size = Vector2(1920, 1080)
+	OS.window_size = OS.get_screen_size()
+	# Postion window in center of screen
+	OS.set_window_position(Vector2(0,0))
 	set_minimal_mouse_block()
 	server.listen(4242)
 
@@ -83,7 +85,6 @@ func _process(delta):
 	#OS.window_position = Vector2(1920, 0) # TODO: This does not seem to work	
 	#OS.set_window_position(Vector2(1920,0))
 	#print(OS.window_position)
-
 	server.poll() # Important
 	if server.is_connection_available():
 		var peer: PacketPeerUDP = server.take_connection()

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -52,7 +52,8 @@ func _ready():
 	x11_fg = X11_FG.new()
 	x11_window_id_burrito = OS.get_native_handle(OS.WINDOW_HANDLE)
 	OS.window_maximized = false
-	OS.window_size = OS.get_screen_size()
+	var size_tuple = x11_fg.get_gw2_geometry()
+	OS.window_size = Vector2(size_tuple[0], size_tuple[1])
 	# Postion window in center of screen
 	OS.set_window_position(Vector2(0,0))
 	set_minimal_mouse_block()
@@ -104,7 +105,8 @@ func _process(delta):
 				decode_frame_packet(spb)
 			elif packet_type == 2:
 				decode_context_packet(spb)
-
+	var size_tuple = x11_fg.get_gw2_geometry()
+	OS.window_size = Vector2(size_tuple[0], size_tuple[1])
 	return
 
 
@@ -228,7 +230,6 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	var x11_window_id_gw2 = spb.get_32()
 	if !is_transient:
 		is_transient = x11_fg.set_transient_for(x11_window_id_burrito, x11_window_id_gw2)
-		
 	var identity_length: int = spb.get_32()
 	var identity_str = spb.get_utf8_string(identity_length)
 	var identity = JSON.parse(identity_str).result

--- a/burrito-fg/src/lib.rs
+++ b/burrito-fg/src/lib.rs
@@ -59,10 +59,10 @@ impl X11_FG {
     }
 
     #[export]
-    fn get_gw2_geometry(&self, _owner: &Node) -> (u16, u16){
+    fn get_window_geometry(&self, _owner: &Node, gw2_id: i32) -> (u16, u16){
         let mut dpy = DisplayConnection::create(None, None).unwrap();
-        let window = get_window_from_name(&mut dpy, String::from("Guild Wars 2"));
-        let geometry = window.unwrap().geometry_immediate(&mut dpy).unwrap();
+        let window = Window::const_from_xid(gw2_id as u32);
+        let geometry = window.geometry_immediate(&mut dpy).unwrap();
         return (geometry.width, geometry.height)
     }
 }

--- a/burrito-fg/src/lib.rs
+++ b/burrito-fg/src/lib.rs
@@ -57,6 +57,14 @@ impl X11_FG {
         godot_print!("Setting transient property failed");
         return false;
     }
+
+    #[export]
+    fn get_gw2_geometry(&self, _owner: &Node) -> (u16, u16){
+        let mut dpy = DisplayConnection::create(None, None).unwrap();
+        let window = get_window_from_name(&mut dpy, String::from("Guild Wars 2"));
+        let geometry = window.unwrap().geometry_immediate(&mut dpy).unwrap();
+        return (geometry.width, geometry.height)
+    }
 }
 
 fn get_window_from_name<D: Display>(dpy: &mut D, name: String) -> Option<Window> {


### PR DESCRIPTION
Attempts to address #29 

Use `OS.get_screen_size` to dynamically set resolution. Assumes full screen used.

Also a minor fix to center the window, using `OS.set_window_position`.

Tested on: Manjaro with Gnome