### PR TITLE
Removing artifact retention 7 day limit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,4 +119,4 @@ jobs:
           # The desired behavior if no files are found using the provided path.
           if-no-files-found: error 
           # Duration after which artifact will expire in days. 0 means using default retention. 
-          retention-days: 7
+          retention-days: 0


### PR DESCRIPTION
In theory the 7 day limit seemed economical, but in practice not having easy access to whatever the "newest" build artifact on master is has proven annoying.