### PR TITLE
Dynamic icon positon depending on ui-scale

### DIFF
--- a/Spatial.gd
+++ b/Spatial.gd
@@ -51,10 +51,10 @@ var is_transient:bool = false
 # The ui-size as read from the link can have the values [0=small; 1=normal; 2=large; 3=larger]
 var ui_size = 1
 # This array holds the width of one item for every ui-scale
-var icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
+const icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
 # The position indicates how many buttons will be there.
 # e.g. if the native ui has 10 buttons we want to be on position 11.
-var button_position = 11 # Place the icon/button on n..th position
+const button_position = 11 # Place the icon/button on n..th position
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -48,6 +48,8 @@ var x11_window_id_burrito: int
 var is_transient:bool = false
 
 # Variables that store informations about ui scaling
+# The ui-size as read from the link can have the values [0=small; 1=normal; 2=large; 3=larger]
+var ui_size = 1
 # This array holds the width of one item for every ui-scale
 var icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
 # The position indicates how many buttons will be there.
@@ -330,9 +332,15 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
 	# TODO: Check if the calculated position is inside the window.
-	if $Control/GlobalMenuButton.margin_left != icon_size_preset[identity["uisz"]] * button_position:
-		$Control/GlobalMenuButton.margin_left = icon_size_preset[identity["uisz"]] * button_position
-		$Control/GlobalMenuButton.margin_right = (icon_size_preset[identity["uisz"]] * (button_position + 1))
+
+	ui_size = identity["uisz"]
+	# If the value is outside of the expected range use the "normal" size.
+	if (ui_size < 0) or (ui_size > 3):
+		ui_size = 1
+
+	if $Control/GlobalMenuButton.margin_left != icon_size_preset[ui_size] * button_position:
+		$Control/GlobalMenuButton.margin_left = icon_size_preset[ui_size] * button_position
+		$Control/GlobalMenuButton.margin_right = (icon_size_preset[ui_size] * (button_position + 1))
 		set_minimal_mouse_block()
 
 	if self.map_id != old_map_id:

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -51,7 +51,7 @@ var is_transient:bool = false
 # The ui-size as read from the link can have the values [0=small; 1=normal; 2=large; 3=larger]
 var ui_size: int = 1
 # This array holds the width of one item for every ui-scale
-const icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
+const icon_size_preset = {0: 26.5, 1: 29.5, 2: 33.0, 3: 36.0} # 0=small; 1=normal; 2=large; 3=larger
 # The position indicates how many buttons will be there.
 # e.g. if the native ui has 10 buttons we want to be on position 11.
 const button_position = 11 # Place the icon/button on n..th position
@@ -331,8 +331,8 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# Calculations to dynamically place the main icon/button
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	self.ui_size = int(identity["uisz"])
-	# If the value is outside of the expected range use the "normal" size.
-	if (self.ui_size < 0) or (self.ui_size > 3):
+	# If the value is not part of the dictionary use the "normal" size.
+	if !self.icon_size_preset.has(self.ui_size):
 		self.ui_size = 1
 
 	var button_position_max = floor(OS.window_size.x / self.icon_size_preset[self.ui_size]) - 1

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -337,11 +337,13 @@ func decode_context_packet(spb: StreamPeerBuffer):
 		ui_size = 1
 
 	var button_position_max = floor(OS.window_size.x / icon_size_preset[ui_size]) - 1
+	var button_margin_left = $Control/GlobalMenuButton.margin_left
 	# Make sure the expected position is inside the window.
 	if (button_position > button_position_max):
-		button_position = button_position_max
+		button_margin_left = icon_size_preset[ui_size] * button_position_max
+	else:
+		button_margin_left = icon_size_preset[ui_size] * button_position
 
-	var button_margin_left = icon_size_preset[ui_size] * button_position
 	if $Control/GlobalMenuButton.margin_left != button_margin_left:
 		$Control/GlobalMenuButton.margin_left = button_margin_left
 		$Control/GlobalMenuButton.margin_right = button_margin_left + icon_size_preset[ui_size]

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -48,8 +48,11 @@ var x11_window_id_burrito: int
 var is_transient:bool = false
 
 # Variables that store informations about ui scaling
