### PR TITLE
Converting GUID to be a scalar string value in protobuf

### DIFF
--- a/xml_converter/doc/trigger/guid.md
+++ b/xml_converter/doc/trigger/guid.md
@@ -5,6 +5,7 @@ class: UniqueId
 xml_fields: ["GUID"]
 applies_to: ["Icon", "Trail"]
 protobuf_field: guid
+ptotobuf_type: "String"
 ---
 A globally unique identifier value to make sure this maker's trigger reset data is always assocaited with this marker and never lost or confused with other markers.
 

--- a/xml_converter/doc/trigger/guid.md
+++ b/xml_converter/doc/trigger/guid.md
@@ -5,7 +5,7 @@ class: UniqueId
 xml_fields: ["GUID"]
 applies_to: ["Icon", "Trail"]
 protobuf_field: guid
-ptotobuf_type: "String"
+protobuf_type: String
 ---
 A globally unique identifier value to make sure this maker's trigger reset data is always assocaited with this marker and never lost or confused with other markers.
 

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -70,6 +70,7 @@ schema = union_t({
         optional={
             "side_effects": array_t(string_t()),
             "uses_file_path": boolean_t(),
+            "ptotobuf_type": enum_t(["Int32", "Fixed32", "Float32", "String"]),
         }
     ),
 })
@@ -166,6 +167,9 @@ class AttributeVariable:
 
     uses_file_path: bool = False
     is_component: bool = False
+
+    # A flag to override the type that should be used when writing or reading from a protobuf
+    ptotobuf_type: Optional[str] = None
 
 
 XML_ATTRIBUTE_PARSER_DEFAULT_ARGUMENTS: Final[List[str]] = ["attribute", "errors"]
@@ -413,6 +417,11 @@ class Generator:
                     if fieldval['xml_bundled_components'] == []:
                         write_to_xml = False
 
+                ptotobuf_type = None
+                if "ptotobuf_type" in fieldval:
+                    ptotobuf_type = fieldval["ptotobuf_type"]
+
+
                 attribute_variable = AttributeVariable(
                     attribute_name=attribute_name,
                     attribute_type=fieldval["type"],
@@ -427,6 +436,7 @@ class Generator:
                     write_to_xml=write_to_xml,
                     attribute_flag_name=attribute_name + "_is_set",
                     side_effects=side_effects,
+                    ptotobuf_type=ptotobuf_type
                 )
                 attribute_variables.append(attribute_variable)
 

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -421,7 +421,6 @@ class Generator:
                 if "ptotobuf_type" in fieldval:
                     ptotobuf_type = fieldval["ptotobuf_type"]
 
-
                 attribute_variable = AttributeVariable(
                     attribute_name=attribute_name,
                     attribute_type=fieldval["type"],

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -169,7 +169,11 @@ class AttributeVariable:
     is_component: bool = False
 
     # A flag to override the type that should be used when writing or reading from a protobuf
-    ptotobuf_type: Optional[str] = None
+    ptotobuf_type: str = ""
+
+    def __post_init__(self) -> None:
+        if self.ptotobuf_type == "":
+            self.ptotobuf_type = self.attribute_type
 
 
 XML_ATTRIBUTE_PARSER_DEFAULT_ARGUMENTS: Final[List[str]] = ["attribute", "errors"]
@@ -417,7 +421,7 @@ class Generator:
                     if fieldval['xml_bundled_components'] == []:
                         write_to_xml = False
 
-                ptotobuf_type = None
+                ptotobuf_type = ""
                 if "ptotobuf_type" in fieldval:
                     ptotobuf_type = fieldval["ptotobuf_type"]
 

--- a/xml_converter/generators/code_generator.py
+++ b/xml_converter/generators/code_generator.py
@@ -70,7 +70,7 @@ schema = union_t({
         optional={
             "side_effects": array_t(string_t()),
             "uses_file_path": boolean_t(),
-            "ptotobuf_type": enum_t(["Int32", "Fixed32", "Float32", "String"]),
+            "protobuf_type": enum_t(["Int32", "Fixed32", "Float32", "String"]),
         }
     ),
 })
