### PR TITLE
removing proto category getter setters for eventual deletion

### DIFF
--- a/xml_converter/doc/category/category.md
+++ b/xml_converter/doc/category/category.md
@@ -5,6 +5,13 @@ class: MarkerCategory
 applies_to: [Icon, Trail]
 xml_fields: [Type, Category]
 protobuf_field: category
+custom_functions:
+  read.proto:
+    function: do_nothing
+    side_effects: []
+  write.proto:
+    function: do_nothing
+    side_effects: []
 ---
 The category this object belongs to.
 

--- a/xml_converter/proto/waypoint.proto
+++ b/xml_converter/proto/waypoint.proto
@@ -51,7 +51,9 @@ message Icon {
     bool tentative__render_on_minimap = 2051;
     string bhdraft__schedule = 2052;
     float bhdraft__schedule_duration = 2053;
-    Category category = 2054;
+
+    // TODO: Delete this when we can parse data per marker instead of per field
+    bool category = 2054;
 }
 
 message Trail {
@@ -83,7 +85,9 @@ message Trail {
     bool tentative__render_on_minimap = 2051;
     string bhdraft__schedule = 2052;
     float bhdraft__schedule_duration = 2053;
-    Category category = 2054;
+
+    // TODO: Delete this when we can parse data per marker instead of per field
+    bool category = 2054;
 }
     
 message TexturePath {

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -437,8 +437,8 @@ waypoint::Icon Icon::as_protobuf() const {
         bool_to_proto(this->can_fade, setter);
     }
     if (this->category_is_set) {
-        std::function<void(waypoint::Category*)> setter = [&proto_icon](waypoint::Category* val) { proto_icon.set_allocated_category(val); };
-        marker_category_to_proto(this->category, setter);
+        std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_category(val); };
+        do_nothing(this->category, setter);
     }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_icon](waypoint::RGBAColor* val) { proto_icon.set_allocated_rgba_color(val); };
@@ -621,8 +621,8 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon) {
     if (proto_icon.can_fade() != 0) {
         proto_to_bool(proto_icon.can_fade(), &(this->can_fade), &(this->can_fade_is_set));
     }
-    if (proto_icon.has_category()) {
-        proto_to_marker_category(proto_icon.category(), &(this->category), &(this->category_is_set));
+    if (proto_icon.category() != 0) {
+        do_nothing(proto_icon.category(), &(this->category), &(this->category_is_set));
     }
     if (proto_icon.has_rgba_color()) {
         proto_to_color(proto_icon.rgba_color(), &(this->color), &(this->color_is_set));

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -263,8 +263,8 @@ waypoint::Trail Trail::as_protobuf() const {
         bool_to_proto(this->can_fade, setter);
     }
     if (this->category_is_set) {
-        std::function<void(waypoint::Category*)> setter = [&proto_trail](waypoint::Category* val) { proto_trail.set_allocated_category(val); };
-        marker_category_to_proto(this->category, setter);
+        std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_category(val); };
+        do_nothing(this->category, setter);
     }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_trail](waypoint::RGBAColor* val) { proto_trail.set_allocated_rgba_color(val); };
@@ -370,8 +370,8 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail) {
     if (proto_trail.can_fade() != 0) {
         proto_to_bool(proto_trail.can_fade(), &(this->can_fade), &(this->can_fade_is_set));
     }
-    if (proto_trail.has_category()) {
-        proto_to_marker_category(proto_trail.category(), &(this->category), &(this->category_is_set));
+    if (proto_trail.category() != 0) {
+        do_nothing(proto_trail.category(), &(this->category), &(this->category_is_set));
     }
     if (proto_trail.has_rgba_color()) {
         proto_to_color(proto_trail.rgba_color(), &(this->color), &(this->color_is_set));


### PR DESCRIPTION
This sets up the eventual complete removal of the field. But for now it handles preventing it from being written to the protobin.