### PR TITLE
Removing doc_type_to_cpp_type variable as it was duplicated

### DIFF
--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -1,7 +1,7 @@
 from jsonschema import validate  # type:ignore
 from jsonschema.exceptions import ValidationError  # type:ignore
 import frontmatter  # type:ignore
-from typing import Any, Dict, List, Tuple, Set, Optional, Final
+from typing import Any, Dict, List, Tuple, Set, Optional, Final, TypedDict
 import os
 import markdown
 from dataclasses import dataclass, field
@@ -104,7 +104,20 @@ class FieldRow:
     description: str
 
 
-documentation_type_data = {
+################################################################################
+# DocumentationTypeData
+#
+# A type definition to indicate what information should be included in the
+# documentation_type_data variable.
+################################################################################
+class DocumentationTypeData(TypedDict):
+    class_name: str
+    cpp_type: str
+
+
+# A map between the documentation types, and useful class name info related to
+# that type.
+documentation_type_data: Dict[str, DocumentationTypeData] = {
     "Fixed32": {
         "class_name": "int",
         "cpp_type": "int",

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -104,16 +104,6 @@ class FieldRow:
     description: str
 
 
-# TODO: Eventually replace all references to `doc_type_to_cpp_type` with
-# references to `documentation_type_data` because they contain the same data
-doc_type_to_cpp_type: Dict[str, str] = {
-    "Fixed32": "int",
-    "Int32": "int",
-    "Boolean": "bool",
-    "Float32": "float",
-    "String": "std::string",
-}
-
 documentation_type_data = {
     "Fixed32": {
         "class_name": "int",
@@ -391,7 +381,7 @@ class Generator:
                         component_attribute_variable = AttributeVariable(
                             attribute_name=attribute_name + "." + component_name,
                             attribute_type="CompoundValue",
-                            cpp_type=doc_type_to_cpp_type[component['type']],
+                            cpp_type=documentation_type_data[component['type']]["cpp_type"],
                             class_name=component_class_name,
                             xml_fields=component_xml_fields,
                             default_xml_field=component_default_xml_field,
@@ -490,7 +480,7 @@ class Generator:
             elif metadata[filepath]['type'] == "CompoundValue":
                 for component in metadata[filepath]['components']:
                     xml_fields = []
-                    if component['type'] not in doc_type_to_cpp_type:
+                    if component['type'] not in documentation_type_data:
                         raise ValueError("Unexpected type for component. Look at markdown file {attribute_name}".format(
                             attribute_name=attribute_name
                         ))
@@ -502,7 +492,7 @@ class Generator:
                     attribute_variable = AttributeVariable(
                         attribute_name=component_attribute_name,
                         attribute_type=metadata[filepath]['type'],
-                        cpp_type=doc_type_to_cpp_type[component['type']],
+                        cpp_type=documentation_type_data[component['type']]["cpp_type"],
                         class_name=attribute_name,
                         xml_fields=xml_fields,
                         protobuf_field=component["protobuf_field"],


### PR DESCRIPTION
`doc_type_to_cpp_type` was already fully represented by `documentation_type_data` so the info was duplicated and also already marked for removal.