@@ -169,11 +169,11 @@ class AttributeVariable:
     is_component: bool = False
 
     # A flag to override the type that should be used when writing or reading from a protobuf
-    ptotobuf_type: str = ""
+    protobuf_type: str = ""
 
     def __post_init__(self) -> None:
-        if self.ptotobuf_type == "":
-            self.ptotobuf_type = self.attribute_type
+        if self.protobuf_type == "":
+            self.protobuf_type = self.attribute_type
 
 
 XML_ATTRIBUTE_PARSER_DEFAULT_ARGUMENTS: Final[List[str]] = ["attribute", "errors"]
@@ -421,9 +421,9 @@ class Generator:
                     if fieldval['xml_bundled_components'] == []:
                         write_to_xml = False
 
-                ptotobuf_type = ""
-                if "ptotobuf_type" in fieldval:
-                    ptotobuf_type = fieldval["ptotobuf_type"]
+                protobuf_type = ""
+                if "protobuf_type" in fieldval:
+                    protobuf_type = fieldval["protobuf_type"]
 
                 attribute_variable = AttributeVariable(
                     attribute_name=attribute_name,
@@ -439,7 +439,7 @@ class Generator:
                     write_to_xml=write_to_xml,
                     attribute_flag_name=attribute_name + "_is_set",
                     side_effects=side_effects,
-                    ptotobuf_type=ptotobuf_type
+                    protobuf_type=protobuf_type
                 )
                 attribute_variables.append(attribute_variable)
 

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -98,7 +98,7 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
-                {% if attribute_variable.ptotobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
+                {% if attribute_variable.protobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
                 {% else %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
@@ -112,11 +112,11 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}) {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
-            {% if attribute_variable.ptotobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
+            {% if attribute_variable.protobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.has_{{attribute_variable.protobuf_field}}()) {
-            {% elif attribute_variable.ptotobuf_type == "String" %}
+            {% elif attribute_variable.protobuf_type == "String" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != "") {
-            {% elif attribute_variable.ptotobuf_type ==  "Enum" %}
+            {% elif attribute_variable.protobuf_type ==  "Enum" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
             {% else %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -98,7 +98,7 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
-                {% if (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
+                {% if attribute_variable.ptotobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
                 {% else %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
@@ -112,11 +112,11 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}) {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
-            {% if (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
+            {% if attribute_variable.ptotobuf_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.has_{{attribute_variable.protobuf_field}}()) {
-            {% elif (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) == "String" %}
+            {% elif attribute_variable.ptotobuf_type == "String" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != "") {
-            {% elif (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) ==  "Enum" %}
+            {% elif attribute_variable.ptotobuf_type ==  "Enum" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
             {% else %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -98,7 +98,7 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
-                {% if (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"]) %}
+                {% if (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
                 {% else %}
                     proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(to_proto_{{attribute_variable.class_name}}(this->{{attribute_variable.attribute_name}}));
@@ -112,11 +112,11 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf() const {
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}) {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
-            {% if (attribute_variable.attribute_type in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"]) %}
+            {% if (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) in ["MultiflagValue", "CompoundValue", "Custom", "CompoundCustomClass"] %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.has_{{attribute_variable.protobuf_field}}()) {
-            {% elif (attribute_variable.attribute_type == "String") %}
+            {% elif (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) == "String" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != "") {
-            {% elif (attribute_variable.attribute_type ==  "Enum") %}
+            {% elif (attribute_variable.ptotobuf_type or attribute_variable.attribute_type) ==  "Enum" %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
             {% else %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {

--- a/xml_converter/proto/waypoint.proto
+++ b/xml_converter/proto/waypoint.proto
@@ -19,7 +19,7 @@ message Category {
 
 message Icon {
     TexturePath texture_path = 2;
-    GUID guid = 3;
+    bytes guid = 3;
     int32 map_id = 4;
     float distance_fade_end = 5;
     float distance_fade_start = 6;
@@ -57,7 +57,7 @@ message Icon {
 
 message Trail {
     TexturePath texture_path = 2;
-    GUID guid = 3;
+    bytes guid = 3;
     int32 map_id = 4;
     float distance_fade_end = 5;
     float distance_fade_start = 6;
@@ -123,10 +123,6 @@ message Trigger {
     Category action_show_category = 13;
     Category action_toggle_category = 14;
     ResetBehavior reset_behavior = 15;
-}
-
-message GUID {
-    bytes guid = 1;
 }
 
 enum CullChirality {

--- a/xml_converter/src/attribute/unique_id.cpp
+++ b/xml_converter/src/attribute/unique_id.cpp
@@ -25,17 +25,13 @@ string stringify_unique_id(UniqueId attribute_value) {
     return base64_encode(&attribute_value.guid[0], attribute_value.guid.size());
 }
 
-waypoint::GUID* to_proto_unique_id(UniqueId attribute_value) {
-    waypoint::GUID* guid = new waypoint::GUID();
-    std::string s(attribute_value.guid.begin(), attribute_value.guid.end());
-    guid->set_guid(s);
-    return guid;
+string to_proto_unique_id(UniqueId attribute_value) {
+    return std::string(attribute_value.guid.begin(), attribute_value.guid.end());
 }
 
-UniqueId from_proto_unique_id(waypoint::GUID attribute_value) {
+UniqueId from_proto_unique_id(string attribute_value) {
     UniqueId unique_id;
-    string s = attribute_value.guid();
-    std::vector<uint8_t> guid(s.begin(), s.end());
+    std::vector<uint8_t> guid(attribute_value.begin(), attribute_value.end());
     unique_id.guid = guid;
     return unique_id;
 }

--- a/xml_converter/src/attribute/unique_id.hpp
+++ b/xml_converter/src/attribute/unique_id.hpp
@@ -20,6 +20,6 @@ UniqueId parse_unique_id(rapidxml::xml_attribute<>* input, std::vector<XMLError*
 
 std::string stringify_unique_id(UniqueId attribute_value);
 
-waypoint::GUID* to_proto_unique_id(UniqueId attribute_value);
+std::string to_proto_unique_id(UniqueId attribute_value);
 
-UniqueId from_proto_unique_id(waypoint::GUID attribute_value);
+UniqueId from_proto_unique_id(std::string attribute_value);

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -529,7 +529,7 @@ waypoint::Icon Icon::as_protobuf() const {
         proto_icon.set_allocated_festival_filter(to_proto_festival_filter(this->festival_filter));
     }
     if (this->guid_is_set) {
-        proto_icon.set_allocated_guid(to_proto_unique_id(this->guid));
+        proto_icon.set_guid(to_proto_unique_id(this->guid));
     }
     if (this->has_countdown_is_set) {
         proto_icon.mutable_trigger()->set_has_countdown(to_proto_bool(this->has_countdown));
@@ -689,7 +689,7 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
         this->festival_filter = from_proto_festival_filter(proto_icon.festival_filter());
         this->festival_filter_is_set = true;
     }
-    if (proto_icon.has_guid()) {
+    if (proto_icon.guid() != "") {
         this->guid = from_proto_unique_id(proto_icon.guid());
         this->guid_is_set = true;
     }

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -319,7 +319,7 @@ waypoint::Trail Trail::as_protobuf() const {
         proto_trail.set_allocated_festival_filter(to_proto_festival_filter(this->festival_filter));
     }
     if (this->guid_is_set) {
-        proto_trail.set_allocated_guid(to_proto_unique_id(this->guid));
+        proto_trail.set_guid(to_proto_unique_id(this->guid));
     }
     if (this->is_wall_is_set) {
         proto_trail.set_is_wall(to_proto_bool(this->is_wall));
@@ -413,7 +413,7 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
         this->festival_filter = from_proto_festival_filter(proto_trail.festival_filter());
         this->festival_filter_is_set = true;
     }
-    if (proto_trail.has_guid()) {
+    if (proto_trail.guid() != "") {
         this->guid = from_proto_unique_id(proto_trail.guid());
         this->guid_is_set = true;
     }


### PR DESCRIPTION
Adds a new field to allow custom values to overwrite their type when reading/writing a protobuf. This could be upgraded in a couple ways but this is a good solution vs the amount of work it would take to automate some of these things.