### PR TITLE
Protobuf only create whats needed

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -93,12 +93,7 @@ vector<string> {{cpp_class}}::as_xml() const {
     return xml_node_contents;
 }
 
-{% if cpp_class == "Category": %}
-    waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf(string full_category_name, map<string, vector<Parseable*>>* parsed_pois) const {
-        full_category_name += this->name;
-{% else %}
-    waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
-{% endif %}
+waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     waypoint::{{cpp_class}} proto_{{cpp_class_header}};
     {% if cpp_class == "Icon": %}
         waypoint::Trigger* trigger = nullptr;
@@ -148,28 +143,6 @@ vector<string> {{cpp_class}}::as_xml() const {
     {% if cpp_class == "Icon": %}
         if (trigger != nullptr) {
             proto_{{cpp_class_header}}.set_allocated_trigger(trigger);
-        }
-    {% endif %}
-    {% if cpp_class == "Category": %}
-
-        auto pois = parsed_pois->find(full_category_name);
-
-        if (pois != parsed_pois->end()) {
-            for (unsigned int i = 0; i < pois->second.size(); i++) {
-                if (pois->second[i]->classname() == "POI") {
-                    Icon* icon = dynamic_cast<Icon*>(pois->second[i]);
-                    proto_{{cpp_class_header}}.add_icon()->MergeFrom(icon->as_protobuf());
-                }
-                else if (pois->second[i]->classname() == "Trail") {
-                    Trail* trail = dynamic_cast<Trail*>(pois->second[i]);
-                    proto_{{cpp_class_header}}.add_trail()->MergeFrom(trail->as_protobuf());
-                }
-            }
-        }
-
-        for (const auto& [key, val] : this->children) {
-            waypoint::{{cpp_class}} proto_{{cpp_class_header}}_child = val.as_protobuf(full_category_name + ".", parsed_pois);
-            proto_{{cpp_class_header}}.add_children()->CopyFrom(proto_{{cpp_class_header}}_child);
         }
     {% endif %}
     return proto_{{cpp_class_header}};

--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -34,11 +34,7 @@ class {{cpp_class}} : public Parseable {
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
-    {% if cpp_class == "Category": %}
-        waypoint::{{cpp_class}} as_protobuf(std::string full_category_name, std::map<std::string, std::vector<Parseable*>>* parsed_pois) const;
-    {% else: %}
-        waypoint::{{cpp_class}} as_protobuf() const;
-    {% endif %}
+    waypoint::{{cpp_class}} as_protobuf() const;
     void parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}});
     {% if attributes_of_type_marker_category %}
         bool validate_attributes_of_type_marker_category();

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -95,8 +95,7 @@ vector<string> Category::as_xml() const {
     return xml_node_contents;
 }
 
