### PR TITLE
[XML Markers] Save Protobins within Godot 

### DIFF
--- a/Gizmo/PointEdit.gd
+++ b/Gizmo/PointEdit.gd
@@ -48,8 +48,10 @@ func update_point():
 		if point_type == "path" || point_type == "area":
 			self.object_link.set_point_position(self.object_index, self.translation)
 			self.object_2d_link.points[self.object_index] = Vector2(self.translation.x, self.translation.z)
+			self.object_link.update_waypoint_trail(self.object_index)
 		if point_type == "icon":
 			self.object_link.translation = self.translation
+			self.object_link.update_waypoint_icon()
 		print("update")
 		self.last_translation  = self.translation
 

--- a/Icon.gd
+++ b/Icon.gd
@@ -5,6 +5,12 @@ const Waypoint = preload("res://waypoint.gd")
 var texture_path
 var waypoint: Waypoint.Icon
 
+func update_waypoint_icon():
+	var position = self.waypoint.position()
+	position.set_x(translation[0])
+	position.set_y(translation[1])
+	position.set_z(-translation[2])
+
 func set_icon_image(texture_path: String):
 	self.texture_path = texture_path
 	

--- a/Route.gd
+++ b/Route.gd
@@ -8,6 +8,12 @@ var waypoint: Waypoint.Trail
 
 var point_list := PoolVector3Array()
 
+func update_waypoint_trail(index):
+	var trail_data = waypoint.get_trail_data()
+	trail_data.get_points_x()[index] = self.point_list[index][0]
+	trail_data.get_points_y()[index] = self.point_list[index][1]
+	trail_data.get_points_z()[index] = -self.point_list[index][2]
+
 func create_mesh(point_list: PoolVector3Array):
 	self.point_list = point_list
 	refresh_mesh()

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -287,7 +287,7 @@ func reset_minimap_masks():
 		minimap_path.material.set_shader_param("minimap_corner2", compass_corner2)
 
 var Waypoint_data = Waypoint.Waypoint.new()
-var marker_file_dir = "user://protobins/"
+var marker_file_dir = Directory.new()
 var marker_file_path = ""
 var root: TreeItem
 

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -60,7 +60,10 @@ func _ready():
 	# Postion at top left corner
 	OS.set_window_position(Vector2(0,0))
 	set_minimal_mouse_block()
+	init_category_tree()
+	marker_file_dir.open("user://protobins/")
 	server.listen(4242)
+
 
 func set_minimal_mouse_block():
 	var top_corner := Vector2(287, 0)

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -78,9 +78,9 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TextureRect" type="TextureRect" parent="Control/GlobalMenuButton"]
+[node name="BurritoIcon" type="TextureRect" parent="Control/GlobalMenuButton"]
 modulate = Color( 1, 1, 1, 0.439216 )
-margin_left = 1.591
+margin_left = 2.0
 margin_top = 3.18198
 margin_right = 26.591
 margin_bottom = 28.182
@@ -88,6 +88,13 @@ texture = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="UnsavedData" type="TextureRect" parent="Control/GlobalMenuButton/BurritoIcon"]
+visible = false
+modulate = Color( 1, 0.0313726, 0.0313726, 1 )
+margin_right = 40.0
+margin_bottom = 40.0
+texture = ExtResource( 3 )
 
 [node name="main_menu_toggle" type="Button" parent="Control/GlobalMenuButton"]
 modulate = Color( 1, 1, 1, 0 )
@@ -821,6 +828,7 @@ color = Color( 0, 0, 0, 1 )
 mesh = SubResource( 3 )
 material/0 = SubResource( 4 )
 
+[connection signal="visibility_changed" from="Control/GlobalMenuButton/BurritoIcon/UnsavedData" to="." method="_on_UnsavedData_visibility_changed"]
 [connection signal="pressed" from="Control/GlobalMenuButton/main_menu_toggle" to="." method="_on_main_menu_toggle_pressed"]
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/CloseEditorQuickPanel" to="." method="_on_CloseEditorQuickPanel_pressed"]
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/ChangeTexture" to="." method="_on_ChangeTexture_pressed"]

--- a/waypoint.gd
+++ b/waypoint.gd
@@ -670,18 +670,6 @@ class Waypoint:
 		service.func_ref = funcref(self, "add_category")
 		data[_category.tag] = service
 		
