### PR TITLE
Adding global state var for the xml parsers

### DIFF
--- a/xml_converter/generators/cpp_templates/attribute_template.hpp
+++ b/xml_converter/generators/cpp_templates/attribute_template.hpp
@@ -6,7 +6,6 @@
 
 #include "../rapidxml-1.13/rapidxml.hpp"
 #include "../state_structs/xml_parse_state.hpp"
-
 {% if type == "Enum" %}
     #include "waypoint.pb.h"
 
@@ -18,6 +17,7 @@
         {% endfor %}
     };
 {% else %}
+
     class XMLError;
     {{proto_field_cpp_type_prototype}}
 

--- a/xml_converter/generators/cpp_templates/attribute_template.hpp
+++ b/xml_converter/generators/cpp_templates/attribute_template.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 {% if type == "Enum" %}
     #include "waypoint.pb.h"
 
@@ -33,6 +35,7 @@
 void xml_attribute_to_{{attribute_name}}(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     {{class_name}}* value,
     bool* is_set);
 

--- a/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
@@ -14,6 +14,7 @@ using namespace std;
 void xml_attribute_to_{{attribute_name}}(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};

--- a/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_{{attribute_name}}(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};

--- a/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_{{attribute_name}}(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -18,12 +18,12 @@ string {{cpp_class}}::classname() {
     return "{{xml_class_name}}";
 }
 {% if cpp_class == "Category": %}
-    void {{cpp_class}}::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, string base_dir) {
+    void {{cpp_class}}::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, XMLParseState* state) {
         for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
-            bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors);
-            bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors);
+            bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors, state);
+            bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors, state);
 
