### PR TITLE
Identify multiple jinja tags in a single line

### DIFF
--- a/xml_converter/generators/jinja_helpers.py
+++ b/xml_converter/generators/jinja_helpers.py
@@ -225,7 +225,7 @@ def unindent_block(block: List[str]) -> List[str]:
 # This function parses out jinja control flow tags from a string of text.
 ################################################################################
 def parse_out_tags(line: str) -> List[str]:
-    tags = []
+    tags: List[str] = []
 
     while True:
         start_index = line.find("{%")


### PR DESCRIPTION
The current system breaks if you do a `{% for ... %}something inline{% endfor %}` because the current regex only captures the `{% endfor %} breaking the indentation stack. This marginally corrects this while not fully solving the problem. Instead it just checks to see if there are multiple tags on a single line, and if there are it assumes that all the open block tags are paired with close block tags. This can be expanded upon further down the line as it is needed.