+# This array holds the width of one menue item for every ui-scale
 var icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
-var button_position = 11 # Place the main menue button on 11th position
+# The position indicates how many buttons will be there.
+# e.g. if the native ui has 10 buttons we want to be on position 11.
+var button_position = 11 # Place the main menue button on n..th position
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -324,8 +327,9 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# this to just be a radian to degree conversion.
 
 	# Calculations to dynamically place the main menue button
-	# First we will calculate how much space every button needs depending on the actual ui scale.
-	# Then we can calculate how many buttons could fit on the screen and place our button at given position.
+	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
+	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
+	# TODO: Check if the calculated position is inside the window.
 	if $Control/GlobalMenuButton.margin_left != icon_size_preset[identity["uisz"]] * button_position:
 		$Control/GlobalMenuButton.margin_left = icon_size_preset[identity["uisz"]] * button_position
 		$Control/GlobalMenuButton.margin_right = (icon_size_preset[identity["uisz"]] * (button_position + 1))

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -50,11 +50,13 @@ var is_transient:bool = false
 # Variables that store informations about ui scaling
 # The ui-size as read from the link can have the values [0=small; 1=normal; 2=large; 3=larger]
 var ui_size: int = 1
-# This array holds the width of one item for every ui-scale
-const icon_size_preset = {0: 26.5, 1: 29.5, 2: 33.0, 3: 36.0} # 0=small; 1=normal; 2=large; 3=larger
-# The position indicates how many buttons will be there.
-# e.g. if the native ui has 10 buttons we want to be on position 11.
-const button_position = 11 # Place the icon/button on n..th position
+# This dictionary holds the left and right margin for the main button for every ui-scale
+const button_margin = {
+	0: {"left": 292, "right": 318}, # small
+	1: {"left": 323, "right": 352}, # normal
+	2: {"left": 361, "right": 394}, # large
+	3: {"left": 395, "right": 431}  # larger
+}
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -329,15 +331,13 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# this to just be a radian to degree conversion.
 
 	# Calculations to dynamically place the main icon/button
-	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	self.ui_size = int(identity["uisz"])
 	# If the value is not part of the dictionary use the "normal" size.
-	if !self.icon_size_preset.has(self.ui_size):
+	if !self.button_margin.has(self.ui_size):
 		self.ui_size = 1
 
-	var button_margin_left = self.icon_size_preset[self.ui_size] * self.button_position
-	$Control/GlobalMenuButton.margin_left = button_margin_left
-	$Control/GlobalMenuButton.margin_right = button_margin_left + self.icon_size_preset[self.ui_size]
+	$Control/GlobalMenuButton.margin_left = self.button_margin[self.ui_size]["left"]
+	$Control/GlobalMenuButton.margin_right = self.button_margin[self.ui_size]["right"]
 	if !is_any_dialog_visible():
 		set_minimal_mouse_block()
 

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -330,7 +330,6 @@ func decode_context_packet(spb: StreamPeerBuffer):
 
 	# Calculations to dynamically place the main icon/button
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
-	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
 	self.ui_size = int(identity["uisz"])
 	# If the value is outside of the expected range use the "normal" size.
 	if (self.ui_size < 0) or (self.ui_size > 3):
@@ -344,9 +343,9 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	else:
 		button_margin_left = self.icon_size_preset[self.ui_size] * self.button_position
 
-	if $Control/GlobalMenuButton.margin_left != button_margin_left:
-		$Control/GlobalMenuButton.margin_left = button_margin_left
-		$Control/GlobalMenuButton.margin_right = button_margin_left + self.icon_size_preset[self.ui_size]
+	$Control/GlobalMenuButton.margin_left = button_margin_left
+	$Control/GlobalMenuButton.margin_right = button_margin_left + self.icon_size_preset[self.ui_size]
+	if !is_any_dialog_visible():
 		set_minimal_mouse_block()
 
 	if self.map_id != old_map_id:
@@ -712,11 +711,16 @@ func clear_adjustment_nodes():
 		child.queue_free()
 
 