-            if (init_xml_attribute(attribute, errors, base_dir)) {
+            if (init_xml_attribute(attribute, errors, state)) {
             }
             else if (is_icon_value || is_trail_value) {
             }
@@ -34,13 +34,13 @@ string {{cpp_class}}::classname() {
     }
 {% endif %}
 
-bool {{cpp_class}}::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, string base_dir) {
+bool {{cpp_class}}::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, XMLParseState* state) {
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     {% for n, attribute_variable in enumerate(attribute_variables) %}
         {% for i, value in enumerate(attribute_variable.xml_fields) %}
             {{ "if" if i == n == 0 else "else if" }} (attributename == "{{value}}") {
-                {{attribute_variable.deserialize_xml_function}}(attribute, errors, {% if attribute_variable.uses_file_path %}base_dir, {% endif %}&(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.deserialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %});
+                {{attribute_variable.deserialize_xml_function}}(attribute, errors, state, &(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.deserialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %});
             }
         {% endfor %}
     {% endfor %}

--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -14,26 +14,26 @@
 
 class {{cpp_class}} : public Parseable {
  public:
-    {% for attribute_variable in attribute_variables: %}
-        {% if attribute_variable.is_component == false: %}
+    {% for attribute_variable in attribute_variables %}
+        {% if attribute_variable.is_component == false %}
             {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
         {% endif %}
     {% endfor %}
-    {% for attribute_variable in attribute_variables: %}
-        {% if attribute_variable.is_component == false: %}
+    {% for attribute_variable in attribute_variables %}
+        {% if attribute_variable.is_component == false %}
             bool {{attribute_variable.attribute_flag_name}} = false;
         {% endif %}
     {% endfor %}
-    {% if cpp_class == "Category": %}
+    {% if cpp_class == "Category" %}
         std::map<std::string, Category> children;
         Icon default_icon;
         Trail default_trail;
 
-        void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
+        void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLParseState* state);
     {% endif %}
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
-    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
+    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLParseState* state);
     waypoint::{{cpp_class}} as_protobuf() const;
     void parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}});
     {% if attributes_of_type_marker_category %}

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -216,14 +216,15 @@ def generate_cpp_variable_data(
 
     cpp_includes.hpp_absolute_includes.add("string")
     cpp_includes.hpp_absolute_includes.add("vector")
+    cpp_includes.hpp_absolute_includes.add("functional")
     cpp_includes.hpp_relative_includes.add("rapidxml-1.13/rapidxml.hpp")
     cpp_includes.hpp_relative_includes.add("parseable.hpp")
     cpp_includes.hpp_relative_includes.add("waypoint.pb.h")
+    cpp_includes.hpp_relative_includes.add("state_structs/xml_parse_state.hpp")
     cpp_includes.hpp_forward_declarations.add("XMLError")
 
     cpp_includes.cpp_absolute_includes.add("iosfwd")
     cpp_includes.cpp_absolute_includes.add("string")
-    cpp_includes.hpp_absolute_includes.add("functional")
     cpp_includes.cpp_relative_includes.add("rapidxml-1.13/rapidxml.hpp")
     cpp_includes.cpp_relative_includes.add("string_helper.hpp")
     cpp_includes.cpp_relative_includes.add("rapid_helpers.hpp")

--- a/xml_converter/src/attribute/bool.cpp
+++ b/xml_converter/src/attribute/bool.cpp
@@ -19,6 +19,7 @@ using namespace std;
 void xml_attribute_to_bool(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     bool* value,
     bool* is_set) {
     if (get_attribute_value(input) == "0" || get_attribute_value(input) == "false") {
@@ -58,6 +59,7 @@ string bool_to_xml_attribute(const string& attribute_name, const bool* value) {
 void inverted_xml_attribute_to_bool(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     bool* value,
     bool* is_set) {
     if (get_attribute_value(input) == "0" || get_attribute_value(input) == "false") {

--- a/xml_converter/src/attribute/bool.hpp
+++ b/xml_converter/src/attribute/bool.hpp
@@ -5,12 +5,14 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
 
 void xml_attribute_to_bool(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     bool* value,
     bool* is_set);
 
@@ -21,6 +23,7 @@ std::string bool_to_xml_attribute(
 void inverted_xml_attribute_to_bool(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     bool* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/color.cpp
+++ b/xml_converter/src/attribute/color.cpp
@@ -51,6 +51,7 @@ int convert_color_channel_float_to_int(float input) {
 void xml_attribute_to_color(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Color* value,
     bool* is_set) {
     Color color;

--- a/xml_converter/src/attribute/color.hpp
+++ b/xml_converter/src/attribute/color.hpp
@@ -5,8 +5,10 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
+
 namespace waypoint {
 class RGBAColor;
 }
@@ -22,6 +24,7 @@ class Color {
 void xml_attribute_to_color(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Color* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/cull_chirality_gen.cpp
+++ b/xml_converter/src/attribute/cull_chirality_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_cull_chirality(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     CullChirality* value,
     bool* is_set) {
     CullChirality cull_chirality;

--- a/xml_converter/src/attribute/cull_chirality_gen.hpp
+++ b/xml_converter/src/attribute/cull_chirality_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 #include "waypoint.pb.h"
 
 class XMLError;
@@ -17,6 +19,7 @@ enum CullChirality {
 void xml_attribute_to_cull_chirality(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     CullChirality* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/cull_chirality_gen.hpp
+++ b/xml_converter/src/attribute/cull_chirality_gen.hpp
@@ -6,7 +6,6 @@
 
 #include "../rapidxml-1.13/rapidxml.hpp"
 #include "../state_structs/xml_parse_state.hpp"
-
 #include "waypoint.pb.h"
 
 class XMLError;

--- a/xml_converter/src/attribute/euler_rotation_gen.cpp
+++ b/xml_converter/src/attribute/euler_rotation_gen.cpp
@@ -14,6 +14,7 @@ using namespace std;
 void xml_attribute_to_euler_rotation(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     EulerRotation* value,
     bool* is_set) {
     EulerRotation euler_rotation;

--- a/xml_converter/src/attribute/euler_rotation_gen.hpp
+++ b/xml_converter/src/attribute/euler_rotation_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class EulerRotation;
@@ -23,6 +25,7 @@ class EulerRotation {
 void xml_attribute_to_euler_rotation(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     EulerRotation* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/festival_filter_gen.cpp
+++ b/xml_converter/src/attribute/festival_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_festival_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     FestivalFilter* value,
     bool* is_set) {
     FestivalFilter festival_filter;

--- a/xml_converter/src/attribute/festival_filter_gen.hpp
+++ b/xml_converter/src/attribute/festival_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class FestivalFilter;
@@ -27,6 +29,7 @@ class FestivalFilter {
 void xml_attribute_to_festival_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     FestivalFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/float.cpp
+++ b/xml_converter/src/attribute/float.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_float(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     float* value,
     bool* is_set) {
     *value = std::stof(get_attribute_value(input));

--- a/xml_converter/src/attribute/float.hpp
+++ b/xml_converter/src/attribute/float.hpp
@@ -5,12 +5,14 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
 
 void xml_attribute_to_float(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     float* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/image.cpp
+++ b/xml_converter/src/attribute/image.cpp
@@ -18,6 +18,7 @@ using namespace std;
 void xml_attribute_to_image(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Image* value,
     bool* is_set) {
     value->path = get_attribute_value(input);

--- a/xml_converter/src/attribute/image.hpp
+++ b/xml_converter/src/attribute/image.hpp
@@ -5,8 +5,10 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
+
 namespace waypoint {
 class TexturePath;
 }
@@ -19,6 +21,7 @@ class Image {
 void xml_attribute_to_image(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Image* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/int.cpp
+++ b/xml_converter/src/attribute/int.cpp
@@ -19,6 +19,7 @@ using namespace std;
 void xml_attribute_to_int(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     int* value,
     bool* is_set) {
     try {

--- a/xml_converter/src/attribute/int.hpp
+++ b/xml_converter/src/attribute/int.hpp
@@ -5,12 +5,14 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
 
 void xml_attribute_to_int(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     int* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/map_type_filter_gen.cpp
+++ b/xml_converter/src/attribute/map_type_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_map_type_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MapTypeFilter* value,
     bool* is_set) {
     MapTypeFilter map_type_filter;

--- a/xml_converter/src/attribute/map_type_filter_gen.hpp
+++ b/xml_converter/src/attribute/map_type_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class MapTypeFilter;
@@ -44,6 +46,7 @@ class MapTypeFilter {
 void xml_attribute_to_map_type_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MapTypeFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/marker_category.cpp
+++ b/xml_converter/src/attribute/marker_category.cpp
@@ -15,6 +15,7 @@
 void xml_attribute_to_marker_category(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MarkerCategory* value,
     bool* is_set) {
     value->category = get_attribute_value(input);

--- a/xml_converter/src/attribute/marker_category.hpp
+++ b/xml_converter/src/attribute/marker_category.hpp
@@ -5,8 +5,10 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
+
 namespace waypoint {
 class Category;
 }
@@ -19,6 +21,7 @@ class MarkerCategory {
 void xml_attribute_to_marker_category(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MarkerCategory* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/mount_filter_gen.cpp
+++ b/xml_converter/src/attribute/mount_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_mount_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MountFilter* value,
     bool* is_set) {
     MountFilter mount_filter;

--- a/xml_converter/src/attribute/mount_filter_gen.hpp
+++ b/xml_converter/src/attribute/mount_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class MountFilter;
@@ -30,6 +32,7 @@ class MountFilter {
 void xml_attribute_to_mount_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     MountFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/position_gen.cpp
+++ b/xml_converter/src/attribute/position_gen.cpp
@@ -14,6 +14,7 @@ using namespace std;
 void xml_attribute_to_position(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Position* value,
     bool* is_set) {
     Position position;

--- a/xml_converter/src/attribute/position_gen.hpp
+++ b/xml_converter/src/attribute/position_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class Position;
@@ -23,6 +25,7 @@ class Position {
 void xml_attribute_to_position(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     Position* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/profession_filter_gen.cpp
+++ b/xml_converter/src/attribute/profession_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_profession_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     ProfessionFilter* value,
     bool* is_set) {
     ProfessionFilter profession_filter;

--- a/xml_converter/src/attribute/profession_filter_gen.hpp
+++ b/xml_converter/src/attribute/profession_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class ProfessionFilter;
@@ -29,6 +31,7 @@ class ProfessionFilter {
 void xml_attribute_to_profession_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     ProfessionFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/reset_behavior_gen.cpp
+++ b/xml_converter/src/attribute/reset_behavior_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_reset_behavior(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     ResetBehavior* value,
     bool* is_set) {
     ResetBehavior reset_behavior;

--- a/xml_converter/src/attribute/reset_behavior_gen.hpp
+++ b/xml_converter/src/attribute/reset_behavior_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 #include "waypoint.pb.h"
 
 class XMLError;
@@ -23,6 +25,7 @@ enum ResetBehavior {
 void xml_attribute_to_reset_behavior(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     ResetBehavior* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/reset_behavior_gen.hpp
+++ b/xml_converter/src/attribute/reset_behavior_gen.hpp
@@ -6,7 +6,6 @@
 
 #include "../rapidxml-1.13/rapidxml.hpp"
 #include "../state_structs/xml_parse_state.hpp"
-
 #include "waypoint.pb.h"
 
 class XMLError;

--- a/xml_converter/src/attribute/specialization_filter_gen.cpp
+++ b/xml_converter/src/attribute/specialization_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_specialization_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     SpecializationFilter* value,
     bool* is_set) {
     SpecializationFilter specialization_filter;

--- a/xml_converter/src/attribute/specialization_filter_gen.hpp
+++ b/xml_converter/src/attribute/specialization_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class SpecializationFilter;
@@ -92,6 +94,7 @@ class SpecializationFilter {
 void xml_attribute_to_specialization_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     SpecializationFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/species_filter_gen.cpp
+++ b/xml_converter/src/attribute/species_filter_gen.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_species_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     SpeciesFilter* value,
     bool* is_set) {
     SpeciesFilter species_filter;

--- a/xml_converter/src/attribute/species_filter_gen.hpp
+++ b/xml_converter/src/attribute/species_filter_gen.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
+
 class XMLError;
 namespace waypoint {
 class SpeciesFilter;
@@ -25,6 +27,7 @@ class SpeciesFilter {
 void xml_attribute_to_species_filter(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     SpeciesFilter* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/string.cpp
+++ b/xml_converter/src/attribute/string.cpp
@@ -18,6 +18,7 @@ using namespace std;
 void xml_attribute_to_string(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     string* value,
     bool* is_set) {
     *value = get_attribute_value(input);

--- a/xml_converter/src/attribute/string.hpp
+++ b/xml_converter/src/attribute/string.hpp
@@ -5,12 +5,14 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
 
 void xml_attribute_to_string(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     std::string* value,
     bool* is_set);
 

--- a/xml_converter/src/attribute/trail_data.cpp
+++ b/xml_converter/src/attribute/trail_data.cpp
@@ -10,6 +10,7 @@
 #include "../rapid_helpers.hpp"
 #include "../rapidxml-1.13/rapidxml.hpp"
 #include "waypoint.pb.h"
+#include "../packaging_xml.hpp"
 
 using namespace std;
 
@@ -21,14 +22,14 @@ using namespace std;
 void xml_attribute_to_trail_data(
     rapidxml::xml_attribute<>* input,
     vector<XMLError*>* errors,
-    string base_dir,
+    XMLParseState* state,
     TrailData* value,
     bool* is_set,
     int* map_id_value,
     bool* is_map_id_set) {
     TrailData trail_data;
     string trail_data_relative_path = get_attribute_value(input);
-    if (base_dir == "") {
+    if (state->xml_filedir  == "") {
         throw "Error: Marker pack base directory is an empty string";
     }
     if (trail_data_relative_path == "") {
@@ -37,7 +38,7 @@ void xml_attribute_to_trail_data(
     }
 
     ifstream trail_data_file;
-    string trail_path = base_dir + "/" + trail_data_relative_path;
+    string trail_path = state->xml_filedir + "/" + trail_data_relative_path;
     trail_data_file.open(trail_path, ios::in | ios::binary);
     if (!trail_data_file.good()) {
         errors->push_back(new XMLAttributeValueError("No trail file found at " + trail_path, input));

--- a/xml_converter/src/attribute/trail_data.cpp
+++ b/xml_converter/src/attribute/trail_data.cpp
@@ -7,10 +7,10 @@
 #include <string>
 #include <vector>
 
+#include "../packaging_xml.hpp"
 #include "../rapid_helpers.hpp"
 #include "../rapidxml-1.13/rapidxml.hpp"
 #include "waypoint.pb.h"
-#include "../packaging_xml.hpp"
 
 using namespace std;
 
@@ -29,7 +29,7 @@ void xml_attribute_to_trail_data(
     bool* is_map_id_set) {
     TrailData trail_data;
     string trail_data_relative_path = get_attribute_value(input);
-    if (state->xml_filedir  == "") {
+    if (state->xml_filedir == "") {
         throw "Error: Marker pack base directory is an empty string";
     }
     if (trail_data_relative_path == "") {

--- a/xml_converter/src/attribute/trail_data.hpp
+++ b/xml_converter/src/attribute/trail_data.hpp
@@ -5,8 +5,10 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
+
 namespace waypoint {
 class TrailData;
 }
@@ -21,7 +23,7 @@ class TrailData {
 void xml_attribute_to_trail_data(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
-    std::string base_dir,
+    XMLParseState* state,
     TrailData* value,
     bool* is_set,
     int* map_id_value,

--- a/xml_converter/src/attribute/unique_id.cpp
+++ b/xml_converter/src/attribute/unique_id.cpp
@@ -15,6 +15,7 @@ using namespace std;
 void xml_attribute_to_unique_id(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     UniqueId* value,
     bool* is_set) {
     string base64;

--- a/xml_converter/src/attribute/unique_id.hpp
+++ b/xml_converter/src/attribute/unique_id.hpp
@@ -6,8 +6,10 @@
 #include <vector>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/xml_parse_state.hpp"
 
 class XMLError;
+
 namespace waypoint {
 class GUID;
 }
@@ -20,6 +22,7 @@ class UniqueId {
 void xml_attribute_to_unique_id(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
+    XMLParseState* state,
     UniqueId* value,
     bool* is_set);
 

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -18,12 +18,12 @@ using namespace std;
 string Category::classname() {
     return "MarkerCategory";
 }
-void Category::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, string base_dir) {
+void Category::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, XMLParseState* state) {
     for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
-        bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors);
-        bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors);
+        bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors, state);
+        bool is_trail_value = this->default_trail.init_xml_attribute(attribute, errors, state);
 
-        if (init_xml_attribute(attribute, errors, base_dir)) {
+        if (init_xml_attribute(attribute, errors, state)) {
         }
         else if (is_icon_value || is_trail_value) {
         }
@@ -33,23 +33,23 @@ void Category::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* erro
     }
 }
 
-bool Category::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, string base_dir) {
+bool Category::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, XMLParseState* state) {
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     if (attributename == "defaulttoggle") {
-        xml_attribute_to_bool(attribute, errors, &(this->default_visibility), &(this->default_visibility_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->default_visibility), &(this->default_visibility_is_set));
     }
     else if (attributename == "displayname") {
-        xml_attribute_to_string(attribute, errors, &(this->display_name), &(this->display_name_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->display_name), &(this->display_name_is_set));
     }
     else if (attributename == "isseparator") {
-        xml_attribute_to_bool(attribute, errors, &(this->is_separator), &(this->is_separator_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->is_separator), &(this->is_separator_is_set));
     }
     else if (attributename == "name") {
-        xml_attribute_to_string(attribute, errors, &(this->name), &(this->name_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->name), &(this->name_is_set));
     }
     else if (attributename == "tipdescription") {
-        xml_attribute_to_string(attribute, errors, &(this->tooltip_description), &(this->tooltip_description_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->tooltip_description), &(this->tooltip_description_is_set));
     }
     else {
         return false;

--- a/xml_converter/src/category_gen.hpp
+++ b/xml_converter/src/category_gen.hpp
@@ -8,6 +8,7 @@
 #include "icon_gen.hpp"
 #include "parseable.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
+#include "state_structs/xml_parse_state.hpp"
 #include "trail_gen.hpp"
 #include "waypoint.pb.h"
 
@@ -29,10 +30,10 @@ class Category : public Parseable {
     Icon default_icon;
     Trail default_trail;
 
-    void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
+    void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLParseState* state);
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
-    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
+    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLParseState* state);
     waypoint::Category as_protobuf() const;
     void parse_protobuf(waypoint::Category proto_category);
 };

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -19,224 +19,224 @@ string Icon::classname() {
     return "POI";
 }
 
-bool Icon::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, string base_dir) {
+bool Icon::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, XMLParseState* state) {
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     if (attributename == "achievementbit") {
-        xml_attribute_to_int(attribute, errors, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
     }
     else if (attributename == "achievementid") {
-        xml_attribute_to_int(attribute, errors, &(this->achievement_id), &(this->achievement_id_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->achievement_id), &(this->achievement_id_is_set));
     }
     else if (attributename == "autotrigger") {
-        xml_attribute_to_bool(attribute, errors, &(this->auto_trigger), &(this->auto_trigger_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->auto_trigger), &(this->auto_trigger_is_set));
     }
     else if (attributename == "bouncedelay") {
-        xml_attribute_to_float(attribute, errors, &(this->bounce_delay), &(this->bounce_delay_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->bounce_delay), &(this->bounce_delay_is_set));
     }
     else if (attributename == "bounceduration") {
-        xml_attribute_to_float(attribute, errors, &(this->bounce_duration), &(this->bounce_duration_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->bounce_duration), &(this->bounce_duration_is_set));
     }
     else if (attributename == "bounceheight") {
-        xml_attribute_to_float(attribute, errors, &(this->bounce_height), &(this->bounce_height_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->bounce_height), &(this->bounce_height_is_set));
     }
     else if (attributename == "type") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->category), &(this->category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->category), &(this->category_is_set));
     }
     else if (attributename == "category") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->category), &(this->category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->category), &(this->category_is_set));
     }
     else if (attributename == "color") {
-        xml_attribute_to_color(attribute, errors, &(this->color), &(this->color_is_set));
+        xml_attribute_to_color(attribute, errors, state, &(this->color), &(this->color_is_set));
     }
     else if (attributename == "bhcolor") {
-        xml_attribute_to_color(attribute, errors, &(this->color), &(this->color_is_set));
+        xml_attribute_to_color(attribute, errors, state, &(this->color), &(this->color_is_set));
     }
     else if (attributename == "alpha") {
-        xml_attribute_to_float(attribute, errors, &(this->color.alpha), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.alpha), &(this->color_is_set));
     }
     else if (attributename == "blue") {
-        xml_attribute_to_float(attribute, errors, &(this->color.blue), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.blue), &(this->color_is_set));
     }
     else if (attributename == "green") {
-        xml_attribute_to_float(attribute, errors, &(this->color.green), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.green), &(this->color_is_set));
     }
     else if (attributename == "red") {
-        xml_attribute_to_float(attribute, errors, &(this->color.red), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.red), &(this->color_is_set));
     }
     else if (attributename == "copy") {
-        xml_attribute_to_string(attribute, errors, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
     }
     else if (attributename == "copyclipboard") {
-        xml_attribute_to_string(attribute, errors, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
     }
     else if (attributename == "copymessage") {
-        xml_attribute_to_string(attribute, errors, &(this->copy_message), &(this->copy_message_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->copy_message), &(this->copy_message_is_set));
     }
     else if (attributename == "cull") {
-        xml_attribute_to_cull_chirality(attribute, errors, &(this->cull_chirality), &(this->cull_chirality_is_set));
+        xml_attribute_to_cull_chirality(attribute, errors, state, &(this->cull_chirality), &(this->cull_chirality_is_set));
     }
     else if (attributename == "canfade") {
-        inverted_xml_attribute_to_bool(attribute, errors, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
+        inverted_xml_attribute_to_bool(attribute, errors, state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
     }
     else if (attributename == "fadefar") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     else if (attributename == "distancefadeend") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     else if (attributename == "fadenear") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     else if (attributename == "distancefadestart") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     else if (attributename == "rotate") {
-        xml_attribute_to_euler_rotation(attribute, errors, &(this->euler_rotation), &(this->euler_rotation_is_set));
+        xml_attribute_to_euler_rotation(attribute, errors, state, &(this->euler_rotation), &(this->euler_rotation_is_set));
     }
     else if (attributename == "rotatex") {
-        xml_attribute_to_float(attribute, errors, &(this->euler_rotation.x_rotation), &(this->euler_rotation_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->euler_rotation.x_rotation), &(this->euler_rotation_is_set));
     }
     else if (attributename == "rotatey") {
-        xml_attribute_to_float(attribute, errors, &(this->euler_rotation.y_rotation), &(this->euler_rotation_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->euler_rotation.y_rotation), &(this->euler_rotation_is_set));
     }
     else if (attributename == "rotatez") {
-        xml_attribute_to_float(attribute, errors, &(this->euler_rotation.z_rotation), &(this->euler_rotation_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->euler_rotation.z_rotation), &(this->euler_rotation_is_set));
     }
     else if (attributename == "festival") {
-        xml_attribute_to_festival_filter(attribute, errors, &(this->festival_filter), &(this->festival_filter_is_set));
+        xml_attribute_to_festival_filter(attribute, errors, state, &(this->festival_filter), &(this->festival_filter_is_set));
     }
     else if (attributename == "guid") {
-        xml_attribute_to_unique_id(attribute, errors, &(this->guid), &(this->guid_is_set));
+        xml_attribute_to_unique_id(attribute, errors, state, &(this->guid), &(this->guid_is_set));
     }
     else if (attributename == "hascountdown") {
-        xml_attribute_to_bool(attribute, errors, &(this->has_countdown), &(this->has_countdown_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->has_countdown), &(this->has_countdown_is_set));
     }
     else if (attributename == "heightoffset") {
-        xml_attribute_to_float(attribute, errors, &(this->height_offset), &(this->height_offset_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->height_offset), &(this->height_offset_is_set));
     }
     else if (attributename == "bhheightoffset") {
-        xml_attribute_to_float(attribute, errors, &(this->height_offset), &(this->height_offset_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->height_offset), &(this->height_offset_is_set));
     }
     else if (attributename == "hide") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->hide_category), &(this->hide_category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->hide_category), &(this->hide_category_is_set));
     }
     else if (attributename == "iconfile") {
-        xml_attribute_to_image(attribute, errors, &(this->icon), &(this->icon_is_set));
+        xml_attribute_to_image(attribute, errors, state, &(this->icon), &(this->icon_is_set));
     }
     else if (attributename == "iconsize") {
-        xml_attribute_to_float(attribute, errors, &(this->icon_size), &(this->icon_size_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->icon_size), &(this->icon_size_is_set));
     }
     else if (attributename == "info") {
-        xml_attribute_to_string(attribute, errors, &(this->info_message), &(this->info_message_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->info_message), &(this->info_message_is_set));
     }
     else if (attributename == "invertbehavior") {
-        xml_attribute_to_bool(attribute, errors, &(this->invert_visibility), &(this->invert_visibility_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->invert_visibility), &(this->invert_visibility_is_set));
     }
     else if (attributename == "mapdisplaysize") {
-        xml_attribute_to_int(attribute, errors, &(this->map_display_size), &(this->map_display_size_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->map_display_size), &(this->map_display_size_is_set));
     }
     else if (attributename == "mapid") {
-        xml_attribute_to_int(attribute, errors, &(this->map_id), &(this->map_id_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->map_id), &(this->map_id_is_set));
     }
     else if (attributename == "maptype") {
-        xml_attribute_to_map_type_filter(attribute, errors, &(this->map_type_filter), &(this->map_type_filter_is_set));
+        xml_attribute_to_map_type_filter(attribute, errors, state, &(this->map_type_filter), &(this->map_type_filter_is_set));
     }
     else if (attributename == "maxsize") {
-        xml_attribute_to_int(attribute, errors, &(this->maximum_size_on_screen), &(this->maximum_size_on_screen_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->maximum_size_on_screen), &(this->maximum_size_on_screen_is_set));
     }
     else if (attributename == "minsize") {
-        xml_attribute_to_int(attribute, errors, &(this->minimum_size_on_screen), &(this->minimum_size_on_screen_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->minimum_size_on_screen), &(this->minimum_size_on_screen_is_set));
     }
     else if (attributename == "mount") {
-        xml_attribute_to_mount_filter(attribute, errors, &(this->mount_filter), &(this->mount_filter_is_set));
+        xml_attribute_to_mount_filter(attribute, errors, state, &(this->mount_filter), &(this->mount_filter_is_set));
     }
     else if (attributename == "position") {
-        xml_attribute_to_position(attribute, errors, &(this->position), &(this->position_is_set));
+        xml_attribute_to_position(attribute, errors, state, &(this->position), &(this->position_is_set));
     }
     else if (attributename == "xpos") {
-        xml_attribute_to_float(attribute, errors, &(this->position.x_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.x_position), &(this->position_is_set));
     }
     else if (attributename == "positionx") {
-        xml_attribute_to_float(attribute, errors, &(this->position.x_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.x_position), &(this->position_is_set));
     }
     else if (attributename == "ypos") {
-        xml_attribute_to_float(attribute, errors, &(this->position.y_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.y_position), &(this->position_is_set));
     }
     else if (attributename == "positiony") {
-        xml_attribute_to_float(attribute, errors, &(this->position.y_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.y_position), &(this->position_is_set));
     }
     else if (attributename == "zpos") {
-        xml_attribute_to_float(attribute, errors, &(this->position.z_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.z_position), &(this->position_is_set));
     }
     else if (attributename == "positionz") {
-        xml_attribute_to_float(attribute, errors, &(this->position.z_position), &(this->position_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->position.z_position), &(this->position_is_set));
     }
     else if (attributename == "profession") {
-        xml_attribute_to_profession_filter(attribute, errors, &(this->profession_filter), &(this->profession_filter_is_set));
+        xml_attribute_to_profession_filter(attribute, errors, state, &(this->profession_filter), &(this->profession_filter_is_set));
     }
     else if (attributename == "ingamevisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_ingame), &(this->render_ingame_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     else if (attributename == "bhingamevisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_ingame), &(this->render_ingame_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     else if (attributename == "mapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_map), &(this->render_on_map_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     else if (attributename == "bhmapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_map), &(this->render_on_map_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     else if (attributename == "minimapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     else if (attributename == "bhminimapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     else if (attributename == "behavior") {
-        xml_attribute_to_reset_behavior(attribute, errors, &(this->reset_behavior), &(this->reset_behavior_is_set));
+        xml_attribute_to_reset_behavior(attribute, errors, state, &(this->reset_behavior), &(this->reset_behavior_is_set));
     }
     else if (attributename == "resetlength") {
-        xml_attribute_to_float(attribute, errors, &(this->reset_length), &(this->reset_length_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->reset_length), &(this->reset_length_is_set));
     }
     else if (attributename == "scaleonmapwithzoom") {
-        xml_attribute_to_bool(attribute, errors, &(this->scale_on_map_with_zoom), &(this->scale_on_map_with_zoom_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->scale_on_map_with_zoom), &(this->scale_on_map_with_zoom_is_set));
     }
     else if (attributename == "schedule") {
-        xml_attribute_to_string(attribute, errors, &(this->schedule), &(this->schedule_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->schedule), &(this->schedule_is_set));
     }
     else if (attributename == "scheduleduration") {
-        xml_attribute_to_float(attribute, errors, &(this->schedule_duration), &(this->schedule_duration_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->schedule_duration), &(this->schedule_duration_is_set));
     }
     else if (attributename == "show") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->show_category), &(this->show_category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->show_category), &(this->show_category_is_set));
     }
     else if (attributename == "specialization") {
-        xml_attribute_to_specialization_filter(attribute, errors, &(this->specialization_filter), &(this->specialization_filter_is_set));
+        xml_attribute_to_specialization_filter(attribute, errors, state, &(this->specialization_filter), &(this->specialization_filter_is_set));
     }
     else if (attributename == "race") {
-        xml_attribute_to_species_filter(attribute, errors, &(this->species_filter), &(this->species_filter_is_set));
+        xml_attribute_to_species_filter(attribute, errors, state, &(this->species_filter), &(this->species_filter_is_set));
     }
     else if (attributename == "species") {
-        xml_attribute_to_species_filter(attribute, errors, &(this->species_filter), &(this->species_filter_is_set));
+        xml_attribute_to_species_filter(attribute, errors, state, &(this->species_filter), &(this->species_filter_is_set));
     }
     else if (attributename == "toggle") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->toggle_category), &(this->toggle_category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->toggle_category), &(this->toggle_category_is_set));
     }
     else if (attributename == "togglecategory") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->toggle_category), &(this->toggle_category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->toggle_category), &(this->toggle_category_is_set));
     }
     else if (attributename == "tipdescription") {
-        xml_attribute_to_string(attribute, errors, &(this->tooltip_description), &(this->tooltip_description_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->tooltip_description), &(this->tooltip_description_is_set));
     }
     else if (attributename == "tipname") {
-        xml_attribute_to_string(attribute, errors, &(this->tooltip_name), &(this->tooltip_name_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->tooltip_name), &(this->tooltip_name_is_set));
     }
     else if (attributename == "triggerrange") {
-        xml_attribute_to_float(attribute, errors, &(this->trigger_range), &(this->trigger_range_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->trigger_range), &(this->trigger_range_is_set));
     }
     else if (attributename == "inforange") {
-        xml_attribute_to_float(attribute, errors, &(this->trigger_range), &(this->trigger_range_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->trigger_range), &(this->trigger_range_is_set));
     }
     else {
         return false;

--- a/xml_converter/src/icon_gen.hpp
+++ b/xml_converter/src/icon_gen.hpp
@@ -20,6 +20,7 @@
 #include "attribute/unique_id.hpp"
 #include "parseable.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
+#include "state_structs/xml_parse_state.hpp"
 #include "waypoint.pb.h"
 
 class XMLError;
@@ -122,7 +123,7 @@ class Icon : public Parseable {
     bool trigger_range_is_set = false;
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
-    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
+    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLParseState* state);
     waypoint::Icon as_protobuf() const;
     void parse_protobuf(waypoint::Icon proto_icon);
     bool validate_attributes_of_type_marker_category();

--- a/xml_converter/src/packaging_xml.cpp
+++ b/xml_converter/src/packaging_xml.cpp
@@ -7,7 +7,6 @@
 #include "rapidxml-1.13/rapidxml_utils.hpp"
 #include "string_helper.hpp"
 
-
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/xml_converter/src/packaging_xml.hpp
+++ b/xml_converter/src/packaging_xml.hpp
@@ -8,6 +8,7 @@
 #include "parseable.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
 #include "rapidxml-1.13/rapidxml_utils.hpp"
+#include "state_structs/xml_parse_state.hpp"
 
 void parse_xml_file(
     std::string xml_filepath,

--- a/xml_converter/src/parseable.cpp
+++ b/xml_converter/src/parseable.cpp
@@ -11,9 +11,9 @@ std::string Parseable::classname() {
     return "Parseable";
 }
 
-void Parseable::init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir) {
+void Parseable::init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLParseState* state) {
     for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
-        if (init_xml_attribute(attribute, errors, base_dir)) {
+        if (init_xml_attribute(attribute, errors, state)) {
         }
         else {
             errors->push_back(new XMLAttributeNameError("Unknown " + this->classname() + " attribute ", attribute));
@@ -28,7 +28,7 @@ void Parseable::init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>
 // all of the other parsible classes. So just return false right away without
 // doing anything.
 ////////////////////////////////////////////////////////////////////////////////
-bool Parseable::init_xml_attribute(rapidxml::xml_attribute<>*, std::vector<XMLError*>*, std::string) {
+bool Parseable::init_xml_attribute(rapidxml::xml_attribute<>*, std::vector<XMLError*>*, XMLParseState*) {
     return false;
 }
 

--- a/xml_converter/src/parseable.hpp
+++ b/xml_converter/src/parseable.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 
 #include "rapidxml-1.13/rapidxml.hpp"
+#include "state_structs/xml_parse_state.hpp"
+
 class XMLError;
 
 class Parseable {
@@ -12,10 +14,10 @@ class Parseable {
     virtual std::string classname();
 
     // A default parser function to parse an entire XML node into the class.
-    void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, std::string base_dir = "");
+    void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLParseState* state);
 
     // A default parser function to parse a single XML attribute into the class.
-    virtual bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
+    virtual bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLParseState*);
 
     virtual std::vector<std::string> as_xml() const;
 };

--- a/xml_converter/src/state_structs/xml_parse_state.hpp
+++ b/xml_converter/src/state_structs/xml_parse_state.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+class Category;
+
+struct XMLParseState {
+    std::string xml_filedir;
+    std::map<std::string, Category>* marker_categories;
+};

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -19,128 +19,128 @@ string Trail::classname() {
     return "Trail";
 }
 
-bool Trail::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, string base_dir) {
+bool Trail::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLError*>* errors, XMLParseState* state) {
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     if (attributename == "achievementbit") {
-        xml_attribute_to_int(attribute, errors, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
     }
     else if (attributename == "achievementid") {
-        xml_attribute_to_int(attribute, errors, &(this->achievement_id), &(this->achievement_id_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->achievement_id), &(this->achievement_id_is_set));
     }
     else if (attributename == "animspeed") {
-        xml_attribute_to_float(attribute, errors, &(this->animation_speed), &(this->animation_speed_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->animation_speed), &(this->animation_speed_is_set));
     }
     else if (attributename == "animationspeed") {
-        xml_attribute_to_float(attribute, errors, &(this->animation_speed), &(this->animation_speed_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->animation_speed), &(this->animation_speed_is_set));
     }
     else if (attributename == "type") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->category), &(this->category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->category), &(this->category_is_set));
     }
     else if (attributename == "category") {
-        xml_attribute_to_marker_category(attribute, errors, &(this->category), &(this->category_is_set));
+        xml_attribute_to_marker_category(attribute, errors, state, &(this->category), &(this->category_is_set));
     }
     else if (attributename == "color") {
-        xml_attribute_to_color(attribute, errors, &(this->color), &(this->color_is_set));
+        xml_attribute_to_color(attribute, errors, state, &(this->color), &(this->color_is_set));
     }
     else if (attributename == "bhcolor") {
-        xml_attribute_to_color(attribute, errors, &(this->color), &(this->color_is_set));
+        xml_attribute_to_color(attribute, errors, state, &(this->color), &(this->color_is_set));
     }
     else if (attributename == "alpha") {
-        xml_attribute_to_float(attribute, errors, &(this->color.alpha), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.alpha), &(this->color_is_set));
     }
     else if (attributename == "blue") {
-        xml_attribute_to_float(attribute, errors, &(this->color.blue), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.blue), &(this->color_is_set));
     }
     else if (attributename == "green") {
-        xml_attribute_to_float(attribute, errors, &(this->color.green), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.green), &(this->color_is_set));
     }
     else if (attributename == "red") {
-        xml_attribute_to_float(attribute, errors, &(this->color.red), &(this->color_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->color.red), &(this->color_is_set));
     }
     else if (attributename == "cull") {
-        xml_attribute_to_cull_chirality(attribute, errors, &(this->cull_chirality), &(this->cull_chirality_is_set));
+        xml_attribute_to_cull_chirality(attribute, errors, state, &(this->cull_chirality), &(this->cull_chirality_is_set));
     }
     else if (attributename == "canfade") {
-        inverted_xml_attribute_to_bool(attribute, errors, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
+        inverted_xml_attribute_to_bool(attribute, errors, state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
     }
     else if (attributename == "fadefar") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     else if (attributename == "distancefadeend") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     else if (attributename == "fadenear") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     else if (attributename == "distancefadestart") {
-        xml_attribute_to_float(attribute, errors, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     else if (attributename == "festival") {
-        xml_attribute_to_festival_filter(attribute, errors, &(this->festival_filter), &(this->festival_filter_is_set));
+        xml_attribute_to_festival_filter(attribute, errors, state, &(this->festival_filter), &(this->festival_filter_is_set));
     }
     else if (attributename == "guid") {
-        xml_attribute_to_unique_id(attribute, errors, &(this->guid), &(this->guid_is_set));
+        xml_attribute_to_unique_id(attribute, errors, state, &(this->guid), &(this->guid_is_set));
     }
     else if (attributename == "iswall") {
-        xml_attribute_to_bool(attribute, errors, &(this->is_wall), &(this->is_wall_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->is_wall), &(this->is_wall_is_set));
     }
     else if (attributename == "mapdisplaysize") {
-        xml_attribute_to_int(attribute, errors, &(this->map_display_size), &(this->map_display_size_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->map_display_size), &(this->map_display_size_is_set));
     }
     else if (attributename == "mapid") {
-        xml_attribute_to_int(attribute, errors, &(this->map_id), &(this->map_id_is_set));
+        xml_attribute_to_int(attribute, errors, state, &(this->map_id), &(this->map_id_is_set));
     }
     else if (attributename == "maptype") {
-        xml_attribute_to_map_type_filter(attribute, errors, &(this->map_type_filter), &(this->map_type_filter_is_set));
+        xml_attribute_to_map_type_filter(attribute, errors, state, &(this->map_type_filter), &(this->map_type_filter_is_set));
     }
     else if (attributename == "mount") {
-        xml_attribute_to_mount_filter(attribute, errors, &(this->mount_filter), &(this->mount_filter_is_set));
+        xml_attribute_to_mount_filter(attribute, errors, state, &(this->mount_filter), &(this->mount_filter_is_set));
     }
     else if (attributename == "profession") {
-        xml_attribute_to_profession_filter(attribute, errors, &(this->profession_filter), &(this->profession_filter_is_set));
+        xml_attribute_to_profession_filter(attribute, errors, state, &(this->profession_filter), &(this->profession_filter_is_set));
     }
     else if (attributename == "ingamevisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_ingame), &(this->render_ingame_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     else if (attributename == "bhingamevisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_ingame), &(this->render_ingame_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     else if (attributename == "mapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_map), &(this->render_on_map_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     else if (attributename == "bhmapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_map), &(this->render_on_map_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     else if (attributename == "minimapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     else if (attributename == "bhminimapvisibility") {
-        xml_attribute_to_bool(attribute, errors, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        xml_attribute_to_bool(attribute, errors, state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     else if (attributename == "schedule") {
-        xml_attribute_to_string(attribute, errors, &(this->schedule), &(this->schedule_is_set));
+        xml_attribute_to_string(attribute, errors, state, &(this->schedule), &(this->schedule_is_set));
     }
     else if (attributename == "scheduleduration") {
-        xml_attribute_to_float(attribute, errors, &(this->schedule_duration), &(this->schedule_duration_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->schedule_duration), &(this->schedule_duration_is_set));
     }
     else if (attributename == "specialization") {
-        xml_attribute_to_specialization_filter(attribute, errors, &(this->specialization_filter), &(this->specialization_filter_is_set));
+        xml_attribute_to_specialization_filter(attribute, errors, state, &(this->specialization_filter), &(this->specialization_filter_is_set));
     }
     else if (attributename == "race") {
-        xml_attribute_to_species_filter(attribute, errors, &(this->species_filter), &(this->species_filter_is_set));
+        xml_attribute_to_species_filter(attribute, errors, state, &(this->species_filter), &(this->species_filter_is_set));
     }
     else if (attributename == "species") {
-        xml_attribute_to_species_filter(attribute, errors, &(this->species_filter), &(this->species_filter_is_set));
+        xml_attribute_to_species_filter(attribute, errors, state, &(this->species_filter), &(this->species_filter_is_set));
     }
     else if (attributename == "texture") {
-        xml_attribute_to_image(attribute, errors, &(this->texture), &(this->texture_is_set));
+        xml_attribute_to_image(attribute, errors, state, &(this->texture), &(this->texture_is_set));
     }
     else if (attributename == "traildata") {
-        xml_attribute_to_trail_data(attribute, errors, base_dir, &(this->trail_data), &(this->trail_data_is_set), &(this->map_id), &(this->map_id_is_set));
+        xml_attribute_to_trail_data(attribute, errors, state, &(this->trail_data), &(this->trail_data_is_set), &(this->map_id), &(this->map_id_is_set));
     }
     else if (attributename == "trailscale") {
-        xml_attribute_to_float(attribute, errors, &(this->trail_scale), &(this->trail_scale_is_set));
+        xml_attribute_to_float(attribute, errors, state, &(this->trail_scale), &(this->trail_scale_is_set));
     }
     else {
         return false;

--- a/xml_converter/src/trail_gen.hpp
+++ b/xml_converter/src/trail_gen.hpp
@@ -18,6 +18,7 @@
 #include "attribute/unique_id.hpp"
 #include "parseable.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
+#include "state_structs/xml_parse_state.hpp"
 #include "waypoint.pb.h"
 
 class XMLError;
@@ -80,7 +81,7 @@ class Trail : public Parseable {
     bool trail_scale_is_set = false;
     virtual std::vector<std::string> as_xml() const;
     virtual std::string classname();
-    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, std::string base_dir = "");
+    bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLParseState* state);
     waypoint::Trail as_protobuf() const;
     void parse_protobuf(waypoint::Trail proto_trail);
     bool validate_attributes_of_type_marker_category();


### PR DESCRIPTION
This will make some of the crazier parsers possible in the long term, such as string indexes, category uids, and file copying. In the short term it maintains functionality with filepaths and allows us to do validation on category names like we have not yet been able to do.