### PR TITLE
Fixed boolean stringification

### DIFF
--- a/xml_converter/intigration_tests/expected_outputs/xml_can_fade_invalid/xml_file.xml
+++ b/xml_converter/intigration_tests/expected_outputs/xml_can_fade_invalid/xml_file.xml
@@ -3,6 +3,6 @@
 </MarkerCategory>
 
 <POIs>
-<POI  CanFade="false" Type="mycategory" IconFile="texture.png" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="mycategory" IconFile="texture.png" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
 </POIs>
 </OverlayData>

--- a/xml_converter/src/attribute/bool.cpp
+++ b/xml_converter/src/attribute/bool.cpp
@@ -40,7 +40,7 @@ void xml_attribute_to_bool(
 // Converts a bool into a fully qualified xml attribute string.
 ////////////////////////////////////////////////////////////////////////////////
 string bool_to_xml_attribute(const string& attribute_name, const bool* value) {
-    if (value) {
+    if (*value) {
         return " " + attribute_name + "=\"true\"";
     }
     else {


### PR DESCRIPTION
Also updated the integration test since there is no default return anymore

The if statement in `bool_to_xml_attribute` was checking if the pointer existed rather than the value of what the pointer referenced. Therefore it was printing True for every call. 