-func _on_Dialog_hide():
+func is_any_dialog_visible():
 	for dialog in $Control/Dialogs.get_children():
 		if dialog.visible:
-			return
-	set_minimal_mouse_block()
+			return true
+	return false
+
+
+func _on_Dialog_hide():
+	if !is_any_dialog_visible():
+		set_minimal_mouse_block()
 
 
 func _on_LoadPath_pressed():

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -331,16 +331,20 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# Calculations to dynamically place the main icon/button
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
-	# TODO: Check if the calculated position is inside the window.
-
 	ui_size = identity["uisz"]
 	# If the value is outside of the expected range use the "normal" size.
 	if (ui_size < 0) or (ui_size > 3):
 		ui_size = 1
 
-	if $Control/GlobalMenuButton.margin_left != icon_size_preset[ui_size] * button_position:
-		$Control/GlobalMenuButton.margin_left = icon_size_preset[ui_size] * button_position
-		$Control/GlobalMenuButton.margin_right = (icon_size_preset[ui_size] * (button_position + 1))
+	var button_position_max = floor(OS.window_size.x / icon_size_preset[ui_size]) - 1
+	# Make sure the expected position is inside the window.
+	if (button_position > button_position_max):
+		button_position = button_position_max
+
+	var button_margin_left = icon_size_preset[ui_size] * button_position
+	if $Control/GlobalMenuButton.margin_left != button_margin_left:
+		$Control/GlobalMenuButton.margin_left = button_margin_left
+		$Control/GlobalMenuButton.margin_right = button_margin_left + icon_size_preset[ui_size]
 		set_minimal_mouse_block()
 
 	if self.map_id != old_map_id:

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -49,7 +49,7 @@ var is_transient:bool = false
 
 # Variables that store informations about ui scaling
 # The ui-size as read from the link can have the values [0=small; 1=normal; 2=large; 3=larger]
-var ui_size = 1
+var ui_size: int = 1
 # This array holds the width of one item for every ui-scale
 const icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
 # The position indicates how many buttons will be there.
@@ -331,22 +331,22 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# Calculations to dynamically place the main icon/button
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
-	ui_size = identity["uisz"]
+	self.ui_size = int(identity["uisz"])
 	# If the value is outside of the expected range use the "normal" size.
-	if (ui_size < 0) or (ui_size > 3):
-		ui_size = 1
+	if (self.ui_size < 0) or (self.ui_size > 3):
+		self.ui_size = 1
 
-	var button_position_max = floor(OS.window_size.x / icon_size_preset[ui_size]) - 1
+	var button_position_max = floor(OS.window_size.x / self.icon_size_preset[self.ui_size]) - 1
 	var button_margin_left = $Control/GlobalMenuButton.margin_left
 	# Make sure the expected position is inside the window.
-	if (button_position > button_position_max):
-		button_margin_left = icon_size_preset[ui_size] * button_position_max
+	if (self.button_position > button_position_max):
+		button_margin_left = self.icon_size_preset[self.ui_size] * button_position_max
 	else:
-		button_margin_left = icon_size_preset[ui_size] * button_position
+		button_margin_left = self.icon_size_preset[self.ui_size] * self.button_position
 
 	if $Control/GlobalMenuButton.margin_left != button_margin_left:
 		$Control/GlobalMenuButton.margin_left = button_margin_left
-		$Control/GlobalMenuButton.margin_right = button_margin_left + icon_size_preset[ui_size]
+		$Control/GlobalMenuButton.margin_right = button_margin_left + self.icon_size_preset[self.ui_size]
 		set_minimal_mouse_block()
 
 	if self.map_id != old_map_id:

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -47,6 +47,10 @@ var taco_parser: TacoParser
 var x11_window_id_burrito: int
 var is_transient:bool = false
 
+# Variables that store informations about ui scaling
+var icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
+var button_position = 11 # Place the main menue button on 11th position
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	get_tree().get_root().set_transparent_background(true)
@@ -318,6 +322,14 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# TODO: after looking back at this it has become obvious this is just degrees
 	# vs radians. 70deg = 1.22173rad and 25deg = 0.4363323rad. We should redo
 	# this to just be a radian to degree conversion.