-		_icon = PBField.new("icon", PB_DATA_TYPE.MESSAGE, PB_RULE.REPEATED, 2, true, [])
-		service = PBServiceField.new()
-		service.field = _icon
-		service.func_ref = funcref(self, "add_icon")
-		data[_icon.tag] = service
-		
-		_trail = PBField.new("trail", PB_DATA_TYPE.MESSAGE, PB_RULE.REPEATED, 3, true, [])
-		service = PBServiceField.new()
-		service.field = _trail
-		service.func_ref = funcref(self, "add_trail")
-		data[_trail.tag] = service
-		
 	var data = {}
 	
 	var _category: PBField
@@ -693,28 +681,6 @@ class Waypoint:
 	func add_category() -> Category:
 		var element = Category.new()
 		_category.value.append(element)
-		return element
-	
-	var _icon: PBField
-	func get_icon() -> Array:
-		return _icon.value
-	func clear_icon() -> void:
-		data[2].state = PB_SERVICE_STATE.UNFILLED
-		_icon.value = []
-	func add_icon() -> Icon:
-		var element = Icon.new()
-		_icon.value.append(element)
-		return element
-	
-	var _trail: PBField
-	func get_trail() -> Array:
-		return _trail.value
-	func clear_trail() -> void:
-		data[3].state = PB_SERVICE_STATE.UNFILLED
-		_trail.value = []
-	func add_trail() -> Trail:
-		var element = Trail.new()
-		_trail.value.append(element)
 		return element
 	
 	func to_string() -> String:
@@ -772,6 +738,18 @@ class Category:
 		service.field = _children
 		service.func_ref = funcref(self, "add_children")
 		data[_children.tag] = service
+		
+		_icon = PBField.new("icon", PB_DATA_TYPE.MESSAGE, PB_RULE.REPEATED, 7, true, [])
+		service = PBServiceField.new()
+		service.field = _icon
+		service.func_ref = funcref(self, "add_icon")
+		data[_icon.tag] = service
+		
+		_trail = PBField.new("trail", PB_DATA_TYPE.MESSAGE, PB_RULE.REPEATED, 8, true, [])
+		service = PBServiceField.new()
+		service.field = _trail
+		service.func_ref = funcref(self, "add_trail")
+		data[_trail.tag] = service
 		
 	var data = {}
 	
@@ -831,6 +809,28 @@ class Category:
 		_children.value.append(element)
 		return element
 	
+	var _icon: PBField
+	func get_icon() -> Array:
+		return _icon.value
+	func clear_icon() -> void:
+		data[7].state = PB_SERVICE_STATE.UNFILLED
+		_icon.value = []
+	func add_icon() -> Icon:
+		var element = Icon.new()
+		_icon.value.append(element)
+		return element
+	
+	var _trail: PBField
+	func get_trail() -> Array:
+		return _trail.value
+	func clear_trail() -> void:
+		data[8].state = PB_SERVICE_STATE.UNFILLED
+		_trail.value = []
+	func add_trail() -> Trail:
+		var element = Trail.new()
+		_trail.value.append(element)
+		return element
+	
 	func to_string() -> String:
 		return PBPacker.message_to_string(data)
 		
@@ -855,12 +855,6 @@ class Category:
 class Icon:
 	func _init():
 		var service
