### PR TITLE
Ensure that dir paths end in a forward slash when path is needed

### DIFF
--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -229,7 +229,7 @@ void write_protobuf_file_per_map_id(
     }
 
     for (auto iterator = mapid_to_category_to_pois.begin(); iterator != mapid_to_category_to_pois.end(); iterator++) {
-        string output_filepath = proto_directory + "/" + to_string(iterator->first) + ".data";
+        string output_filepath = proto_directory + to_string(iterator->first) + ".data";
 
         _write_protobuf_file(
             output_filepath,

--- a/xml_converter/src/string_helper.cpp
+++ b/xml_converter/src/string_helper.cpp
@@ -287,3 +287,10 @@ bool has_suffix(std::string const& fullString, std::string const& ending) {
         return false;
     }
 }
+
+void ensure_trailing_slash(std::string* directory_path) {
+    if (!has_suffix(*directory_path , "/")) {
+        *directory_path += "/";
+    }
+    return;
+}

--- a/xml_converter/src/string_helper.hpp
+++ b/xml_converter/src/string_helper.hpp
@@ -21,3 +21,4 @@ std::vector<uint8_t> base64_decode(std::string const&);
 
 std::string get_base_dir(std::string filepath);
 bool has_suffix(std::string const& fullString, std::string const& ending);
+void ensure_trailing_slash(std::string* directory_path);

--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -43,7 +43,8 @@ vector<string> get_files_by_suffix(string directory, string suffix) {
     while ((entry = readdir(dir)) != NULL) {
         string filename = entry->d_name;
         if (filename != "." && filename != "..") {
-            string path = directory + "/" + filename;
+            ensure_trailing_slash(&directory);
+            string path = directory + filename;
             if (entry->d_type == DT_DIR) {
                 vector<string> subfiles = get_files_by_suffix(path, suffix);
                 // Default: markerpacks have all xml files in the first directory
@@ -68,9 +69,9 @@ void move_supplementary_files(string input_directory, string output_directory) {
     while ((entry = readdir(dir)) != NULL) {
         string filename = entry->d_name;
         if (filename != "." && filename != "..") {
-            string path = input_directory + "/" + filename;
+            string path = input_directory + filename;
             if (entry->d_type == DT_DIR) {
-                string new_directory = output_directory + "/" + filename;
+                string new_directory = output_directory + filename;
                 if (mkdir(new_directory.c_str(), 0700) == -1 && errno != EEXIST) {
                     cout << "Error making " << new_directory << endl;
                     continue;
@@ -83,7 +84,7 @@ void move_supplementary_files(string input_directory, string output_directory) {
             else {
                 // TODO: Only include files that are referenced by the
                 // individual markers in order to avoid any unnessecary files
-                string new_path = output_directory + "/" + filename;
+                string new_path = output_directory + filename;
                 copy_file(path, new_path);
             }
         }
@@ -95,6 +96,7 @@ void read_taco_directory(string input_path, map<string, Category>* marker_catego
         cout << "Error: " << input_path << " is not an existing directory or file" << endl;
     }
     else if (filesystem::is_directory(input_path)) {
+        ensure_trailing_slash(&input_path);
         vector<string> xml_files = get_files_by_suffix(input_path, ".xml");
         for (const string& path : xml_files) {
             parse_xml_file(path, marker_categories, parsed_pois);
@@ -107,9 +109,6 @@ void read_taco_directory(string input_path, map<string, Category>* marker_catego
 
 void write_taco_directory(string output_path, map<string, Category>* marker_categories, vector<Parseable*>* parsed_pois) {
     // TODO: Exportion of XML Marker Packs File Structure #111
-    if (!has_suffix(output_path, "/")) {
-        output_path += "/";
-    }
     if (!filesystem::is_directory(output_path)) {
         if (!filesystem::create_directory(output_path)) {
             cout << "Error: " << output_path << "is not a valid directory path" << endl;
@@ -152,6 +151,8 @@ void process_data(
         // TODO: This is wildly incorrect now because we might have a
         //       different output directory then output_split_waypoint_dir
         if (output_split_waypoint_dir != "") {
+
+            ensure_trailing_slash(&output_split_waypoint_dir);
             move_supplementary_files(input_taco_paths[i], output_split_waypoint_dir);
         }
     }
@@ -172,6 +173,7 @@ void process_data(
     // Write all of the xml taco paths
     begin = chrono::high_resolution_clock::now();
     for (size_t i = 0; i < output_taco_paths.size(); i++) {
+        ensure_trailing_slash(&output_taco_paths[i]);
         write_taco_directory(output_taco_paths[i], &marker_categories, &parsed_pois);
     }
     end = chrono::high_resolution_clock::now();
@@ -181,6 +183,7 @@ void process_data(
 
     // Write all of the protobin waypoint paths
     for (size_t i = 0; i < output_waypoint_paths.size(); i++) {
+        ensure_trailing_slash(&output_waypoint_paths[i]);
         StringHierarchy category_filter;
         category_filter.add_path({}, true);
         write_protobuf_file(output_waypoint_paths[i], category_filter, &marker_categories, &parsed_pois);
@@ -189,6 +192,7 @@ void process_data(
     // Write the special map-split protbin waypoint file
     begin = chrono::high_resolution_clock::now();
     if (output_split_waypoint_dir != "") {
+        ensure_trailing_slash(&output_split_waypoint_dir);
         StringHierarchy category_filter;
         category_filter.add_path({}, true);
         write_protobuf_file_per_map_id(output_split_waypoint_dir, category_filter, &marker_categories, &parsed_pois);


### PR DESCRIPTION
This ensures that when we are given a dir file path, whether it is `a/b` or `a/b/`, we are always using the trailing backslash in the strings. 