### PR TITLE
Preallocating join string

### DIFF
--- a/xml_converter/src/string_helper.cpp
+++ b/xml_converter/src/string_helper.cpp
@@ -48,8 +48,15 @@ vector<string> split(string input, string delimiter) {
     return output;
 }
 
-string join(const vector<string>& input, string delimiter) {
+string join(const vector<string>& input, const string& delimiter) {
     string result;
+    size_t size = 0;
+    for (size_t i = 0; i < input.size(); i++) {
+        size += input[i].size() + delimiter.size();
+    }
+
+    result.resize(size);
+
     for (size_t i = 0; i < input.size(); i++) {
         result += input[i];
         // Don't add delimiter after the last element

--- a/xml_converter/src/string_helper.hpp
+++ b/xml_converter/src/string_helper.hpp
@@ -12,7 +12,7 @@ bool normalized_matches_any(std::string test, std::vector<std::string> list);
 std::string lowercase(std::string);
 
 std::vector<std::string> split(std::string input, std::string delimiter);
-std::string join(const std::vector<std::string>& input, std::string delimiter);
+std::string join(const std::vector<std::string>& input, const std::string& delimiter);
 
 std::string normalize(std::string input_string);
 


### PR DESCRIPTION
Preallocating the length of the join string means that there wont be reallocations being done within the loop speeding it up