-		
-		_category = PBField.new("category", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 1, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
-		service = PBServiceField.new()
-		service.field = _category
-		service.func_ref = funcref(self, "new_category")
-		data[_category.tag] = service
 		
 		_texture_path = PBField.new("texture_path", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 2, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
 		service = PBServiceField.new()
@@ -1034,17 +1028,13 @@ class Icon:
 		service.field = _bhdraft__schedule_duration
 		data[_bhdraft__schedule_duration.tag] = service
 		
+		_category = PBField.new("category", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 2054, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
+		service = PBServiceField.new()
+		service.field = _category
+		service.func_ref = funcref(self, "new_category")
+		data[_category.tag] = service
+		
 	var data = {}
-	
-	var _category: PBField
-	func get_category() -> Category:
-		return _category.value
-	func clear_category() -> void:
-		data[1].state = PB_SERVICE_STATE.UNFILLED
-		_category.value = DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE]
-	func new_category() -> Category:
-		_category.value = Category.new()
-		return _category.value
 	
 	var _texture_path: PBField
 	func get_texture_path() -> TexturePath:
@@ -1346,6 +1336,16 @@ class Icon:
 	func set_bhdraft__schedule_duration(value : float) -> void:
 		_bhdraft__schedule_duration.value = value
 	
+	var _category: PBField
+	func get_category() -> Category:
+		return _category.value
+	func clear_category() -> void:
+		data[2054].state = PB_SERVICE_STATE.UNFILLED
+		_category.value = DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE]
+	func new_category() -> Category:
+		_category.value = Category.new()
+		return _category.value
+	
 	func to_string() -> String:
 		return PBPacker.message_to_string(data)
 		
@@ -1370,12 +1370,6 @@ class Icon:
 class Trail:
 	func _init():
 		var service
-		
-		_category = PBField.new("category", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 1, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
-		service = PBServiceField.new()
-		service.field = _category
-		service.func_ref = funcref(self, "new_category")
-		data[_category.tag] = service
 		
 		_texture_path = PBField.new("texture_path", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 2, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
 		service = PBServiceField.new()
@@ -1517,17 +1511,13 @@ class Trail:
 		service.field = _bhdraft__schedule_duration
 		data[_bhdraft__schedule_duration.tag] = service
 		
+		_category = PBField.new("category", PB_DATA_TYPE.MESSAGE, PB_RULE.OPTIONAL, 2054, true, DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE])
+		service = PBServiceField.new()
+		service.field = _category
+		service.func_ref = funcref(self, "new_category")
+		data[_category.tag] = service
+		
 	var data = {}
-	
-	var _category: PBField
-	func get_category() -> Category:
-		return _category.value
-	func clear_category() -> void:
-		data[1].state = PB_SERVICE_STATE.UNFILLED
-		_category.value = DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE]
-	func new_category() -> Category:
-		_category.value = Category.new()
-		return _category.value
 	
 	var _texture_path: PBField
 	func get_texture_path() -> TexturePath:
@@ -1772,6 +1762,16 @@ class Trail:
 		_bhdraft__schedule_duration.value = DEFAULT_VALUES_3[PB_DATA_TYPE.FLOAT]
 	func set_bhdraft__schedule_duration(value : float) -> void:
 		_bhdraft__schedule_duration.value = value
+	
+	var _category: PBField
+	func get_category() -> Category:
+		return _category.value
+	func clear_category() -> void:
+		data[2054].state = PB_SERVICE_STATE.UNFILLED
+		_category.value = DEFAULT_VALUES_3[PB_DATA_TYPE.MESSAGE]
+	func new_category() -> Category:
+		_category.value = Category.new()
+		return _category.value
 	
 	func to_string() -> String:
 		return PBPacker.message_to_string(data)
@@ -4260,11 +4260,6 @@ class TrailData:
 	func _init():
 		var service
 		
-		_trail_data = PBField.new("trail_data", PB_DATA_TYPE.STRING, PB_RULE.OPTIONAL, 1, true, DEFAULT_VALUES_3[PB_DATA_TYPE.STRING])
-		service = PBServiceField.new()
-		service.field = _trail_data
-		data[_trail_data.tag] = service
-		
 		_points_x = PBField.new("points_x", PB_DATA_TYPE.FLOAT, PB_RULE.REPEATED, 2, true, [])
 		service = PBServiceField.new()
 		service.field = _points_x
@@ -4281,15 +4276,6 @@ class TrailData:
 		data[_points_z.tag] = service
 		
 	var data = {}
-	
-	var _trail_data: PBField
-	func get_trail_data() -> String:
-		return _trail_data.value
-	func clear_trail_data() -> void:
-		data[1].state = PB_SERVICE_STATE.UNFILLED
-		_trail_data.value = DEFAULT_VALUES_3[PB_DATA_TYPE.STRING]
-	func set_trail_data(value : String) -> void:
-		_trail_data.value = value
 	
 	var _points_x: PBField
 	func get_points_x() -> Array:


### PR DESCRIPTION
Split from https://github.com/AsherGlick/Burrito/pull/154

Dependent on https://github.com/AsherGlick/Burrito/pull/157

Addressing Issue [XML Markers] Save Marker Protobins from GDScript https://github.com/AsherGlick/Burrito/issues/78

Addresses the questions posed in the issue by saving all data when the save button is pressed. The average user would not make a distinction of saving one pack's data and not another. Same principle applies to switching maps. By saving all data, you are also not required to be in the map where the changes have been made.

Finally, an autosave check was added before a new maps data is loaded. This could be augmented further to catch changes within x amount of time.