-waypoint::Category Category::as_protobuf(string full_category_name, map<string, vector<Parseable*>>* parsed_pois) const {
-    full_category_name += this->name;
+waypoint::Category Category::as_protobuf() const {
     waypoint::Category proto_category;
     if (this->default_visibility_is_set) {
         proto_category.set_default_visibility(this->default_visibility);
@@ -112,26 +111,6 @@ waypoint::Category Category::as_protobuf(string full_category_name, map<string, 
     }
     if (this->tooltip_description_is_set) {
         proto_category.set_tip_description(this->tooltip_description);
-    }
-
-    auto pois = parsed_pois->find(full_category_name);
-
-    if (pois != parsed_pois->end()) {
-        for (unsigned int i = 0; i < pois->second.size(); i++) {
-            if (pois->second[i]->classname() == "POI") {
-                Icon* icon = dynamic_cast<Icon*>(pois->second[i]);
-                proto_category.add_icon()->MergeFrom(icon->as_protobuf());
-            }
-            else if (pois->second[i]->classname() == "Trail") {
-                Trail* trail = dynamic_cast<Trail*>(pois->second[i]);
-                proto_category.add_trail()->MergeFrom(trail->as_protobuf());
-            }
-        }
-    }
-
-    for (const auto& [key, val] : this->children) {
-        waypoint::Category proto_category_child = val.as_protobuf(full_category_name + ".", parsed_pois);
-        proto_category.add_children()->CopyFrom(proto_category_child);
     }
     return proto_category;
 }

--- a/xml_converter/src/category_gen.hpp
+++ b/xml_converter/src/category_gen.hpp
@@ -32,6 +32,6 @@ class Category : public Parseable {
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
-    waypoint::Category as_protobuf(std::string full_category_name, std::map<std::string, std::vector<Parseable*>>* parsed_pois) const;
+    waypoint::Category as_protobuf() const;
     void parse_protobuf(waypoint::Category proto_category);
 };

--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -148,14 +148,7 @@ MaybeCategory build_category_objects(
     return return_value;
 }
 
-void write_protobuf_file(
-    const string &filepath,
-    const StringHierarchy &category_filter,
-    const map<string, Category>* marker_categories,
-    const vector<Parseable*>* parsed_pois
-) {
-    // TODO: call _write_protobuf_file
-}
+
 
 void _write_protobuf_file(
     const string &filepath,
@@ -187,6 +180,37 @@ void _write_protobuf_file(
 
     output_message.SerializeToOstream(&outfile);
     outfile.close();
+}
+
+void write_protobuf_file(
+    const string &filepath,
+    const StringHierarchy &category_filter,
+    const map<string, Category>* marker_categories,
+    const vector<Parseable*>* parsed_pois
+) {
+    std::map<string, std::vector<Parseable*>> category_to_pois;
+
+    for (size_t i = 0; i < parsed_pois->size(); i++) {
+        Parseable* parsed_poi = (*parsed_pois)[i];
+        if (parsed_poi->classname() == "POI") {
+            Icon* icon = dynamic_cast<Icon*>(parsed_poi);
+            category_to_pois[icon->category.category].push_back(parsed_poi);
+        }
+        else if (parsed_poi->classname() == "Trail") {
+            Trail* trail = dynamic_cast<Trail*>(parsed_poi);
+            category_to_pois[trail->category.category].push_back(parsed_poi);
+        }
+        else {
+            std::cout << "Unknown type" << std::endl;
+        }
+    }
+
+    _write_protobuf_file(
+        filepath,
+        category_filter,
+        marker_categories,
+        category_to_pois
+    );
 }
 
 // Write protobuf per map id

--- a/xml_converter/src/packaging_protobin.hpp
+++ b/xml_converter/src/packaging_protobin.hpp
@@ -8,6 +8,7 @@
 #include "category_gen.hpp"
 #include "parseable.hpp"
 #include "waypoint.pb.h"
+#include "string_hierarchy.hpp"
 
 void read_protobuf_file(
     std::string proto_filepath,
@@ -15,6 +16,13 @@ void read_protobuf_file(
     std::vector<Parseable*>* parsed_pois);
 
 void write_protobuf_file(
-    std::string proto_directory,
-    std::map<std::string, Category>* marker_categories,
-    std::vector<Parseable*>* parsed_pois);
+    const std::string &proto_directory,
+    const StringHierarchy &category_filter,
+    const std::map<std::string, Category>* marker_categories,
+    const std::vector<Parseable*>* parsed_pois);
+
+void write_protobuf_file_per_map_id(
+    const std::string &proto_directory,
+    const StringHierarchy &category_filter,
+    const std::map<std::string, Category>* marker_categories,
+    const std::vector<Parseable*>* parsed_pois);

--- a/xml_converter/src/packaging_protobin.hpp
+++ b/xml_converter/src/packaging_protobin.hpp
@@ -7,8 +7,8 @@
 
 #include "category_gen.hpp"
 #include "parseable.hpp"
-#include "waypoint.pb.h"
 #include "string_hierarchy.hpp"
+#include "waypoint.pb.h"
 
 void read_protobuf_file(
     std::string proto_filepath,
@@ -16,13 +16,13 @@ void read_protobuf_file(
     std::vector<Parseable*>* parsed_pois);
 
 void write_protobuf_file(
-    const std::string &proto_directory,
-    const StringHierarchy &category_filter,
+    const std::string& proto_directory,
+    const StringHierarchy& category_filter,
     const std::map<std::string, Category>* marker_categories,
     const std::vector<Parseable*>* parsed_pois);
 
 void write_protobuf_file_per_map_id(
-    const std::string &proto_directory,
-    const StringHierarchy &category_filter,
+    const std::string& proto_directory,
+    const StringHierarchy& category_filter,
     const std::map<std::string, Category>* marker_categories,
     const std::vector<Parseable*>* parsed_pois);

--- a/xml_converter/src/string_helper.cpp
+++ b/xml_converter/src/string_helper.cpp
@@ -48,6 +48,18 @@ vector<string> split(string input, string delimiter) {
     return output;
 }
 
+string join(const vector<string> &input, string delimiter) {
+    string result;
+    for(size_t i = 0; i < input.size(); i++) {
+        result += input[i];
+        // Don't add delimiter after the last element
+        if(i < input.size() - 1) {
+            result += delimiter;
+        }
+    }
+    return result;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // normalize
 //

--- a/xml_converter/src/string_helper.cpp
+++ b/xml_converter/src/string_helper.cpp
@@ -48,12 +48,12 @@ vector<string> split(string input, string delimiter) {
     return output;
 }
 
-string join(const vector<string> &input, string delimiter) {
+string join(const vector<string>& input, string delimiter) {
     string result;
-    for(size_t i = 0; i < input.size(); i++) {
+    for (size_t i = 0; i < input.size(); i++) {
         result += input[i];
         // Don't add delimiter after the last element
-        if(i < input.size() - 1) {
+        if (i < input.size() - 1) {
             result += delimiter;
         }
     }

--- a/xml_converter/src/string_helper.hpp
+++ b/xml_converter/src/string_helper.hpp
@@ -12,6 +12,7 @@ bool normalized_matches_any(std::string test, std::vector<std::string> list);
 std::string lowercase(std::string);
 
 std::vector<std::string> split(std::string input, std::string delimiter);
+std::string join(const std::vector<std::string> &input, std::string delimiter);
 
 std::string normalize(std::string input_string);
 

--- a/xml_converter/src/string_helper.hpp
+++ b/xml_converter/src/string_helper.hpp
@@ -12,7 +12,7 @@ bool normalized_matches_any(std::string test, std::vector<std::string> list);
 std::string lowercase(std::string);
 
 std::vector<std::string> split(std::string input, std::string delimiter);
-std::string join(const std::vector<std::string> &input, std::string delimiter);
+std::string join(const std::vector<std::string>& input, std::string delimiter);
 
 std::string normalize(std::string input_string);
 

--- a/xml_converter/src/string_hierarchy.cpp
+++ b/xml_converter/src/string_hierarchy.cpp
@@ -8,7 +8,7 @@
 // Returns if the given path is in the hierarchy or not
 ////////////////////////////////////////////////////////////////////////////////
 bool StringHierarchy::in_hierarchy(
-    const std::vector<std::string> &path) {
+    const std::vector<std::string> &path) const {
     return this->_in_hierarchy(path, 0);
 }
 
@@ -20,7 +20,7 @@ bool StringHierarchy::in_hierarchy(
 ////////////////////////////////////////////////////////////////////////////////
 bool StringHierarchy::_in_hierarchy(
     const std::vector<std::string> &path,
-    const size_t continue_index) {
+    const size_t continue_index) const {
     // If all children of this hierarchy node are included then this path exists.
     if (this->all_children_included) {
         return true;

--- a/xml_converter/src/string_hierarchy.hpp
+++ b/xml_converter/src/string_hierarchy.hpp
@@ -7,7 +7,7 @@
 class StringHierarchy {
  public:
     bool in_hierarchy(
-        const std::vector<std::string> &path);
+        const std::vector<std::string> &path) const;
 
     void add_path(
         const std::vector<std::string> &path,
@@ -16,7 +16,7 @@ class StringHierarchy {
  private:
     bool _in_hierarchy(
         const std::vector<std::string> &path,
-        const size_t continue_index);
+        const size_t continue_index) const;
 
     void _add_path(
         const std::vector<std::string> &path,

--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -165,13 +165,17 @@ void process_data(
 
     // Write all of the protobin waypoint paths
     for (size_t i = 0; i < output_waypoint_paths.size(); i++) {
-        write_protobuf_file(output_waypoint_paths[i], &marker_categories, &parsed_pois);
+        StringHierarchy category_filter;
+        category_filter.add_path({}, true);
+        write_protobuf_file(output_waypoint_paths[i], category_filter, &marker_categories, &parsed_pois);
     }
 
     // Write the special map-split protbin waypoint file
     begin = chrono::high_resolution_clock::now();
     if (output_split_waypoint_dir != "") {
-        write_protobuf_file(output_split_waypoint_dir, &marker_categories, &parsed_pois);
+        StringHierarchy category_filter;
+        category_filter.add_path({}, true);
+        write_protobuf_file_per_map_id(output_split_waypoint_dir, category_filter, &marker_categories, &parsed_pois);
     }
     end = chrono::high_resolution_clock::now();
     dur = end - begin;


### PR DESCRIPTION
Reduced from an exponential growth, and a random metric of:

```
The taco parse function took 2476 milliseconds to run
The protobuf write function took 37937 milliseconds to run
```

to a more linear growth, and the same metric of:
```
The taco parse function took 2494 milliseconds to run
The protobuf write function took 6735 milliseconds to run
```

The new system is now much more linear with output size as the entire sum of all the markerpacks are not being copied in memory for each output file anymore.