### PR TITLE
Allow Sane Indendentation in Jinja Templates

### DIFF
--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -7,6 +7,7 @@ import os
 import markdown
 from dataclasses import dataclass, field
 from jinja2 import Template, FileSystemLoader, Environment
+from jinja_helpers import UnindentBlocks
 
 SchemaType = Dict[str, Any]
 schema = """
@@ -374,7 +375,13 @@ class Generator:
     def write_cpp_classes(self, output_directory: str) -> None:
         print("Writing XML Node Cpp Classes")
         file_loader = FileSystemLoader('cpp_templates')
-        env = Environment(loader=file_loader, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
+        env = Environment(
+            loader=file_loader,
+            extensions=["jinja_helpers.UnindentBlocks"],
+            keep_trailing_newline=True,
+            trim_blocks=True,
+            lstrip_blocks=True
+        )
         header_template: Template = env.get_template("class_template.hpp")
         code_template: Template = env.get_template("class_template.cpp")
         attributes_of_type_marker_category: List[str] = []
@@ -562,7 +569,13 @@ class Generator:
         os.makedirs(output_directory, exist_ok=True)
 
         file_loader = FileSystemLoader('cpp_templates')
-        env = Environment(loader=file_loader, keep_trailing_newline=True, trim_blocks=True, lstrip_blocks=True)
+        env = Environment(
+            loader=file_loader,
+            extensions=["jinja_helpers.UnindentBlocks"],
+            keep_trailing_newline=True,
+            trim_blocks=True,
+            lstrip_blocks=True
+        )
         attribute_names: Dict[str, str] = {}
         attribute_variables: List[AttributeVariable] = []
         attribute_variable: AttributeVariable

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -377,7 +377,7 @@ class Generator:
         file_loader = FileSystemLoader('cpp_templates')
         env = Environment(
             loader=file_loader,
-            extensions=["jinja_helpers.UnindentBlocks"],
+            extensions=[UnindentBlocks],
             keep_trailing_newline=True,
             trim_blocks=True,
             lstrip_blocks=True
@@ -571,7 +571,7 @@ class Generator:
         file_loader = FileSystemLoader('cpp_templates')
         env = Environment(
             loader=file_loader,
-            extensions=["jinja_helpers.UnindentBlocks"],
+            extensions=[UnindentBlocks],
             keep_trailing_newline=True,
             trim_blocks=True,
             lstrip_blocks=True

--- a/xml_converter/generators/cpp_templates/attribute_template.hpp
+++ b/xml_converter/generators/cpp_templates/attribute_template.hpp
@@ -5,37 +5,37 @@
 
 #include "../rapidxml-1.13/rapidxml.hpp"
 {% if type == "Enum":%}
-#include "waypoint.pb.h"
+    #include "waypoint.pb.h"
 
-class XMLError;
+    class XMLError;
 
-enum {{class_name}} {
-    {% for attribute_variable in attribute_variables: %}
-    {{attribute_variable.attribute_name}},
-    {% endfor %}
-};
+    enum {{class_name}} {
+        {% for attribute_variable in attribute_variables: %}
+        {{attribute_variable.attribute_name}},
+        {% endfor %}
+    };
 {% else: %}
-class XMLError;
-namespace waypoint {
-class {{class_name}};
-}
-
-class {{class_name}} {
- public:
-    {% for attribute_variable in attribute_variables: %}
-    {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
-    {% endfor %}
-
-    virtual std::string classname() {
-        return "{{class_name}}";
+    class XMLError;
+    namespace waypoint {
+    class {{class_name}};
     }
-};
+
+    class {{class_name}} {
+     public:
+        {% for attribute_variable in attribute_variables: %}
+        {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
+        {% endfor %}
+
+        virtual std::string classname() {
+            return "{{class_name}}";
+        }
+    };
 {% endif %}
 {{class_name}} parse_{{attribute_name}}(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 std::string stringify_{{attribute_name}}({{class_name}} attribute_value);
 {% if type == "Enum":%}
-waypoint::{{class_name}} to_proto_{{attribute_name}}({{class_name}} attribute_value);
+    waypoint::{{class_name}} to_proto_{{attribute_name}}({{class_name}} attribute_value);
 {% else: %}
-waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_value);
+    waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_value);
 {% endif %}
 {{class_name}} from_proto_{{attribute_name}}(waypoint::{{class_name}} proto_{{attribute_name}});

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -2,15 +2,15 @@
 
 #include <algorithm>
 {% for absolute_include in cpp_includes.sorted_cpp_absolute_includes() %}
-#include <{{absolute_include}}>
+    #include <{{absolute_include}}>
 {% endfor %}
 
 {% for relative_include in cpp_includes.sorted_cpp_relative_includes() %}
-#include "{{relative_include}}"
+    #include "{{relative_include}}"
 {% endfor %}
 
 {% for forward_declaration in cpp_includes.sorted_cpp_forward_declarations() %}
-class {{forward_declaration}};
+    class {{forward_declaration}};
 {% endfor %}
 using namespace std;
 
@@ -18,48 +18,48 @@ string {{cpp_class}}::classname() {
     return "{{xml_class_name}}";
 }
 {% if cpp_class == "Category": %}
-void {{cpp_class}}::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, string base_dir) {
-    for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
-        bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors);
-        bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors);
+    void {{cpp_class}}::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, string base_dir) {
+        for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
+            bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors);
+            bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors);
 
-        if (init_xml_attribute(attribute, errors, base_dir)) {
-        }
-        else if (is_icon_value || is_trail_value) {
-        }
-        else {
-            errors->push_back(new XMLAttributeNameError("Unknown " + this->classname() + " attribute ", attribute));
+            if (init_xml_attribute(attribute, errors, base_dir)) {
+            }
+            else if (is_icon_value || is_trail_value) {
+            }
+            else {
+                errors->push_back(new XMLAttributeNameError("Unknown " + this->classname() + " attribute ", attribute));
+            }
         }
     }
-}
 {% endif %}
 
 bool {{cpp_class}}::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, string base_dir) {
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     {% for n, attribute_variable in enumerate(attribute_variables) %}
-    {% for i, value in enumerate(attribute_variable.xml_fields) %}
-    {% if i == 0 and n == 0: %}
-    if (attributename == "{{value}}") {
-        this->{{attribute_variable.attribute_name}} = parse_{{attribute_variable.class_name}}({{", ".join(attribute_variable.args)}});
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% elif (attribute_variable.attribute_type == "CompoundValue" and attribute_variable.compound_name != None) %}
-    else if (attributename == "{{value}}") {
-        this->{{attribute_variable.compound_name}}.{{attribute_variable.attribute_name}} = parse_float(attribute, errors);
-        this->{{attribute_variable.compound_name}}_is_set = true;
-    }
-    {% else: %}
-    else if (attributename == "{{value}}") {
-        this->{{attribute_variable.attribute_name}} = parse_{{attribute_variable.class_name}}({{", ".join(attribute_variable.args)}});
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-        {% for side_effect in attribute_variable.side_effects %}
-        this->{{side_effect}} = this->{{attribute_variable.class_name}}.side_effect_{{side_effect}};
-        this->{{side_effect}}_is_set = true;
+        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+            {% if i == 0 and n == 0: %}
+                if (attributename == "{{value}}") {
+                    this->{{attribute_variable.attribute_name}} = parse_{{attribute_variable.class_name}}({{", ".join(attribute_variable.args)}});
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% elif (attribute_variable.attribute_type == "CompoundValue" and attribute_variable.compound_name != None) %}
+                else if (attributename == "{{value}}") {
+                    this->{{attribute_variable.compound_name}}.{{attribute_variable.attribute_name}} = parse_float(attribute, errors);
+                    this->{{attribute_variable.compound_name}}_is_set = true;
+                }
+            {% else: %}
+                else if (attributename == "{{value}}") {
+                    this->{{attribute_variable.attribute_name}} = parse_{{attribute_variable.class_name}}({{", ".join(attribute_variable.args)}});
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                    {% for side_effect in attribute_variable.side_effects %}
+                        this->{{side_effect}} = this->{{attribute_variable.class_name}}.side_effect_{{side_effect}};
+                        this->{{side_effect}}_is_set = true;
+                    {% endfor %}
+                }
+            {% endif %}
         {% endfor %}
-    }
-    {% endif %}
-    {% endfor %}
     {% endfor %}
     else {
         return false;
@@ -69,169 +69,169 @@ bool {{cpp_class}}::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vec
 
 {%- if attributes_of_type_marker_category %}
 
-bool {{cpp_class}}::validate_attributes_of_type_marker_category() {
-    {% for attribute in attributes_of_type_marker_category %}
-    // TODO: validate "{{attribute}}"
-    {% endfor %}
-    return true;
-}
+    bool {{cpp_class}}::validate_attributes_of_type_marker_category() {
+        {% for attribute in attributes_of_type_marker_category %}
+        // TODO: validate "{{attribute}}"
+        {% endfor %}
+        return true;
+    }
 {% endif %}
 
 vector<string> {{cpp_class}}::as_xml() const {
     vector<string> xml_node_contents;
     xml_node_contents.push_back("<{{xml_class_name}} ");
     {% for attribute_variable in attribute_variables %}
-    {% if (attribute_variable.attribute_type == "CompoundValue") %}
-    {% if (attribute_variable.xml_export == "Children" and attribute_variable.compound_name != None) %}
-    if (this->{{attribute_variable.compound_name}}_is_set) {
-        xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + to_string(this->{{attribute_variable.compound_name}}.{{attribute_variable.attribute_name}}) + "\"");
-    }
-    {% elif (attribute_variable.xml_export == "Parent" and attribute_variable.compound_name == None)%}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
-    }
-    {% elif (attribute_variable.xml_export == "Parent and Children")%}
-    {% for value in attribute_variable.xml_fields %}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        xml_node_contents.push_back(" {{value}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
+        {% if (attribute_variable.attribute_type == "CompoundValue") %}
+            {% if (attribute_variable.xml_export == "Children" and attribute_variable.compound_name != None) %}
+                if (this->{{attribute_variable.compound_name}}_is_set) {
+                    xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + to_string(this->{{attribute_variable.compound_name}}.{{attribute_variable.attribute_name}}) + "\"");
+                }
+            {% elif (attribute_variable.xml_export == "Parent" and attribute_variable.compound_name == None)%}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
+                }
+            {% elif (attribute_variable.xml_export == "Parent and Children")%}
+                {% for value in attribute_variable.xml_fields %}
+                    if (this->{{attribute_variable.attribute_name}}_is_set) {
+                        xml_node_contents.push_back(" {{value}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
+                {% endfor %}
+                }
+            {% endif %}
+        {% else: %}
+            if (this->{{attribute_variable.attribute_name}}_is_set) {
+                xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
+            }
+        {% endif %}
     {% endfor %}
-    }
-    {% endif %}
-    {% else: %}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        xml_node_contents.push_back(" {{attribute_variable.default_xml_fields[0]}}=\"" + stringify_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}) + "\"");
-    }
-    {% endif %}
-    {% endfor %}
-{% if cpp_class == "Category": %}
-    xml_node_contents.push_back(">\n");
+    {% if cpp_class == "Category": %}
+        xml_node_contents.push_back(">\n");
 
-    for (const auto& [key, val] : this->children) {
-        string text;
-        for (const auto& s : val.as_xml()) {
-            text += s;
+        for (const auto& [key, val] : this->children) {
+            string text;
+            for (const auto& s : val.as_xml()) {
+                text += s;
+            }
+
+            xml_node_contents.push_back("\t" + text);
         }
 
-        xml_node_contents.push_back("\t" + text);
-    }
-
-    xml_node_contents.push_back("</MarkerCategory>\n");
-{% else: %}
-    xml_node_contents.push_back("/>");
-{% endif %}
+        xml_node_contents.push_back("</MarkerCategory>\n");
+    {% else: %}
+        xml_node_contents.push_back("/>");
+    {% endif %}
     return xml_node_contents;
 }
 
 waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     waypoint::{{cpp_class}} proto_{{cpp_class_header}};
     {% if cpp_class == "Icon": %}
-    waypoint::Trigger* trigger = nullptr;
+        waypoint::Trigger* trigger = nullptr;
     {% endif %}
-    {%for attribute_variable in attribute_variables%}
-    {% if (attribute_variable.is_trigger == true)%}
-    {% if (attribute_variable.attribute_type == "Custom")%}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        if (trigger == nullptr) {
-            trigger = new waypoint::Trigger();
-        }
-        trigger->set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-    }
-    {% elif (attribute_variable.attribute_type == "Enum")%}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        if (trigger == nullptr) {
-            trigger = new waypoint::Trigger();
-        }
-        trigger->set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-    }
-    {% else: %}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        if (trigger == nullptr) {
-            trigger = new waypoint::Trigger();
-        }
-        trigger->set_{{attribute_variable.protobuf_field}}(this->{{attribute_variable.attribute_name}});
-    }
-    {% endif %}
-    {% else: %}
-    {% if (attribute_variable.attribute_type == "Enum")%}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        proto_{{cpp_class_header}}.set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-    }
-    {% elif (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom"]) and attribute_variable.compound_name == None%}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        proto_{{cpp_class_header}}.set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-    }
-    {% elif (attribute_variable.compound_name != None)%}
-    {% else: %}
-    if (this->{{attribute_variable.attribute_name}}_is_set) {
-        proto_{{cpp_class_header}}.set_{{attribute_variable.protobuf_field}}(this->{{attribute_variable.attribute_name}});
-    }
-    {% endif %}
-    {% endif %}
+    {% for attribute_variable in attribute_variables %}
+        {% if (attribute_variable.is_trigger == true)%}
+            {% if (attribute_variable.attribute_type == "Custom")%}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    if (trigger == nullptr) {
+                        trigger = new waypoint::Trigger();
+                    }
+                    trigger->set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
+                }
+            {% elif (attribute_variable.attribute_type == "Enum")%}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    if (trigger == nullptr) {
+                        trigger = new waypoint::Trigger();
+                    }
+                    trigger->set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
+                }
+            {% else: %}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    if (trigger == nullptr) {
+                        trigger = new waypoint::Trigger();
+                    }
+                    trigger->set_{{attribute_variable.protobuf_field}}(this->{{attribute_variable.attribute_name}});
+                }
+            {% endif %}
+        {% else: %}
+            {% if (attribute_variable.attribute_type == "Enum")%}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    proto_{{cpp_class_header}}.set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
+                }
+            {% elif (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom"]) and attribute_variable.compound_name == None%}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    proto_{{cpp_class_header}}.set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
+                }
+            {% elif (attribute_variable.compound_name != None)%}
+            {% else: %}
+                if (this->{{attribute_variable.attribute_name}}_is_set) {
+                    proto_{{cpp_class_header}}.set_{{attribute_variable.protobuf_field}}(this->{{attribute_variable.attribute_name}});
+                }
+            {% endif %}
+        {% endif %}
     {% endfor %}
     {% if cpp_class == "Icon": %}
-    if (trigger != nullptr) {
-        proto_{{cpp_class_header}}.set_allocated_trigger(trigger);
-    }
+        if (trigger != nullptr) {
+            proto_{{cpp_class_header}}.set_allocated_trigger(trigger);
+        }
     {% endif %}
     {% if cpp_class == "Category": %}
-    for (const auto& [key, val] : this->children) {
-        waypoint::{{cpp_class}} proto_{{cpp_class_header}}_child = val.as_protobuf();
-        proto_{{cpp_class_header}}.add_children()->CopyFrom(proto_{{cpp_class_header}}_child);
-    }
+        for (const auto& [key, val] : this->children) {
+            waypoint::{{cpp_class}} proto_{{cpp_class_header}}_child = val.as_protobuf();
+            proto_{{cpp_class_header}}.add_children()->CopyFrom(proto_{{cpp_class_header}}_child);
+        }
     {% endif %}
     return proto_{{cpp_class_header}};
 }
 
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}) {
     {% if cpp_class == "Icon": %}
-    waypoint::Trigger trigger = proto_{{cpp_class_header}}.trigger();
+        waypoint::Trigger trigger = proto_{{cpp_class_header}}.trigger();
     {% endif %}
-    {%for attribute_variable in attribute_variables%}
-    {% if (attribute_variable.is_trigger == true)%}
-    {% if (attribute_variable.attribute_type == "Custom")%}
-    if (trigger.has_{{attribute_variable.protobuf_field}}()) {
-        this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(trigger.{{attribute_variable.protobuf_field}}());
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% elif attribute_variable.class_name == "string" %}
-    if (trigger.{{attribute_variable.protobuf_field}}() != "") {
-        this->{{attribute_variable.attribute_name}} = trigger.{{attribute_variable.protobuf_field}}();
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% elif (attribute_variable.attribute_type ==  "Enum") %}
-    if (trigger.{{attribute_variable.protobuf_field}}() != 0) {
-        this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(trigger.{{attribute_variable.protobuf_field}}());
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% else: %}
-    if (trigger.{{attribute_variable.protobuf_field}}() != 0) {
-        this->{{attribute_variable.attribute_name}} = trigger.{{attribute_variable.protobuf_field}}();
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% endif %}
-    {% else: %}
-    {% if (attribute_variable.attribute_type ==  "Enum") %}
-    if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != 0) {
-        this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}());
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% elif (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom"]) and attribute_variable.compound_name == None%}
-    if (proto_{{cpp_class_header}}.has_{{attribute_variable.protobuf_field}}()) {
-        this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}());
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% elif (attribute_variable.compound_name != None) %}
-    {% elif (attribute_variable.class_name == "string") %}
-    if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != "") {
-        this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}();
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% else: %}
-    if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != 0) {
-        this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}();
-        this->{{attribute_variable.attribute_name}}_is_set = true;
-    }
-    {% endif %}
-    {% endif %}
+    {% for attribute_variable in attribute_variables %}
+        {% if (attribute_variable.is_trigger == true) %}
+            {% if (attribute_variable.attribute_type == "Custom") %}
+                if (trigger.has_{{attribute_variable.protobuf_field}}()) {
+                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(trigger.{{attribute_variable.protobuf_field}}());
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% elif attribute_variable.class_name == "string" %}
+                if (trigger.{{attribute_variable.protobuf_field}}() != "") {
+                    this->{{attribute_variable.attribute_name}} = trigger.{{attribute_variable.protobuf_field}}();
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% elif (attribute_variable.attribute_type ==  "Enum") %}
+                if (trigger.{{attribute_variable.protobuf_field}}() != 0) {
+                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(trigger.{{attribute_variable.protobuf_field}}());
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% else: %}
+                if (trigger.{{attribute_variable.protobuf_field}}() != 0) {
+                    this->{{attribute_variable.attribute_name}} = trigger.{{attribute_variable.protobuf_field}}();
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% endif %}
+        {% else: %}
+            {% if (attribute_variable.attribute_type ==  "Enum") %}
+                if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != 0) {
+                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}());
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% elif (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom"]) and attribute_variable.compound_name == None%}
+                if (proto_{{cpp_class_header}}.has_{{attribute_variable.protobuf_field}}()) {
+                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}());
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% elif (attribute_variable.compound_name != None) %}
+            {% elif (attribute_variable.class_name == "string") %}
+                if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != "") {
+                    this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}();
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% else: %}
+                if (proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}() != 0) {
+                    this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}.{{attribute_variable.protobuf_field}}();
+                    this->{{attribute_variable.attribute_name}}_is_set = true;
+                }
+            {% endif %}
+        {% endif %}
     {% endfor %}
 }

--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -1,35 +1,36 @@
 #pragma once
 
 {% for absolute_include in cpp_includes.sorted_hpp_absolute_includes() %}
-#include <{{absolute_include}}>
+    #include <{{absolute_include}}>
 {% endfor %}
 
 {% for relative_include in cpp_includes.sorted_hpp_relative_includes() %}
-#include "{{relative_include}}"
+    #include "{{relative_include}}"
 {% endfor %}
 
 {% for forward_declaration in cpp_includes.sorted_hpp_forward_declarations() %}
-class {{forward_declaration}};
+    class {{forward_declaration}};
 {% endfor %}
 
 class {{cpp_class}} : public Parseable {
  public:
     {% for attribute_variable in attribute_variables: %}
-    {% if attribute_variable.compound_name == None: %}
-    {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
-    {% endif %}
+        {% if attribute_variable.compound_name == None: %}
+            {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
+        {% endif %}
     {% endfor %}
     {% for attribute_variable in attribute_variables: %}
-    {% if attribute_variable.compound_name == None: %}
-    bool {{attribute_variable.attribute_name}}_is_set = false;
-    {% endif %}
+        {% if attribute_variable.compound_name == None: %}
+            bool {{attribute_variable.attribute_name}}_is_set = false;
+        {% endif %}
     {% endfor %}
     {% if cpp_class == "Category": %}
-    std::map<std::string, Category> children;
-    Icon default_icon;
-    Trail default_trail;
+        std::map<std::string, Category> children;
+        Icon default_icon;
+        Trail default_trail;
 
-    void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
+        void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
+        void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors);
     {% endif %}
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
@@ -37,6 +38,6 @@ class {{cpp_class}} : public Parseable {
     waypoint::{{cpp_class}} as_protobuf() const;
     void parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}});
     {% if attributes_of_type_marker_category %}
-    bool validate_attributes_of_type_marker_category();
+        bool validate_attributes_of_type_marker_category();
     {% endif %}
 };

--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -30,7 +30,6 @@ class {{cpp_class}} : public Parseable {
         Trail default_trail;
 
         void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
-        void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors);
     {% endif %}
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();

--- a/xml_converter/generators/cpp_templates/compoundvalue.cpp
+++ b/xml_converter/generators/cpp_templates/compoundvalue.cpp
@@ -15,36 +15,36 @@ using namespace std;
     {{class_name}} {{attribute_name}};
     vector<string> compound_values;
     string attributename;
-{% for attribute_variable in attribute_variables: %}
-    {{attribute_name}}.{{attribute_variable.attribute_name}} = 0;
-{% endfor %}
+    {% for attribute_variable in attribute_variables: %}
+        {{attribute_name}}.{{attribute_variable.attribute_name}} = 0;
+    {% endfor %}
     attributename = get_attribute_name(input);
     compound_values = split(get_attribute_value(input), ",");
     if (compound_values.size() == {{ attribute_variables|length }}) {
-{% for n, attribute_variable in enumerate(attribute_variables) %}
-        {{attribute_name}}.{{attribute_variables[n].attribute_name}} = std::stof(compound_values[{{n}}]);
-{% endfor %}
+        {% for n, attribute_variable in enumerate(attribute_variables) %}
+            {{attribute_name}}.{{attribute_variables[n].attribute_name}} = std::stof(compound_values[{{n}}]);
+        {% endfor %}
     }
     return {{attribute_name}};
 }
 {% if attribute_variables[0].xml_export == "Parent" %}
-string stringify_{{attribute_name}}({{class_name}} attribute_value) {
-    string output;
-    {% for n, attribute_variable in enumerate(attribute_variables) %}
-        {% if n == 0: %}
-    output = to_string(attribute_value.{{attribute_variables[n].attribute_name}});
-        {% else %}
-    output = output + "," + to_string(attribute_value.{{attribute_variables[n].attribute_name}});
-        {% endif %}
-    {% endfor %}
-    return output;
-}
+    string stringify_{{attribute_name}}({{class_name}} attribute_value) {
+        string output;
+        {% for n, attribute_variable in enumerate(attribute_variables) %}
+            {% if n == 0: %}
+                output = to_string(attribute_value.{{attribute_variables[n].attribute_name}});
+            {% else %}
+                output = output + "," + to_string(attribute_value.{{attribute_variables[n].attribute_name}});
+            {% endif %}
+        {% endfor %}
+        return output;
+    }
 {% endif %}
 
 waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_value) {
     waypoint::{{class_name}}* proto_{{attribute_name}} = new waypoint::{{class_name}}();
     {% for attribute_variable in attribute_variables %}
-    proto_{{attribute_name}}->set_{{attribute_variable.protobuf_field}}(attribute_value.{{attribute_variable.attribute_name}});
+        proto_{{attribute_name}}->set_{{attribute_variable.protobuf_field}}(attribute_value.{{attribute_variable.attribute_name}});
     {% endfor %}
     return proto_{{attribute_name}};
 }
@@ -52,7 +52,7 @@ waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_v
 {{class_name}} from_proto_{{attribute_name}}(waypoint::{{class_name}} proto_{{attribute_name}}) {
     {{class_name}} {{attribute_name}};
     {% for attribute_variable in attribute_variables: %}
-    {{attribute_name}}.{{attribute_variable.attribute_name}} = proto_{{attribute_name}}.{{attribute_variable.protobuf_field}}();
+        {{attribute_name}}.{{attribute_variable.attribute_name}} = proto_{{attribute_name}}.{{attribute_variable.protobuf_field}}();
     {% endfor %}
     return {{attribute_name}};
 }

--- a/xml_converter/generators/cpp_templates/enum.cpp
+++ b/xml_converter/generators/cpp_templates/enum.cpp
@@ -16,17 +16,17 @@ using namespace std;
     {{class_name}} {{attribute_name}};
     string normalized_value = normalize(get_attribute_value(input));
     {% for n, attribute_variable in enumerate(attribute_variables) %}
-    {% for i, value in enumerate(attribute_variable.xml_fields) %}
-    {% if i == 0 and n == 0: %}
-    if (normalized_value == "{{value}}") {
-        {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
-    }
-    {% else: %}
-    else if (normalized_value == "{{value}}") {
-        {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
-    }
-    {% endif %}
-    {% endfor %}
+        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+            {% if i == 0 and n == 0: %}
+                if (normalized_value == "{{value}}") {
+                    {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
+                }
+            {% else %}
+                else if (normalized_value == "{{value}}") {
+                    {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
+                }
+            {% endif %}
+        {% endfor %}
     {% endfor %}
     else {
         errors->push_back(new XMLAttributeValueError("Found an invalid value that was not in the Enum {{class_name}}", input));
@@ -37,17 +37,17 @@ using namespace std;
 
 string stringify_{{attribute_name}}({{class_name}} attribute_value) {
     {% for n, attribute_variable in enumerate(attribute_variables) %}
-    {% for i, value in enumerate(attribute_variable.xml_fields) %}
-        {%-if i == 0 and n == 0:%}
-    if (attribute_value == {{class_name}}::{{attribute_variable.attribute_name}}) {
-        return "{{value}}";
-    }
-    {% else: %}
-    else if (attribute_value == {{class_name}}::{{attribute_variable.attribute_name}}) {
-        return "{{value}}";
-    }
-    {%  endif %}
-    {%  endfor %}
+        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+            {%-if i == 0 and n == 0:%}
+                if (attribute_value == {{class_name}}::{{attribute_variable.attribute_name}}) {
+                    return "{{value}}";
+                }
+            {% else: %}
+                else if (attribute_value == {{class_name}}::{{attribute_variable.attribute_name}}) {
+                    return "{{value}}";
+                }
+            {%  endif %}
+        {%  endfor %}
     {%  endfor %}
     else {
         return "{{class_name}}::{{attribute_variables[0].xml_fields[0]}}";
@@ -56,10 +56,10 @@ string stringify_{{attribute_name}}({{class_name}} attribute_value) {
 
 waypoint::{{class_name}} to_proto_{{attribute_name}}({{class_name}} attribute_value) {
     switch (attribute_value) {
-    {% for attribute_variable in attribute_variables %}
-        case {{class_name}}::{{attribute_variable.attribute_name}}:
-            return waypoint::{{class_name}}::{{attribute_variable.attribute_name}};
-    {% endfor %}
+        {% for attribute_variable in attribute_variables %}
+            case {{class_name}}::{{attribute_variable.attribute_name}}:
+                return waypoint::{{class_name}}::{{attribute_variable.attribute_name}};
+        {% endfor %}
         default:
             return waypoint::{{class_name}}::{{attribute_variables[0].attribute_name}};
     }
@@ -67,10 +67,10 @@ waypoint::{{class_name}} to_proto_{{attribute_name}}({{class_name}} attribute_va
 
 {{class_name}} from_proto_{{attribute_name}}(waypoint::{{class_name}} proto_{{attribute_name}}) {
     switch (proto_{{attribute_name}}) {
-    {% for attribute_variable in attribute_variables %}
-        case waypoint::{{class_name}}::{{attribute_variable.attribute_name}}:
-            return {{class_name}}::{{attribute_variable.attribute_name}};
-    {% endfor %}
+        {% for attribute_variable in attribute_variables %}
+            case waypoint::{{class_name}}::{{attribute_variable.attribute_name}}:
+                return {{class_name}}::{{attribute_variable.attribute_name}};
+        {% endfor %}
         default:
             return {{class_name}}::{{attribute_variables[0].attribute_name}};
     }

--- a/xml_converter/generators/cpp_templates/multiflagvalue.cpp
+++ b/xml_converter/generators/cpp_templates/multiflagvalue.cpp
@@ -16,24 +16,24 @@ using namespace std;
     {{class_name}} {{attribute_name}};
     vector<string> flag_values;
     flag_values = split(get_attribute_value(input), ",");
-{% for attribute_variable in attribute_variables %}
-    {{attribute_name}}.{{attribute_variable.attribute_name}} = false;
-{% endfor %}
+    {% for attribute_variable in attribute_variables %}
+        {{attribute_name}}.{{attribute_variable.attribute_name}} = false;
+    {% endfor %}
 
     for (string flag_value : flag_values) {
         string normalized_flag_value = normalize(flag_value);
         {% for n, attribute_variable in enumerate(attribute_variables) %}
-        {% for i, value in enumerate(attribute_variable.xml_fields) %}
-        {% if i == 0 and n == 0: %}
-        if (normalized_flag_value == "{{value}}") {
-            {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
-        }
-        {% else: %}
-        else if (normalized_flag_value == "{{value}}") {
-            {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
-        }
-        {% endif %}
-        {%- endfor %}
+            {% for i, value in enumerate(attribute_variable.xml_fields) %}
+                {% if i == 0 and n == 0: %}
+                    if (normalized_flag_value == "{{value}}") {
+                        {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
+                    }
+                {% else: %}
+                    else if (normalized_flag_value == "{{value}}") {
+                        {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
+                    }
+                {% endif %}
+            {%- endfor %}
         {%- endfor %}
         else {
             errors->push_back(new XMLAttributeValueError("Invalid Filter for {{class_name}}. Found " + flag_value, input));
@@ -45,18 +45,18 @@ using namespace std;
 
 string stringify_{{attribute_name}}({{class_name}} attribute_value) {
     string output = "";
-{% for n, attribute_variable in enumerate(attribute_variables)%}
-    if (attribute_value.{{attribute_variable.attribute_name}} == true) {
-        output = output + "{{attribute_variable.xml_fields[0]}}";
-    }
-{% endfor %}
+    {% for n, attribute_variable in enumerate(attribute_variables)%}
+        if (attribute_value.{{attribute_variable.attribute_name}} == true) {
+            output = output + "{{attribute_variable.xml_fields[0]}}";
+        }
+    {% endfor %}
     return output;
 }
 
 waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_value) {
     waypoint::{{class_name}}* proto_{{attribute_name}} = new waypoint::{{class_name}}();
     {% for n, attribute_variable in enumerate(attribute_variables)%}
-    proto_{{attribute_name}}->set_{{attribute_variable.attribute_name}}(attribute_value.{{attribute_variable.attribute_name}});
+        proto_{{attribute_name}}->set_{{attribute_variable.attribute_name}}(attribute_value.{{attribute_variable.attribute_name}});
     {% endfor %}
     return proto_{{attribute_name}};
 }
@@ -64,7 +64,7 @@ waypoint::{{class_name}}* to_proto_{{attribute_name}}({{class_name}} attribute_v
 {{class_name}} from_proto_{{attribute_name}}(waypoint::{{class_name}} proto_{{attribute_name}}) {
     {{class_name}} {{attribute_name}};
     {% for n, attribute_variable in enumerate(attribute_variables)%}
-    {{attribute_name}}.{{attribute_variable.attribute_name}} = proto_{{attribute_name}}.{{attribute_variable.attribute_name}}();
+        {{attribute_name}}.{{attribute_variable.attribute_name}} = proto_{{attribute_name}}.{{attribute_variable.attribute_name}}();
     {% endfor %}
     return {{attribute_name}};
 }

--- a/xml_converter/generators/jinja_helpers.py
+++ b/xml_converter/generators/jinja_helpers.py
@@ -1,0 +1,213 @@
+from dataclasses import dataclass
+from jinja2.ext import Extension
+from typing import Tuple, Optional, List
+import enum
+import re
+
+
+################################################################################
+# IndentFlow
+#
+# An enum to represent the different actions that can be taken for a given line
+# of the jinja template.
+################################################################################
+class IndentFlow(enum.Enum):
+    push = enum.auto()
+    keep = enum.auto()
+    pop = enum.auto()
+    poppush = enum.auto()
+
+
+################################################################################
+# IndentStackElem
+#
+# A dataclass that keeps track of the indentation of a specific block of the
+# template and can apply the indentation to all the lines in that block easily.
+################################################################################
+@dataclass
+class IndentStackElem():
+    indentation: str
+    token: str
+    startline: str
+    lines: List[str]
+
+    def apply_indent(self):
+
+        indented_lines = [self.indentation + self.startline]
+
+        for line in unindent_block(self.lines):
+            if line == "":
+                indented_lines.append(line)
+                continue
+            indented_lines.append(self.indentation + line)
+
+        return indented_lines
+
+
+################################################################################
+# unindent_blocks
+#
+# Attempts to read a jinja format string and 
+################################################################################
+tag_regex = re.compile(r".*\{\%-?(.*)\-?%\}.*")
+
+indentation_regex = re.compile(r"^(?P<indent>[ \t]*)(?P<line>.*)")
+
+class UnindentBlocks(Extension):
+    def preprocess(self, source, name, filename=None) -> str:
+        indentation_stack: List[IndentStackElem] = [IndentStackElem("", "", "", [])]
+
+        output_lines: List[str] = []
+
+        for line in source.split("\n"):
+
+
+            indentation_match = re.match(indentation_regex, line)
+            if indentation_match == None:
+                raise ValueError("Cannot Identify Indentation")
+
+            whitespace = indentation_match.groupdict()["indent"]
+            unindented_line = indentation_match.groupdict()["line"]
+
+
+            flow = self.indent_flow(unindented_line)
+
+            if flow[0] == IndentFlow.push:
+                indentation_stack.append(IndentStackElem(whitespace, flow[1], unindented_line, []))
+
+
+            elif flow[0] == IndentFlow.keep:
+                # if we are not in a block just do the normal thing
+                if len(indentation_stack) == 0:
+                    output_lines.append(whitespace + unindented_line)
+                else:
+                   # TODO check flow[1]
+                    indentation_stack[-1].lines.append(line)
+            
+            elif flow[0] == IndentFlow.poppush:
+                chunk = indentation_stack.pop()
+                indentation_stack[-1].lines += chunk.apply_indent()
+                indentation_stack.append(IndentStackElem(
+                    chunk.indentation,
+                    chunk.token,
+                    unindented_line,
+                    []
+                ))
+
+            elif flow[0] == IndentFlow.pop:
+                # TODO check flow[1]
+                chunk = indentation_stack.pop()
+                indentation_stack[-1].lines += chunk.apply_indent()
+                indentation_stack[-1].lines.append(chunk.indentation + unindented_line)
+
+        # TODO: sanitycheck that indentation stack has only 1 element
+        return "\n".join(indentation_stack[0].lines)
+
+    ############################################################################
+    # indent_flow
+    #
+    # Returns how the indenting should change for subsequent lines
+    #
+    # First argument is push, keep, or pop to indicate what to do with the indentation stack
+    # the second argument is the control block, for push that block should be added
+    # for keep or pop, that value should be checked, or checked and removed
+    #
+    # if keep and the value is None then dont check and keep going.
+    # The second value is mostly for sanity checking that all these blocks have pairs.
+    # There will definitely be issues with this if there is a block that starts on a line by itself
+    # but does not end on a line by itself
+    ############################################################################
+    def indent_flow(self, line: str) -> Tuple[IndentFlow, str]:
+        tag_match = re.match(tag_regex, line)
+
+        if tag_match == None:
+            return IndentFlow.keep, ""
+
+        parsed_tag_line = tag_match.groups()[0].strip()
+
+        if parsed_tag_line.startswith("for"):
+            return IndentFlow.push, "for"
+        elif parsed_tag_line.startswith("endfor"):
+            return IndentFlow.pop, "for"
+        elif parsed_tag_line.startswith("if"):
+            return IndentFlow.push, "if"
+        elif parsed_tag_line.startswith("elif"):
+            return IndentFlow.poppush, "if"
+        elif parsed_tag_line.startswith("else"):
+            return IndentFlow.poppush, "if"
+        elif parsed_tag_line.startswith("endif"):
+            return IndentFlow.pop, "if"
+
+        # # TODO: Make tests for macro, call, filter
+        # elif parsed_tag_line.startswith("macro"):
+        #     return IndentFlow.push, "macro"
+        # elif parsed_tag_line.startswith("endmacro"):
+        #     return IndentFlow.pop, "macro"
+        # elif parsed_tag_line.startswith("call"):
+        #     return IndentFlow.push, "call"
+        # elif parsed_tag_line.startswith("endcall"):
+        #     return IndentFlow.pop, "call"
+        # elif parsed_tag_line.startswith("filter"):
+        #     return IndentFlow.push, "filter"
+        # elif parsed_tag_line.startswith("endfilter"):
+        #     return IndentFlow.pop, "filter"
+
+        # # TODO: Do more testing to branch between set and blockset
+        # elif parsed_tag_line.startswith("set"):
+        #     return IndentFlow.push, "set" # or maybe `IndentFlow.keep, ""` if not a block set
+        # elif parsed_tag_line.startswith("endset"):
+        #     return IndentFlow.pop, "set"
+
+        raise ValueError("Unknown Jinja2 Statement " + parsed_tag_line)
+
+
+################################################################################
+# unindent_block
+#
+# Takes a list of text lines and removes a uniform indent for every line.
+# TODO: The organization of this function is pretty poor and should be redone.
+# The best way to do this is probably by writing some tests first and then
+# refactoring this function afterwards.
+################################################################################
+def unindent_block(block: List[str]) -> List[str]:
+    common_indent = ""
+    next_indent: Optional[str] = None
+    index = -1
+
+    searching = True
+    while searching:
+        index += 1
+
+        for line in block:
+            # Ignore blank lines so that they dont cause the removed indent to
+            # be 0 characters long.
+            if line == "":
+                continue
+
+            # Exit if we reach the end of a line
+            if index >= len(line):
+                searching = False
+                break
+
+            if next_indent == None:
+                next_indent = line[index]
+
+                # Stop searching when you get to non-whitespace
+                if next_indent not in {" ", "\t"}:
+                    searching = False
+                    break
+
+            # Exit if we find a non matching indent character in one of the other lines
+            if next_indent != line[index]:
+                searching = False
+                break
+
+        # A sanity check for if we never triggered anything in the for loop
+        # EG: all empty lines
+        if next_indent == None:
+            break
+
+        common_indent += next_indent
+        next_indent = None
+        
+    return [line[index:] for line in block]


### PR DESCRIPTION
A simple Jinja2 plugin was written that acts as a preprocessor and aligns the indents of all of the blocks to the indentation level of the block start. This allows for very rudimentary indentation within the jinja template without that indentation carrying over to the generated files.

This PR will likely need to be rebased against the other PRs currently waiting to be merged into `xml_converter`, it will be easier to just reapply the indentation changes to the templates in this PR then it will be to apply these changes to other PRs because we can validate in this PR that none of the generated files themselves have changed. Therefore this should be blocked on #114 and #124 being merged first.

This extension may eventually become its own project, and this is just a first draft to allow for way easier code reviews on the template files themselves. Because such, documenting this extension is not a priority.