### PR TITLE
Using the correct preallocation method for the join function

### DIFF
--- a/xml_converter/src/string_helper.cpp
+++ b/xml_converter/src/string_helper.cpp
@@ -55,7 +55,7 @@ string join(const vector<string>& input, const string& delimiter) {
         size += input[i].size() + delimiter.size();
     }
 
-    result.resize(size);
+    result.reserve(size);
 
     for (size_t i = 0; i < input.size(); i++) {
         result += input[i];


### PR DESCRIPTION
The previous one caused some errors with null characters being added to the output string which would show up on the written xml diff.