### PR TITLE
creating the folder for the diff file

### DIFF
--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Get Filenames
       run: |
         for file in $(git diff --name-only origin/${{ github.base_ref }} refs/pull/${{ github.event.pull_request.number }}/head | grep '.bin$'); do
+          mkdir -p $(dirname "$file")
           if [ -n "$(git ls-tree "origin/${{ github.base_ref }}" -- "$file")" ]; then
             git show origin/${{ github.base_ref }}:$file > $file._old
             protoc --decode=waypoint.Waypoint xml_converter/proto/waypoint.proto < $file._old > $file.textproto._old


### PR DESCRIPTION
Now that we are running the workflow on the pr target branch and pulling the files from the pr branch, it is possible the file folder containing the files does not exist yet. This change just forces that file folder to exist so the old/new versions of the file can be written properly to it.