### PR TITLE
Adding zero cost wrappers to the proto serializers

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -97,19 +97,13 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     waypoint::{{cpp_class}} proto_{{cpp_class_header}};
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
-            {% if (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"])%}
-                if (this->{{attribute_variable.attribute_flag_name}}) {
+            if (this->{{attribute_variable.attribute_flag_name}}) {
+                {% if (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"]) %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-                }
-            {% elif (attribute_variable.attribute_type == "Enum")%}
-                if (this->{{attribute_variable.attribute_flag_name}}) {
+                {% else %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
-                }
-            {% else: %}
-                if (this->{{attribute_variable.attribute_flag_name}}) {
-                    proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(this->{{attribute_variable.attribute_name}});
-                }
-            {% endif %}
+                {% endif %}
+            }
         {% endif %}
     {% endfor %}
     return proto_{{cpp_class_header}};
@@ -120,25 +114,16 @@ void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_hea
         {% if attribute_variable.is_component == false %}
             {% if (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"]) %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.has_{{attribute_variable.protobuf_field}}()) {
-                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}());
-                    this->{{attribute_variable.attribute_flag_name}} = true;
-                }
-            {% elif (attribute_variable.class_name == "string") %}{# TODO: why is this .class_name when the others are .attribute_name #}
+            {% elif (attribute_variable.attribute_type == "String") %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != "") {
-                    this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}();
-                    this->{{attribute_variable.attribute_flag_name}} = true;
-                }
             {% elif (attribute_variable.attribute_type ==  "Enum") %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
-                    this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}());
-                    this->{{attribute_variable.attribute_flag_name}} = true;
-                }
             {% else %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
-                    this->{{attribute_variable.attribute_name}} = proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}();
-                    this->{{attribute_variable.attribute_flag_name}} = true;
-                }
             {% endif %}
+                this->{{attribute_variable.attribute_name}} = from_proto_{{attribute_variable.class_name}}(proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}());
+                this->{{attribute_variable.attribute_flag_name}} = true;
+            }
         {% endif %}
     {% endfor %}
 }

