### PR TITLE
Adding a Basic CLI Interface

### DIFF
--- a/xml_converter/presubmit.sh
+++ b/xml_converter/presubmit.sh
@@ -34,22 +34,21 @@ if (( $? > 0 )); then
     error_count=`expr $error_count + 1`
 fi
 
-# Run Include What You Use
-#
-# We have 2 sed filters here, they could be combined but they are split for clarity
-# The first one removes all blank lines
-# The second one removes all "everything is good" lines from iwyu
-#
-# TODO: When this or newer versions of iwyu_tool that carry over the exit codes
-# from the include-what-you-use command calls are more widely standard this can
-# be replaced with just a call to iwyu_tool instead.
-echo "Include What You Use"
-echo "--------------------"
-../third_party/iwyu_tool.py -p . -o quiet
-# include-what-you-use has a "success code" of 2 for a legacy reason.
-if [[ $? -ne 2 ]]; then
-    error_count=`expr $error_count + 1`
-fi
+
+# IWYU is too noisy right now and not always completely correct. It is going
+# to be disabled for now but later will be re-enabled once it is wrangled better
+# # Run Include What You Use
+# #
+# # TODO: When this or newer versions of iwyu_tool that carry over the exit codes
+# # from the include-what-you-use command calls are more widely standard this can
+# # be replaced with just a call to iwyu_tool instead.
+# echo "Include What You Use"
+# echo "--------------------"
+# ../third_party/iwyu_tool.py -p . -o quiet
+# # include-what-you-use has a "success code" of 2 for a legacy reason.
+# if [[ $? -ne 2 ]]; then
+#     error_count=`expr $error_count + 1`
+# fi
 
 
 # Validate that clang-format would make no changes

--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -1,6 +1,5 @@
 #include <dirent.h>
-#include <errno.h>
-#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -437,7 +436,6 @@ void convert_taco_directory(string directory, string output_directory, map<strin
     read_taco_directory(directory, marker_categories, parsed_pois);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // process_data
 //
@@ -446,8 +444,7 @@ void convert_taco_directory(string directory, string output_directory, map<strin
 ////////////////////////////////////////////////////////////////////////////////
 void process_data(
     vector<string> input_paths,
-    string output_directory
-) {
+    string output_directory) {
     auto begin = chrono::high_resolution_clock::now();
 
     vector<Parseable*> parsed_pois;
@@ -483,7 +480,6 @@ void process_data(
     cout << "The protobuf write function took " << ms << " milliseconds to run" << endl;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // main
 //
@@ -495,8 +491,7 @@ void process_data(
 //   ./xml_converter --input-path ../packs/marker_pack --output-path ../output_packs
 //   ./xml_converter --input-path ../packs/* --output-path ../output_packs
 ////////////////////////////////////////////////////////////////////////////////
-int main(int argc, char *argv[]) {
-
+int main(int argc, char* argv[]) {
     vector<string> input_paths;
 
     // Typically "~/.local/share/godot/app_userdata/Burrito/protobins" for


### PR DESCRIPTION
Allows for interacting on a very basic level with the xml_converter via the CLI instead of needing to hardcode paths in.
There are still some issues, such as segfaulting on incorrect directories, but those issues are not introduced in this change.

Example Usage:
```shell
./xml_converter --input-path ../packs/marker_pack --output-path ../output_packs
./xml_converter --input-path ../packs/*/ --output-path ../output_packs
```

the `*/` might be necessary to only include directories and not `.taco` or `.zip` files to prevent the aforementioned segfaults (which will be corrected later).