+
+	# Calculations to dynamically place the main menue button
+	# First we will calculate how much space every button needs depending on the actual ui scale.
+	# Then we can calculate how many buttons could fit on the screen and place our button at given position.
+	if $Control/GlobalMenuButton.margin_left != icon_size_preset[identity["uisz"]] * button_position:
+		$Control/GlobalMenuButton.margin_left = icon_size_preset[identity["uisz"]] * button_position
+		$Control/GlobalMenuButton.margin_right = (icon_size_preset[identity["uisz"]] * (button_position + 1))
+		set_minimal_mouse_block()
 
 	if self.map_id != old_map_id:
 		print("New Map")

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -48,11 +48,11 @@ var x11_window_id_burrito: int
 var is_transient:bool = false
 
 # Variables that store informations about ui scaling
-# This array holds the width of one menue item for every ui-scale
+# This array holds the width of one item for every ui-scale
 var icon_size_preset = [26.5, 29.5, 33.0, 36.0] # 0=small; 1=normal; 2=large; 3=larger
 # The position indicates how many buttons will be there.
 # e.g. if the native ui has 10 buttons we want to be on position 11.
-var button_position = 11 # Place the main menue button on n..th position
+var button_position = 11 # Place the icon/button on n..th position
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -326,7 +326,7 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	# vs radians. 70deg = 1.22173rad and 25deg = 0.4363323rad. We should redo
 	# this to just be a radian to degree conversion.
 
-	# Calculations to dynamically place the main menue button
+	# Calculations to dynamically place the main icon/button
 	# The left- and right-margin can be calculated from the ui-scale combined with the preset icon width and the desired position.
 	# set_minimal_mouse_block() should be called only once, if it is called while any burrito windows is open it will become unclickable.
 	# TODO: Check if the calculated position is inside the window.

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -335,14 +335,7 @@ func decode_context_packet(spb: StreamPeerBuffer):
 	if !self.icon_size_preset.has(self.ui_size):
 		self.ui_size = 1
 
-	var button_position_max = floor(OS.window_size.x / self.icon_size_preset[self.ui_size]) - 1
-	var button_margin_left = $Control/GlobalMenuButton.margin_left
-	# Make sure the expected position is inside the window.
-	if (self.button_position > button_position_max):
-		button_margin_left = self.icon_size_preset[self.ui_size] * button_position_max
-	else:
-		button_margin_left = self.icon_size_preset[self.ui_size] * self.button_position
-
+	var button_margin_left = self.icon_size_preset[self.ui_size] * self.button_position
 	$Control/GlobalMenuButton.margin_left = button_margin_left
 	$Control/GlobalMenuButton.margin_right = button_margin_left + self.icon_size_preset[self.ui_size]
 	if !is_any_dialog_visible():


### PR DESCRIPTION
This PR aims to change the position of the main button/icon according to the used ui-scale.
Nothing will be scaled or otherwise resized, all this PR does is recalculating the position.

#### What needs to happen to move the button/icon and the clickable are.
 - The left- and the right-margin must be changed. https://github.com/AsherGlick/Burrito/blob/a344bdfcfa738ca764ffe677c5f7ba10217b15db/Spatial.tscn#L74-L75
 - The function `set_minimal_mouse_block()` must be called _once_ after changing the margins. https://github.com/AsherGlick/Burrito/blob/a344bdfcfa738ca764ffe677c5f7ba10217b15db/Spatial.gd#L121

#### How to calculate the margins.
Every button has a fixed width depending on the ui-scale.
If we know the width of one button we can calculate the margin of every n..th button.
So we can preset the button width for every scale, we can also preset the desired position of our button. (e.g. if the native ui has 10 buttons we want to be on position 11.)
After reading the ui-scale from the link, it can be used to select the appropriate base width and calculate the final position.

#### Possible conflicts.
When the function `set_minimal_mouse_block()` is called, the clickable area of all open windows will be deleted.
So the user will see the windows but can no longer interact with them.