--- a/xml_converter/src/attribute/bool.hpp
+++ b/xml_converter/src/attribute/bool.hpp
@@ -12,5 +12,9 @@ bool parse_bool(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors
 std::string stringify_bool(bool attribute_value);
 
 // Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
-inline bool const& from_proto_bool(const bool &x) {return x;}
-inline bool const& to_proto_bool(const bool &x) {return x;}
+inline bool const& from_proto_bool(const bool& x) {
+    return x;
+}
+inline bool const& to_proto_bool(const bool& x) {
+    return x;
+}

--- a/xml_converter/src/attribute/bool.hpp
+++ b/xml_converter/src/attribute/bool.hpp
@@ -10,3 +10,7 @@ class XMLError;
 bool parse_bool(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 
 std::string stringify_bool(bool attribute_value);
+
+// Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
+inline bool const& from_proto_bool(const bool &x) {return x;}
+inline bool const& to_proto_bool(const bool &x) {return x;}

--- a/xml_converter/src/attribute/float.hpp
+++ b/xml_converter/src/attribute/float.hpp
@@ -12,5 +12,9 @@ float parse_float(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* erro
 std::string stringify_float(float attribute_value);
 
 // Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
-inline float const& from_proto_float(const float &x) {return x;}
-inline float const& to_proto_float(const float &x) {return x;}
+inline float const& from_proto_float(const float& x) {
+    return x;
+}
+inline float const& to_proto_float(const float& x) {
+    return x;
+}

--- a/xml_converter/src/attribute/float.hpp
+++ b/xml_converter/src/attribute/float.hpp
@@ -10,3 +10,7 @@ class XMLError;
 float parse_float(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 
 std::string stringify_float(float attribute_value);
+
+// Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
+inline float const& from_proto_float(const float &x) {return x;}
+inline float const& to_proto_float(const float &x) {return x;}

--- a/xml_converter/src/attribute/int.hpp
+++ b/xml_converter/src/attribute/int.hpp
@@ -12,5 +12,9 @@ int parse_int(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 std::string stringify_int(int attribute_value);
 
 // Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
-inline int const& from_proto_int(const int &x) {return x;}
-inline int const& to_proto_int(const int &x) {return x;}
+inline int const& from_proto_int(const int& x) {
+    return x;
+}
+inline int const& to_proto_int(const int& x) {
+    return x;
+}

--- a/xml_converter/src/attribute/int.hpp
+++ b/xml_converter/src/attribute/int.hpp
@@ -10,3 +10,7 @@ class XMLError;
 int parse_int(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 
 std::string stringify_int(int attribute_value);
+
+// Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
+inline int const& from_proto_int(const int &x) {return x;}
+inline int const& to_proto_int(const int &x) {return x;}

--- a/xml_converter/src/attribute/string.hpp
+++ b/xml_converter/src/attribute/string.hpp
@@ -12,5 +12,9 @@ std::string parse_string(rapidxml::xml_attribute<>* input, std::vector<XMLError*
 std::string stringify_string(std::string attribute_value);
 
 // Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
-inline std::string const& from_proto_string(const std::string &x) {return x;}
-inline std::string const& to_proto_string(const std::string &x) {return x;}
+inline std::string const& from_proto_string(const std::string& x) {
+    return x;
+}
+inline std::string const& to_proto_string(const std::string& x) {
+    return x;
+}

--- a/xml_converter/src/attribute/string.hpp
+++ b/xml_converter/src/attribute/string.hpp
@@ -10,3 +10,7 @@ class XMLError;
 std::string parse_string(rapidxml::xml_attribute<>* input, std::vector<XMLError*>* errors);
 
 std::string stringify_string(std::string attribute_value);
+
+// Zero Cost Abstraction identity functions to make parsing and writing protobufs more uniform
+inline std::string const& from_proto_string(const std::string &x) {return x;}
+inline std::string const& to_proto_string(const std::string &x) {return x;}

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -98,42 +98,42 @@ vector<string> Category::as_xml() const {
 waypoint::Category Category::as_protobuf() const {
     waypoint::Category proto_category;
     if (this->default_visibility_is_set) {
-        proto_category.set_default_visibility(this->default_visibility);
+        proto_category.set_default_visibility(to_proto_bool(this->default_visibility));
     }
     if (this->display_name_is_set) {
-        proto_category.set_display_name(this->display_name);
+        proto_category.set_display_name(to_proto_string(this->display_name));
     }
     if (this->is_separator_is_set) {
-        proto_category.set_is_separator(this->is_separator);
+        proto_category.set_is_separator(to_proto_bool(this->is_separator));
     }
     if (this->name_is_set) {
-        proto_category.set_name(this->name);
+        proto_category.set_name(to_proto_string(this->name));
     }
     if (this->tooltip_description_is_set) {
-        proto_category.set_tip_description(this->tooltip_description);
+        proto_category.set_tip_description(to_proto_string(this->tooltip_description));
     }
     return proto_category;
 }
 
 void Category::parse_protobuf(waypoint::Category proto_category) {
     if (proto_category.default_visibility() != 0) {
-        this->default_visibility = proto_category.default_visibility();
+        this->default_visibility = from_proto_bool(proto_category.default_visibility());
         this->default_visibility_is_set = true;
     }
     if (proto_category.display_name() != "") {
-        this->display_name = proto_category.display_name();
+        this->display_name = from_proto_string(proto_category.display_name());
         this->display_name_is_set = true;
     }
     if (proto_category.is_separator() != 0) {
-        this->is_separator = proto_category.is_separator();
+        this->is_separator = from_proto_bool(proto_category.is_separator());
         this->is_separator_is_set = true;
     }
     if (proto_category.name() != "") {
-        this->name = proto_category.name();
+        this->name = from_proto_string(proto_category.name());
         this->name_is_set = true;
     }
     if (proto_category.tip_description() != "") {
-        this->tooltip_description = proto_category.tip_description();
+        this->tooltip_description = from_proto_string(proto_category.tip_description());
         this->tooltip_description_is_set = true;
     }
 }

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -481,25 +481,25 @@ vector<string> Icon::as_xml() const {
 waypoint::Icon Icon::as_protobuf() const {
     waypoint::Icon proto_icon;
     if (this->achievement_bitmask_is_set) {
-        proto_icon.set_achievement_bit(this->achievement_bitmask);
+        proto_icon.set_achievement_bit(to_proto_int(this->achievement_bitmask));
     }
     if (this->achievement_id_is_set) {
-        proto_icon.set_achievement_id(this->achievement_id);
+        proto_icon.set_achievement_id(to_proto_int(this->achievement_id));
     }
     if (this->auto_trigger_is_set) {
-        proto_icon.mutable_trigger()->set_auto_trigger(this->auto_trigger);
+        proto_icon.mutable_trigger()->set_auto_trigger(to_proto_bool(this->auto_trigger));
     }
     if (this->bounce_delay_is_set) {
-        proto_icon.mutable_trigger()->set_bounce_delay(this->bounce_delay);
+        proto_icon.mutable_trigger()->set_bounce_delay(to_proto_float(this->bounce_delay));
     }
     if (this->bounce_duration_is_set) {
-        proto_icon.mutable_trigger()->set_bounce_duration(this->bounce_duration);
+        proto_icon.mutable_trigger()->set_bounce_duration(to_proto_float(this->bounce_duration));
     }
     if (this->bounce_height_is_set) {
-        proto_icon.mutable_trigger()->set_bounce_height(this->bounce_height);
+        proto_icon.mutable_trigger()->set_bounce_height(to_proto_float(this->bounce_height));
     }
     if (this->can_fade_is_set) {
-        proto_icon.set_can_fade(this->can_fade);
+        proto_icon.set_can_fade(to_proto_bool(this->can_fade));
     }
     if (this->category_is_set) {
         proto_icon.set_allocated_category(to_proto_marker_category(this->category));
@@ -508,19 +508,19 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.set_allocated_rgba_color(to_proto_color(this->color));
     }
     if (this->copy_clipboard_is_set) {
-        proto_icon.mutable_trigger()->set_action_copy_clipboard(this->copy_clipboard);
+        proto_icon.mutable_trigger()->set_action_copy_clipboard(to_proto_string(this->copy_clipboard));
     }
     if (this->copy_message_is_set) {
-        proto_icon.mutable_trigger()->set_action_copy_message(this->copy_message);
+        proto_icon.mutable_trigger()->set_action_copy_message(to_proto_string(this->copy_message));
     }
     if (this->cull_chirality_is_set) {
         proto_icon.set_cull_chirality(to_proto_cull_chirality(this->cull_chirality));
     }
     if (this->distance_fade_end_is_set) {
-        proto_icon.set_distance_fade_end(this->distance_fade_end);
+        proto_icon.set_distance_fade_end(to_proto_float(this->distance_fade_end));
     }
     if (this->distance_fade_start_is_set) {
-        proto_icon.set_distance_fade_start(this->distance_fade_start);
+        proto_icon.set_distance_fade_start(to_proto_float(this->distance_fade_start));
     }
     if (this->euler_rotation_is_set) {
         proto_icon.set_allocated_euler_rotation(to_proto_euler_rotation(this->euler_rotation));
@@ -532,10 +532,10 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.set_allocated_guid(to_proto_unique_id(this->guid));
     }
     if (this->has_countdown_is_set) {
-        proto_icon.mutable_trigger()->set_has_countdown(this->has_countdown);
+        proto_icon.mutable_trigger()->set_has_countdown(to_proto_bool(this->has_countdown));
     }
     if (this->height_offset_is_set) {
-        proto_icon.set_height_offset(this->height_offset);
+        proto_icon.set_height_offset(to_proto_float(this->height_offset));
     }
     if (this->hide_category_is_set) {
         proto_icon.mutable_trigger()->set_allocated_action_hide_category(to_proto_marker_category(this->hide_category));
@@ -544,28 +544,28 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.set_allocated_texture_path(to_proto_image(this->icon));
     }
     if (this->icon_size_is_set) {
-        proto_icon.set_tentative__scale(this->icon_size);
+        proto_icon.set_tentative__scale(to_proto_float(this->icon_size));
     }
     if (this->info_message_is_set) {
-        proto_icon.mutable_trigger()->set_action_info_message(this->info_message);
+        proto_icon.mutable_trigger()->set_action_info_message(to_proto_string(this->info_message));
     }
     if (this->invert_visibility_is_set) {
-        proto_icon.mutable_trigger()->set_invert_display(this->invert_visibility);
+        proto_icon.mutable_trigger()->set_invert_display(to_proto_bool(this->invert_visibility));
     }
     if (this->map_display_size_is_set) {
-        proto_icon.set_map_display_size(this->map_display_size);
+        proto_icon.set_map_display_size(to_proto_int(this->map_display_size));
     }
     if (this->map_id_is_set) {
-        proto_icon.set_map_id(this->map_id);
+        proto_icon.set_map_id(to_proto_int(this->map_id));
     }
     if (this->map_type_filter_is_set) {
         proto_icon.set_allocated_map_type_filter(to_proto_map_type_filter(this->map_type_filter));
     }
     if (this->maximum_size_on_screen_is_set) {
-        proto_icon.set_maximum_size_on_screen(this->maximum_size_on_screen);
+        proto_icon.set_maximum_size_on_screen(to_proto_int(this->maximum_size_on_screen));
     }
     if (this->minimum_size_on_screen_is_set) {
-        proto_icon.set_minimum_size_on_screen(this->minimum_size_on_screen);
+        proto_icon.set_minimum_size_on_screen(to_proto_int(this->minimum_size_on_screen));
     }
     if (this->mount_filter_is_set) {
         proto_icon.set_allocated_mount_filter(to_proto_mount_filter(this->mount_filter));
@@ -577,28 +577,28 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.set_allocated_profession_filter(to_proto_profession_filter(this->profession_filter));
     }
     if (this->render_ingame_is_set) {
-        proto_icon.set_tentative__render_ingame(this->render_ingame);
+        proto_icon.set_tentative__render_ingame(to_proto_bool(this->render_ingame));
     }
     if (this->render_on_map_is_set) {
-        proto_icon.set_tentative__render_on_map(this->render_on_map);
+        proto_icon.set_tentative__render_on_map(to_proto_bool(this->render_on_map));
     }
     if (this->render_on_minimap_is_set) {
-        proto_icon.set_tentative__render_on_minimap(this->render_on_minimap);
+        proto_icon.set_tentative__render_on_minimap(to_proto_bool(this->render_on_minimap));
     }
     if (this->reset_behavior_is_set) {
         proto_icon.mutable_trigger()->set_reset_behavior(to_proto_reset_behavior(this->reset_behavior));
     }
     if (this->reset_length_is_set) {
-        proto_icon.mutable_trigger()->set_reset_length(this->reset_length);
+        proto_icon.mutable_trigger()->set_reset_length(to_proto_float(this->reset_length));
     }
     if (this->scale_on_map_with_zoom_is_set) {
-        proto_icon.set_scale_on_map_with_zoom(this->scale_on_map_with_zoom);
+        proto_icon.set_scale_on_map_with_zoom(to_proto_bool(this->scale_on_map_with_zoom));
     }
     if (this->schedule_is_set) {
-        proto_icon.set_bhdraft__schedule(this->schedule);
+        proto_icon.set_bhdraft__schedule(to_proto_string(this->schedule));
     }
     if (this->schedule_duration_is_set) {
-        proto_icon.set_bhdraft__schedule_duration(this->schedule_duration);
+        proto_icon.set_bhdraft__schedule_duration(to_proto_float(this->schedule_duration));
     }
     if (this->show_category_is_set) {
         proto_icon.mutable_trigger()->set_allocated_action_show_category(to_proto_marker_category(this->show_category));
@@ -613,44 +613,44 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.mutable_trigger()->set_allocated_action_toggle_category(to_proto_marker_category(this->toggle_category));
     }
     if (this->tooltip_description_is_set) {
-        proto_icon.set_tip_description(this->tooltip_description);
+        proto_icon.set_tip_description(to_proto_string(this->tooltip_description));
     }
     if (this->tooltip_name_is_set) {
-        proto_icon.set_tip_name(this->tooltip_name);
+        proto_icon.set_tip_name(to_proto_string(this->tooltip_name));
     }
     if (this->trigger_range_is_set) {
-        proto_icon.mutable_trigger()->set_range(this->trigger_range);
+        proto_icon.mutable_trigger()->set_range(to_proto_float(this->trigger_range));
     }
     return proto_icon;
 }
 
 void Icon::parse_protobuf(waypoint::Icon proto_icon) {
     if (proto_icon.achievement_bit() != 0) {
-        this->achievement_bitmask = proto_icon.achievement_bit();
+        this->achievement_bitmask = from_proto_int(proto_icon.achievement_bit());
         this->achievement_bitmask_is_set = true;
     }
     if (proto_icon.achievement_id() != 0) {
-        this->achievement_id = proto_icon.achievement_id();
+        this->achievement_id = from_proto_int(proto_icon.achievement_id());
         this->achievement_id_is_set = true;
     }
     if (proto_icon.trigger().auto_trigger() != 0) {
-        this->auto_trigger = proto_icon.trigger().auto_trigger();
+        this->auto_trigger = from_proto_bool(proto_icon.trigger().auto_trigger());
         this->auto_trigger_is_set = true;
     }
     if (proto_icon.trigger().bounce_delay() != 0) {
-        this->bounce_delay = proto_icon.trigger().bounce_delay();
+        this->bounce_delay = from_proto_float(proto_icon.trigger().bounce_delay());
         this->bounce_delay_is_set = true;
     }
     if (proto_icon.trigger().bounce_duration() != 0) {
-        this->bounce_duration = proto_icon.trigger().bounce_duration();
+        this->bounce_duration = from_proto_float(proto_icon.trigger().bounce_duration());
         this->bounce_duration_is_set = true;
     }
     if (proto_icon.trigger().bounce_height() != 0) {
-        this->bounce_height = proto_icon.trigger().bounce_height();
+        this->bounce_height = from_proto_float(proto_icon.trigger().bounce_height());
         this->bounce_height_is_set = true;
     }
     if (proto_icon.can_fade() != 0) {
-        this->can_fade = proto_icon.can_fade();
+        this->can_fade = from_proto_bool(proto_icon.can_fade());
         this->can_fade_is_set = true;
     }
     if (proto_icon.has_category()) {
@@ -662,11 +662,11 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->color_is_set = true;
     }
     if (proto_icon.trigger().action_copy_clipboard() != "") {
-        this->copy_clipboard = proto_icon.trigger().action_copy_clipboard();
+        this->copy_clipboard = from_proto_string(proto_icon.trigger().action_copy_clipboard());
         this->copy_clipboard_is_set = true;
     }
     if (proto_icon.trigger().action_copy_message() != "") {
-        this->copy_message = proto_icon.trigger().action_copy_message();
+        this->copy_message = from_proto_string(proto_icon.trigger().action_copy_message());
         this->copy_message_is_set = true;
     }
     if (proto_icon.cull_chirality() != 0) {
@@ -674,11 +674,11 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->cull_chirality_is_set = true;
     }
     if (proto_icon.distance_fade_end() != 0) {
-        this->distance_fade_end = proto_icon.distance_fade_end();
+        this->distance_fade_end = from_proto_float(proto_icon.distance_fade_end());
         this->distance_fade_end_is_set = true;
     }
     if (proto_icon.distance_fade_start() != 0) {
-        this->distance_fade_start = proto_icon.distance_fade_start();
+        this->distance_fade_start = from_proto_float(proto_icon.distance_fade_start());
         this->distance_fade_start_is_set = true;
     }
     if (proto_icon.has_euler_rotation()) {
@@ -694,11 +694,11 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->guid_is_set = true;
     }
     if (proto_icon.trigger().has_countdown() != 0) {
-        this->has_countdown = proto_icon.trigger().has_countdown();
+        this->has_countdown = from_proto_bool(proto_icon.trigger().has_countdown());
         this->has_countdown_is_set = true;
     }
     if (proto_icon.height_offset() != 0) {
-        this->height_offset = proto_icon.height_offset();
+        this->height_offset = from_proto_float(proto_icon.height_offset());
         this->height_offset_is_set = true;
     }
     if (proto_icon.trigger().has_action_hide_category()) {
@@ -710,23 +710,23 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->icon_is_set = true;
     }
     if (proto_icon.tentative__scale() != 0) {
-        this->icon_size = proto_icon.tentative__scale();
+        this->icon_size = from_proto_float(proto_icon.tentative__scale());
         this->icon_size_is_set = true;
     }
     if (proto_icon.trigger().action_info_message() != "") {
-        this->info_message = proto_icon.trigger().action_info_message();
+        this->info_message = from_proto_string(proto_icon.trigger().action_info_message());
         this->info_message_is_set = true;
     }
     if (proto_icon.trigger().invert_display() != 0) {
-        this->invert_visibility = proto_icon.trigger().invert_display();
+        this->invert_visibility = from_proto_bool(proto_icon.trigger().invert_display());
         this->invert_visibility_is_set = true;
     }
     if (proto_icon.map_display_size() != 0) {
-        this->map_display_size = proto_icon.map_display_size();
+        this->map_display_size = from_proto_int(proto_icon.map_display_size());
         this->map_display_size_is_set = true;
     }
     if (proto_icon.map_id() != 0) {
-        this->map_id = proto_icon.map_id();
+        this->map_id = from_proto_int(proto_icon.map_id());
         this->map_id_is_set = true;
     }
     if (proto_icon.has_map_type_filter()) {
@@ -734,11 +734,11 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->map_type_filter_is_set = true;
     }
     if (proto_icon.maximum_size_on_screen() != 0) {
-        this->maximum_size_on_screen = proto_icon.maximum_size_on_screen();
+        this->maximum_size_on_screen = from_proto_int(proto_icon.maximum_size_on_screen());
         this->maximum_size_on_screen_is_set = true;
     }
     if (proto_icon.minimum_size_on_screen() != 0) {
-        this->minimum_size_on_screen = proto_icon.minimum_size_on_screen();
+        this->minimum_size_on_screen = from_proto_int(proto_icon.minimum_size_on_screen());
         this->minimum_size_on_screen_is_set = true;
     }
     if (proto_icon.has_mount_filter()) {
@@ -754,15 +754,15 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->profession_filter_is_set = true;
     }
     if (proto_icon.tentative__render_ingame() != 0) {
-        this->render_ingame = proto_icon.tentative__render_ingame();
+        this->render_ingame = from_proto_bool(proto_icon.tentative__render_ingame());
         this->render_ingame_is_set = true;
     }
     if (proto_icon.tentative__render_on_map() != 0) {
-        this->render_on_map = proto_icon.tentative__render_on_map();
+        this->render_on_map = from_proto_bool(proto_icon.tentative__render_on_map());
         this->render_on_map_is_set = true;
     }
     if (proto_icon.tentative__render_on_minimap() != 0) {
-        this->render_on_minimap = proto_icon.tentative__render_on_minimap();
+        this->render_on_minimap = from_proto_bool(proto_icon.tentative__render_on_minimap());
         this->render_on_minimap_is_set = true;
     }
     if (proto_icon.trigger().reset_behavior() != 0) {
@@ -770,19 +770,19 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->reset_behavior_is_set = true;
     }
     if (proto_icon.trigger().reset_length() != 0) {
-        this->reset_length = proto_icon.trigger().reset_length();
+        this->reset_length = from_proto_float(proto_icon.trigger().reset_length());
         this->reset_length_is_set = true;
     }
     if (proto_icon.scale_on_map_with_zoom() != 0) {
-        this->scale_on_map_with_zoom = proto_icon.scale_on_map_with_zoom();
+        this->scale_on_map_with_zoom = from_proto_bool(proto_icon.scale_on_map_with_zoom());
         this->scale_on_map_with_zoom_is_set = true;
     }
     if (proto_icon.bhdraft__schedule() != "") {
-        this->schedule = proto_icon.bhdraft__schedule();
+        this->schedule = from_proto_string(proto_icon.bhdraft__schedule());
         this->schedule_is_set = true;
     }
     if (proto_icon.bhdraft__schedule_duration() != 0) {
-        this->schedule_duration = proto_icon.bhdraft__schedule_duration();
+        this->schedule_duration = from_proto_float(proto_icon.bhdraft__schedule_duration());
         this->schedule_duration_is_set = true;
     }
     if (proto_icon.trigger().has_action_show_category()) {
@@ -802,15 +802,15 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->toggle_category_is_set = true;
     }
     if (proto_icon.tip_description() != "") {
-        this->tooltip_description = proto_icon.tip_description();
+        this->tooltip_description = from_proto_string(proto_icon.tip_description());
         this->tooltip_description_is_set = true;
     }
     if (proto_icon.tip_name() != "") {
-        this->tooltip_name = proto_icon.tip_name();
+        this->tooltip_name = from_proto_string(proto_icon.tip_name());
         this->tooltip_name_is_set = true;
     }
     if (proto_icon.trigger().range() != 0) {
-        this->trigger_range = proto_icon.trigger().range();
+        this->trigger_range = from_proto_float(proto_icon.trigger().range());
         this->trigger_range_is_set = true;
     }
 }

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -289,16 +289,16 @@ vector<string> Trail::as_xml() const {
 waypoint::Trail Trail::as_protobuf() const {
     waypoint::Trail proto_trail;
     if (this->achievement_bitmask_is_set) {
-        proto_trail.set_achievement_bit(this->achievement_bitmask);
+        proto_trail.set_achievement_bit(to_proto_int(this->achievement_bitmask));
     }
     if (this->achievement_id_is_set) {
-        proto_trail.set_achievement_id(this->achievement_id);
+        proto_trail.set_achievement_id(to_proto_int(this->achievement_id));
     }
     if (this->animation_speed_is_set) {
-        proto_trail.set_animation_speed(this->animation_speed);
+        proto_trail.set_animation_speed(to_proto_float(this->animation_speed));
     }
     if (this->can_fade_is_set) {
-        proto_trail.set_can_fade(this->can_fade);
+        proto_trail.set_can_fade(to_proto_bool(this->can_fade));
     }
     if (this->category_is_set) {
         proto_trail.set_allocated_category(to_proto_marker_category(this->category));
@@ -310,10 +310,10 @@ waypoint::Trail Trail::as_protobuf() const {
         proto_trail.set_cull_chirality(to_proto_cull_chirality(this->cull_chirality));
     }
     if (this->distance_fade_end_is_set) {
-        proto_trail.set_distance_fade_end(this->distance_fade_end);
+        proto_trail.set_distance_fade_end(to_proto_float(this->distance_fade_end));
     }
     if (this->distance_fade_start_is_set) {
-        proto_trail.set_distance_fade_start(this->distance_fade_start);
+        proto_trail.set_distance_fade_start(to_proto_float(this->distance_fade_start));
     }
     if (this->festival_filter_is_set) {
         proto_trail.set_allocated_festival_filter(to_proto_festival_filter(this->festival_filter));
@@ -322,13 +322,13 @@ waypoint::Trail Trail::as_protobuf() const {
         proto_trail.set_allocated_guid(to_proto_unique_id(this->guid));
     }
     if (this->is_wall_is_set) {
-        proto_trail.set_is_wall(this->is_wall);
+        proto_trail.set_is_wall(to_proto_bool(this->is_wall));
     }
     if (this->map_display_size_is_set) {
-        proto_trail.set_map_display_size(this->map_display_size);
+        proto_trail.set_map_display_size(to_proto_int(this->map_display_size));
     }
     if (this->map_id_is_set) {
-        proto_trail.set_map_id(this->map_id);
+        proto_trail.set_map_id(to_proto_int(this->map_id));
     }
     if (this->map_type_filter_is_set) {
         proto_trail.set_allocated_map_type_filter(to_proto_map_type_filter(this->map_type_filter));
@@ -340,19 +340,19 @@ waypoint::Trail Trail::as_protobuf() const {
         proto_trail.set_allocated_profession_filter(to_proto_profession_filter(this->profession_filter));
     }
     if (this->render_ingame_is_set) {
-        proto_trail.set_tentative__render_ingame(this->render_ingame);
+        proto_trail.set_tentative__render_ingame(to_proto_bool(this->render_ingame));
     }
     if (this->render_on_map_is_set) {
-        proto_trail.set_tentative__render_on_map(this->render_on_map);
+        proto_trail.set_tentative__render_on_map(to_proto_bool(this->render_on_map));
     }
     if (this->render_on_minimap_is_set) {
-        proto_trail.set_tentative__render_on_minimap(this->render_on_minimap);
+        proto_trail.set_tentative__render_on_minimap(to_proto_bool(this->render_on_minimap));
     }
     if (this->schedule_is_set) {
-        proto_trail.set_bhdraft__schedule(this->schedule);
+        proto_trail.set_bhdraft__schedule(to_proto_string(this->schedule));
     }
     if (this->schedule_duration_is_set) {
-        proto_trail.set_bhdraft__schedule_duration(this->schedule_duration);
+        proto_trail.set_bhdraft__schedule_duration(to_proto_float(this->schedule_duration));
     }
     if (this->specialization_filter_is_set) {
         proto_trail.set_allocated_specialization_filter(to_proto_specialization_filter(this->specialization_filter));
@@ -367,26 +367,26 @@ waypoint::Trail Trail::as_protobuf() const {
         proto_trail.set_allocated_trail_data(to_proto_trail_data(this->trail_data));
     }
     if (this->trail_scale_is_set) {
-        proto_trail.set_scale(this->trail_scale);
+        proto_trail.set_scale(to_proto_float(this->trail_scale));
     }
     return proto_trail;
 }
 
 void Trail::parse_protobuf(waypoint::Trail proto_trail) {
     if (proto_trail.achievement_bit() != 0) {
-        this->achievement_bitmask = proto_trail.achievement_bit();
+        this->achievement_bitmask = from_proto_int(proto_trail.achievement_bit());
         this->achievement_bitmask_is_set = true;
     }
     if (proto_trail.achievement_id() != 0) {
-        this->achievement_id = proto_trail.achievement_id();
+        this->achievement_id = from_proto_int(proto_trail.achievement_id());
         this->achievement_id_is_set = true;
     }
     if (proto_trail.animation_speed() != 0) {
-        this->animation_speed = proto_trail.animation_speed();
+        this->animation_speed = from_proto_float(proto_trail.animation_speed());
         this->animation_speed_is_set = true;
     }
     if (proto_trail.can_fade() != 0) {
-        this->can_fade = proto_trail.can_fade();
+        this->can_fade = from_proto_bool(proto_trail.can_fade());
         this->can_fade_is_set = true;
     }
     if (proto_trail.has_category()) {
@@ -402,11 +402,11 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
         this->cull_chirality_is_set = true;
     }
     if (proto_trail.distance_fade_end() != 0) {
-        this->distance_fade_end = proto_trail.distance_fade_end();
+        this->distance_fade_end = from_proto_float(proto_trail.distance_fade_end());
         this->distance_fade_end_is_set = true;
     }
     if (proto_trail.distance_fade_start() != 0) {
-        this->distance_fade_start = proto_trail.distance_fade_start();
+        this->distance_fade_start = from_proto_float(proto_trail.distance_fade_start());
         this->distance_fade_start_is_set = true;
     }
     if (proto_trail.has_festival_filter()) {
@@ -418,15 +418,15 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
         this->guid_is_set = true;
     }
     if (proto_trail.is_wall() != 0) {
-        this->is_wall = proto_trail.is_wall();
+        this->is_wall = from_proto_bool(proto_trail.is_wall());
         this->is_wall_is_set = true;
     }
     if (proto_trail.map_display_size() != 0) {
-        this->map_display_size = proto_trail.map_display_size();
+        this->map_display_size = from_proto_int(proto_trail.map_display_size());
         this->map_display_size_is_set = true;
     }
     if (proto_trail.map_id() != 0) {
-        this->map_id = proto_trail.map_id();
+        this->map_id = from_proto_int(proto_trail.map_id());
         this->map_id_is_set = true;
     }
     if (proto_trail.has_map_type_filter()) {
@@ -442,23 +442,23 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
         this->profession_filter_is_set = true;
     }
     if (proto_trail.tentative__render_ingame() != 0) {
-        this->render_ingame = proto_trail.tentative__render_ingame();
+        this->render_ingame = from_proto_bool(proto_trail.tentative__render_ingame());
         this->render_ingame_is_set = true;
     }
     if (proto_trail.tentative__render_on_map() != 0) {
-        this->render_on_map = proto_trail.tentative__render_on_map();
+        this->render_on_map = from_proto_bool(proto_trail.tentative__render_on_map());
         this->render_on_map_is_set = true;
     }
     if (proto_trail.tentative__render_on_minimap() != 0) {
-        this->render_on_minimap = proto_trail.tentative__render_on_minimap();
+        this->render_on_minimap = from_proto_bool(proto_trail.tentative__render_on_minimap());
         this->render_on_minimap_is_set = true;
     }
     if (proto_trail.bhdraft__schedule() != "") {
-        this->schedule = proto_trail.bhdraft__schedule();
+        this->schedule = from_proto_string(proto_trail.bhdraft__schedule());
         this->schedule_is_set = true;
     }
     if (proto_trail.bhdraft__schedule_duration() != 0) {
-        this->schedule_duration = proto_trail.bhdraft__schedule_duration();
+        this->schedule_duration = from_proto_float(proto_trail.bhdraft__schedule_duration());
         this->schedule_duration_is_set = true;
     }
     if (proto_trail.has_specialization_filter()) {
@@ -478,7 +478,7 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
         this->trail_data_is_set = true;
     }
     if (proto_trail.scale() != 0) {
-        this->trail_scale = proto_trail.scale();
+        this->trail_scale = from_proto_float(proto_trail.scale());
         this->trail_scale_is_set = true;
     }
 }


### PR DESCRIPTION
This is not entirely necessary, they are all identify functions. However adding them means that we dont need to differentiate between the scalar/primitive types and instead we can just treat all types generally the same.