### PR TITLE
String Hierarchy Utility Functions

### DIFF
--- a/xml_converter/.clang-format
+++ b/xml_converter/.clang-format
@@ -57,7 +57,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: false
+DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true

--- a/xml_converter/.clang-format
+++ b/xml_converter/.clang-format
@@ -106,7 +106,6 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1 # 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReferenceAlignment: Right
 RawStringFormats:
   - Language:        Cpp
     Delimiters:

--- a/xml_converter/.clang-format
+++ b/xml_converter/.clang-format
@@ -57,7 +57,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -106,6 +106,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1 # 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+ReferenceAlignment: Right
 RawStringFormats:
   - Language:        Cpp
     Delimiters:

--- a/xml_converter/src/string_hierarchy.cpp
+++ b/xml_converter/src/string_hierarchy.cpp
@@ -5,6 +5,24 @@
 ////////////////////////////////////////////////////////////////////////////////
 // in_hierarchy
 //
+// Returns if a particular node exists at the top level of the hirearchy.
+////////////////////////////////////////////////////////////////////////////////
+bool StringHierarchy::in_hierarchy(
+    const std::string &node) const {
+    if (this->all_children_included) {
+        return true;
+    }
+
+    auto iterator = this->children.find(node);
+    if (iterator == this->children.end()) {
+        return false;
+    }
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// in_hierarchy
+//
 // Returns if the given path is in the hierarchy or not
 ////////////////////////////////////////////////////////////////////////////////
 bool StringHierarchy::in_hierarchy(
@@ -37,6 +55,40 @@ bool StringHierarchy::_in_hierarchy(
     }
 
     return iterator->second._in_hierarchy(path, continue_index + 1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// sub_hierarchy
+//
+// A helper function to grab a sub hierarchy one level down from the top.
+////////////////////////////////////////////////////////////////////////////////
+const StringHierarchy* StringHierarchy::sub_hierarchy(
+    const std::string &node) const {
+    if (this->all_children_included) {
+        return this;
+    }
+
+    auto iterator = this->children.find(node);
+    if (iterator == this->children.end()) {
+        return nullptr;
+    }
+    return &(iterator->second);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// sub_hierarchy
+//
+// Get a subtree of the StringHierarchy in order to avoid needing to query the
+// entire hierarchy in the case where the use case is traversing down a tree
+// anyways and does not want to keep track of the parent's values.
+////////////////////////////////////////////////////////////////////////////////
+const StringHierarchy* StringHierarchy::sub_hierarchy(
+    const std::vector<std::string> &path) const {
+    const StringHierarchy* sub_hierarchy = this;
+    for (size_t i = 0; i < path.size(); i++) {
+        sub_hierarchy = this->sub_hierarchy(path[i]);
+    }
+    return sub_hierarchy;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/xml_converter/src/string_hierarchy.cpp
+++ b/xml_converter/src/string_hierarchy.cpp
@@ -37,7 +37,7 @@ bool StringHierarchy::in_hierarchy(
 // ambiguity between the vector and string overloads of the function.
 ////////////////////////////////////////////////////////////////////////////////
 bool StringHierarchy::in_hierarchy(
-    const std::initializer_list<std::string> input) const {
+    const std::initializer_list<std::string> &input) const {
     std::vector<std::string> vec;
     vec.insert(vec.end(), input.begin(), input.end());
     return this->in_hierarchy(vec);
@@ -95,7 +95,7 @@ const StringHierarchy *StringHierarchy::sub_hierarchy(
 // prevent ambiguity between the vector and string overloads of the function.
 ////////////////////////////////////////////////////////////////////////////////
 const StringHierarchy *StringHierarchy::sub_hierarchy(
-    const std::initializer_list<std::string> input) const {
+    const std::initializer_list<std::string> &input) const {
     std::vector<std::string> vec;
     vec.insert(vec.end(), input.begin(), input.end());
     return this->sub_hierarchy(vec);

--- a/xml_converter/src/string_hierarchy.cpp
+++ b/xml_converter/src/string_hierarchy.cpp
@@ -20,8 +20,6 @@ bool StringHierarchy::in_hierarchy(
     return true;
 }
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // in_hierarchy
 //
@@ -39,8 +37,7 @@ bool StringHierarchy::in_hierarchy(
 // ambiguity between the vector and string overloads of the function.
 ////////////////////////////////////////////////////////////////////////////////
 bool StringHierarchy::in_hierarchy(
-    const std::initializer_list<std::string> input
-) const {
+    const std::initializer_list<std::string> input) const {
     std::vector<std::string> vec;
     vec.insert(vec.end(), input.begin(), input.end());
     return this->in_hierarchy(vec);
@@ -78,7 +75,7 @@ bool StringHierarchy::_in_hierarchy(
 //
 // A helper function to grab a sub hierarchy one level down from the top.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy* StringHierarchy::sub_hierarchy(
+const StringHierarchy *StringHierarchy::sub_hierarchy(
     const std::string &node) const {
     if (this->all_children_included) {
         return this;
@@ -91,20 +88,18 @@ const StringHierarchy* StringHierarchy::sub_hierarchy(
     return &(iterator->second);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // sub_hierarchy
 //
 // An explicit version of sub_hierarchy that takes an initalizer list to
 // prevent ambiguity between the vector and string overloads of the function.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy* StringHierarchy::sub_hierarchy(
+const StringHierarchy *StringHierarchy::sub_hierarchy(
     const std::initializer_list<std::string> input) const {
     std::vector<std::string> vec;
     vec.insert(vec.end(), input.begin(), input.end());
     return this->sub_hierarchy(vec);
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // sub_hierarchy
@@ -113,9 +108,9 @@ const StringHierarchy* StringHierarchy::sub_hierarchy(
 // entire hierarchy in the case where the use case is traversing down a tree
 // anyways and does not want to keep track of the parent's values.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy* StringHierarchy::sub_hierarchy(
+const StringHierarchy *StringHierarchy::sub_hierarchy(
     const std::vector<std::string> &path) const {
-    const StringHierarchy* sub_hierarchy = this;
+    const StringHierarchy *sub_hierarchy = this;
     for (size_t i = 0; i < path.size(); i++) {
         sub_hierarchy = sub_hierarchy->sub_hierarchy(path[i]);
         // Escape before segfaulting.

--- a/xml_converter/src/string_hierarchy.cpp
+++ b/xml_converter/src/string_hierarchy.cpp
@@ -20,6 +20,8 @@ bool StringHierarchy::in_hierarchy(
     return true;
 }
 
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // in_hierarchy
 //
@@ -28,6 +30,20 @@ bool StringHierarchy::in_hierarchy(
 bool StringHierarchy::in_hierarchy(
     const std::vector<std::string> &path) const {
     return this->_in_hierarchy(path, 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// in_hierarchy
+//
+// An explicit version of in_hierarchy that takes an initalizer list to prevent
+// ambiguity between the vector and string overloads of the function.
+////////////////////////////////////////////////////////////////////////////////
+bool StringHierarchy::in_hierarchy(
+    const std::initializer_list<std::string> input
+) const {
+    std::vector<std::string> vec;
+    vec.insert(vec.end(), input.begin(), input.end());
+    return this->in_hierarchy(vec);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -75,6 +91,21 @@ const StringHierarchy* StringHierarchy::sub_hierarchy(
     return &(iterator->second);
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+// sub_hierarchy
+//
+// An explicit version of sub_hierarchy that takes an initalizer list to
+// prevent ambiguity between the vector and string overloads of the function.
+////////////////////////////////////////////////////////////////////////////////
+const StringHierarchy* StringHierarchy::sub_hierarchy(
+    const std::initializer_list<std::string> input) const {
+    std::vector<std::string> vec;
+    vec.insert(vec.end(), input.begin(), input.end());
+    return this->sub_hierarchy(vec);
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // sub_hierarchy
 //
@@ -86,7 +117,11 @@ const StringHierarchy* StringHierarchy::sub_hierarchy(
     const std::vector<std::string> &path) const {
     const StringHierarchy* sub_hierarchy = this;
     for (size_t i = 0; i < path.size(); i++) {
-        sub_hierarchy = this->sub_hierarchy(path[i]);
+        sub_hierarchy = sub_hierarchy->sub_hierarchy(path[i]);
+        // Escape before segfaulting.
+        if (sub_hierarchy == nullptr) {
+            return nullptr;
+        }
     }
     return sub_hierarchy;
 }

--- a/xml_converter/src/string_hierarchy.hpp
+++ b/xml_converter/src/string_hierarchy.hpp
@@ -15,13 +15,13 @@ class StringHierarchy {
     bool in_hierarchy(
         const std::initializer_list<std::string>) const;
 
-    const StringHierarchy* sub_hierarchy(
+    const StringHierarchy *sub_hierarchy(
         const std::string &node) const;
 
-    const StringHierarchy* sub_hierarchy(
+    const StringHierarchy *sub_hierarchy(
         const std::initializer_list<std::string> input) const;
 
-    const StringHierarchy* sub_hierarchy(
+    const StringHierarchy *sub_hierarchy(
         const std::vector<std::string> &path) const;
 
     void add_path(

--- a/xml_converter/src/string_hierarchy.hpp
+++ b/xml_converter/src/string_hierarchy.hpp
@@ -12,8 +12,14 @@ class StringHierarchy {
     bool in_hierarchy(
         const std::vector<std::string> &path) const;
 
+    bool in_hierarchy(
+        const std::initializer_list<std::string>) const;
+
     const StringHierarchy* sub_hierarchy(
         const std::string &node) const;
+
+    const StringHierarchy* sub_hierarchy(
+        const std::initializer_list<std::string> input) const;
 
     const StringHierarchy* sub_hierarchy(
         const std::vector<std::string> &path) const;

--- a/xml_converter/src/string_hierarchy.hpp
+++ b/xml_converter/src/string_hierarchy.hpp
@@ -13,13 +13,13 @@ class StringHierarchy {
         const std::vector<std::string> &path) const;
 
     bool in_hierarchy(
-        const std::initializer_list<std::string>) const;
+        const std::initializer_list<std::string> &input) const;
 
     const StringHierarchy *sub_hierarchy(
         const std::string &node) const;
 
     const StringHierarchy *sub_hierarchy(
-        const std::initializer_list<std::string> input) const;
+        const std::initializer_list<std::string> &input) const;
 
     const StringHierarchy *sub_hierarchy(
         const std::vector<std::string> &path) const;

--- a/xml_converter/src/string_hierarchy.hpp
+++ b/xml_converter/src/string_hierarchy.hpp
@@ -7,6 +7,15 @@
 class StringHierarchy {
  public:
     bool in_hierarchy(
+        const std::string &node) const;
+
+    bool in_hierarchy(
+        const std::vector<std::string> &path) const;
+
+    const StringHierarchy* sub_hierarchy(
+        const std::string &node) const;
+
+    const StringHierarchy* sub_hierarchy(
         const std::vector<std::string> &path) const;
 
     void add_path(

--- a/xml_converter/tests/test_string_hierarchy.cpp
+++ b/xml_converter/tests/test_string_hierarchy.cpp
@@ -18,6 +18,11 @@ TEST_F(StringHierarchyTest, BasicPath) {
     EXPECT_TRUE(string_hierarchy.in_hierarchy({"root", "child1", "child2"}));
 }
 
+TEST_F(StringHierarchyTest, BasicPathSingle) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    EXPECT_TRUE(string_hierarchy.in_hierarchy("root"));
+}
+
 TEST_F(StringHierarchyTest, ParentPath) {
     string_hierarchy.add_path({"root", "child1", "child2"}, false);
     EXPECT_TRUE(string_hierarchy.in_hierarchy({"root", "child1"}));
@@ -32,6 +37,11 @@ TEST_F(StringHierarchyTest, InvalidAdjacentNode) {
 TEST_F(StringHierarchyTest, InvalidRoot) {
     string_hierarchy.add_path({"root", "child1", "child2"}, false);
     EXPECT_FALSE(string_hierarchy.in_hierarchy({"badroot"}));
+}
+
+TEST_F(StringHierarchyTest, InvalidRootSingle) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    EXPECT_FALSE(string_hierarchy.in_hierarchy("badroot"));
 }
 
 TEST_F(StringHierarchyTest, NonExistantDepthNode) {
@@ -65,6 +75,41 @@ TEST_F(StringHierarchyTest, OverwriteAllChildrenRoot) {
 TEST_F(StringHierarchyTest, AllowAll) {
     string_hierarchy.add_path({}, true);
     EXPECT_TRUE(string_hierarchy.in_hierarchy({"literally", "anything"}));
+}
+
+TEST_F(StringHierarchyTest, AllowAllSingle) {
+    string_hierarchy.add_path({}, true);
+    EXPECT_TRUE(string_hierarchy.in_hierarchy("everything"));
+}
+
+TEST_F(StringHierarchyTest, InvalidHierarchy) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    const StringHierarchy* sub_hierarchy = string_hierarchy.sub_hierarchy({"invalid"});
+    EXPECT_EQ(sub_hierarchy, nullptr);
+}
+
+TEST_F(StringHierarchyTest, SubHierarchy) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    const StringHierarchy* sub_hierarchy = string_hierarchy.sub_hierarchy({"root", "child1"});
+    EXPECT_NE(sub_hierarchy, nullptr);
+    EXPECT_FALSE(sub_hierarchy->in_hierarchy("root"));
+    EXPECT_FALSE(sub_hierarchy->in_hierarchy("child1"));
+    EXPECT_TRUE(sub_hierarchy->in_hierarchy("child2"));
+}
+
+TEST_F(StringHierarchyTest, InvalidDeepHierarchy) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    const StringHierarchy* sub_hierarchy = string_hierarchy.sub_hierarchy({"invalid", "nonexistant"});
+    EXPECT_EQ(sub_hierarchy, nullptr);
+}
+
+TEST_F(StringHierarchyTest, SubHierarchySingle) {
+    string_hierarchy.add_path({"root", "child1", "child2"}, false);
+    const StringHierarchy* sub_hierarchy = string_hierarchy.sub_hierarchy("root");
+    EXPECT_NE(sub_hierarchy, nullptr);
+    EXPECT_FALSE(sub_hierarchy->in_hierarchy("root"));
+    EXPECT_TRUE(sub_hierarchy->in_hierarchy("child1"));
+    EXPECT_TRUE(sub_hierarchy->in_hierarchy({"child1", "child2"}));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This adds some string hierarchy utility functions that allow for some minor optimizations when calling string hierarchy functions with a single path, by not requiring that a vector be created to house the path.

It also introduces sub_hierarchy functionality so that hierarchy don't need to be queried from the root, allowing for recursive traversal the category tree without requiring a full hierarchy path be constructed or maintained.

~Lastly it fixes up some incorrect linter checks that were mostly passing because the linter was looking at the existing code to try and determine what the rule should be. But now it is explicitly that pointer `*`s should be attached to the type, and reference `&`s should be attached to the variable.~

The linter change turned out to be widespread. It will be moved to its own pr.