### PR TITLE
Making all the state variables live as long as the generator instead of the xml node

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -31,11 +31,11 @@ class {{cpp_class}} : public Parseable {
 
         void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLReaderState* state);
     {% endif %}
-    virtual std::vector<std::string> as_xml() const;
+    virtual std::vector<std::string> as_xml(XMLWriterState* state) const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState* state);
-    waypoint::{{cpp_class}} as_protobuf() const;
-    void parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}});
+    waypoint::{{cpp_class}} as_protobuf(ProtoWriterState* state) const;
+    void parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}, ProtoReaderState* state);
     {% if attributes_of_type_marker_category %}
         bool validate_attributes_of_type_marker_category();
     {% endif %}

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -57,30 +57,29 @@ bool Category::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<X
     return true;
 }
 
-vector<string> Category::as_xml() const {
-    XMLWriterState state;
+vector<string> Category::as_xml(XMLWriterState* state) const {
     vector<string> xml_node_contents;
     xml_node_contents.push_back("<MarkerCategory ");
     if (this->default_visibility_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("DefaultToggle", &state, &this->default_visibility));
+        xml_node_contents.push_back(bool_to_xml_attribute("DefaultToggle", state, &this->default_visibility));
     }
     if (this->display_name_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("DisplayName", &state, &this->display_name));
+        xml_node_contents.push_back(string_to_xml_attribute("DisplayName", state, &this->display_name));
     }
     if (this->is_separator_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("IsSeparator", &state, &this->is_separator));
+        xml_node_contents.push_back(bool_to_xml_attribute("IsSeparator", state, &this->is_separator));
     }
     if (this->name_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("Name", &state, &this->name));
+        xml_node_contents.push_back(string_to_xml_attribute("Name", state, &this->name));
     }
     if (this->tooltip_description_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("TipDescription", &state, &this->tooltip_description));
+        xml_node_contents.push_back(string_to_xml_attribute("TipDescription", state, &this->tooltip_description));
     }
     xml_node_contents.push_back(">\n");
 
     for (const auto& [key, val] : this->children) {
         string text;
-        for (const auto& s : val.as_xml()) {
+        for (const auto& s : val.as_xml(state)) {
             text += s;
         }
 
@@ -91,47 +90,45 @@ vector<string> Category::as_xml() const {
     return xml_node_contents;
 }
 
-waypoint::Category Category::as_protobuf() const {
-    ProtoWriterState state;
+waypoint::Category Category::as_protobuf(ProtoWriterState* state) const {
     waypoint::Category proto_category;
     if (this->default_visibility_is_set) {
         std::function<void(bool)> setter = [&proto_category](bool val) { proto_category.set_default_visibility(val); };
-        bool_to_proto(this->default_visibility, &state, setter);
+        bool_to_proto(this->default_visibility, state, setter);
     }
     if (this->display_name_is_set) {
         std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_name(val); };
-        string_to_proto(this->display_name, &state, setter);
+        string_to_proto(this->display_name, state, setter);
     }
     if (this->is_separator_is_set) {
         std::function<void(bool)> setter = [&proto_category](bool val) { proto_category.set_is_separator(val); };
-        bool_to_proto(this->is_separator, &state, setter);
+        bool_to_proto(this->is_separator, state, setter);
     }
     if (this->name_is_set) {
         std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_name(val); };
-        do_nothing(this->name, &state, setter);
+        do_nothing(this->name, state, setter);
     }
     if (this->tooltip_description_is_set) {
         std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_tip_description(val); };
-        string_to_proto(this->tooltip_description, &state, setter);
+        string_to_proto(this->tooltip_description, state, setter);
     }
     return proto_category;
 }
 
-void Category::parse_protobuf(waypoint::Category proto_category) {
-    ProtoReaderState state;
+void Category::parse_protobuf(waypoint::Category proto_category, ProtoReaderState* state) {
     if (proto_category.default_visibility() != 0) {
-        proto_to_bool(proto_category.default_visibility(), &state, &(this->default_visibility), &(this->default_visibility_is_set));
+        proto_to_bool(proto_category.default_visibility(), state, &(this->default_visibility), &(this->default_visibility_is_set));
     }
     if (proto_category.name() != "") {
-        proto_display_name_to_display_name_and_name(proto_category.name(), &state, &(this->display_name), &(this->display_name_is_set), &(this->name), &(this->name_is_set));
+        proto_display_name_to_display_name_and_name(proto_category.name(), state, &(this->display_name), &(this->display_name_is_set), &(this->name), &(this->name_is_set));
     }
     if (proto_category.is_separator() != 0) {
-        proto_to_bool(proto_category.is_separator(), &state, &(this->is_separator), &(this->is_separator_is_set));
+        proto_to_bool(proto_category.is_separator(), state, &(this->is_separator), &(this->is_separator_is_set));
     }
     if (proto_category.name() != "") {
-        do_nothing(proto_category.name(), &state, &(this->name), &(this->name_is_set));
+        do_nothing(proto_category.name(), state, &(this->name), &(this->name_is_set));
     }
     if (proto_category.tip_description() != "") {
-        proto_to_string(proto_category.tip_description(), &state, &(this->tooltip_description), &(this->tooltip_description_is_set));
+        proto_to_string(proto_category.tip_description(), state, &(this->tooltip_description), &(this->tooltip_description_is_set));
     }
 }

--- a/xml_converter/src/category_gen.hpp
+++ b/xml_converter/src/category_gen.hpp
@@ -31,9 +31,9 @@ class Category : public Parseable {
     Trail default_trail;
 
     void init_from_xml(rapidxml::xml_node<>* node, std::vector<XMLError*>* errors, XMLReaderState* state);
-    virtual std::vector<std::string> as_xml() const;
+    virtual std::vector<std::string> as_xml(XMLWriterState* state) const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState* state);
-    waypoint::Category as_protobuf() const;
-    void parse_protobuf(waypoint::Category proto_category);
+    waypoint::Category as_protobuf(ProtoWriterState* state) const;
+    void parse_protobuf(waypoint::Category proto_category, ProtoReaderState* state);
 };

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -252,496 +252,493 @@ bool Icon::validate_attributes_of_type_marker_category() {
     return true;
 }
 
-vector<string> Icon::as_xml() const {
-    XMLWriterState state;
+vector<string> Icon::as_xml(XMLWriterState* state) const {
     vector<string> xml_node_contents;
     xml_node_contents.push_back("<POI ");
     if (this->achievement_bitmask_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("AchievementBit", &state, &this->achievement_bitmask));
+        xml_node_contents.push_back(int_to_xml_attribute("AchievementBit", state, &this->achievement_bitmask));
     }
     if (this->achievement_id_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("AchievementId", &state, &this->achievement_id));
+        xml_node_contents.push_back(int_to_xml_attribute("AchievementId", state, &this->achievement_id));
     }
     if (this->auto_trigger_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("AutoTrigger", &state, &this->auto_trigger));
+        xml_node_contents.push_back(bool_to_xml_attribute("AutoTrigger", state, &this->auto_trigger));
     }
     if (this->bounce_delay_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("BounceDelay", &state, &this->bounce_delay));
+        xml_node_contents.push_back(float_to_xml_attribute("BounceDelay", state, &this->bounce_delay));
     }
     if (this->bounce_duration_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("BounceDuration", &state, &this->bounce_duration));
+        xml_node_contents.push_back(float_to_xml_attribute("BounceDuration", state, &this->bounce_duration));
     }
     if (this->bounce_height_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("BounceHeight", &state, &this->bounce_height));
+        xml_node_contents.push_back(float_to_xml_attribute("BounceHeight", state, &this->bounce_height));
     }
     if (this->category_is_set) {
-        xml_node_contents.push_back(marker_category_to_xml_attribute("Type", &state, &this->category));
+        xml_node_contents.push_back(marker_category_to_xml_attribute("Type", state, &this->category));
     }
     if (this->color_is_set) {
-        xml_node_contents.push_back(color_to_xml_attribute("Color", &state, &this->color));
+        xml_node_contents.push_back(color_to_xml_attribute("Color", state, &this->color));
     }
     if (this->color_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("Alpha", &state, &this->color.alpha));
+        xml_node_contents.push_back(float_to_xml_attribute("Alpha", state, &this->color.alpha));
     }
     if (this->copy_clipboard_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("Copy", &state, &this->copy_clipboard));
+        xml_node_contents.push_back(string_to_xml_attribute("Copy", state, &this->copy_clipboard));
     }
     if (this->copy_message_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("CopyMessage", &state, &this->copy_message));
+        xml_node_contents.push_back(string_to_xml_attribute("CopyMessage", state, &this->copy_message));
     }
     if (this->cull_chirality_is_set) {
-        xml_node_contents.push_back(cull_chirality_to_xml_attribute("Cull", &state, &this->cull_chirality));
+        xml_node_contents.push_back(cull_chirality_to_xml_attribute("Cull", state, &this->cull_chirality));
     }
     if (this->disable_player_cutout_is_set) {
-        xml_node_contents.push_back(bool_to_inverted_xml_attribute("CanFade", &state, &this->disable_player_cutout));
+        xml_node_contents.push_back(bool_to_inverted_xml_attribute("CanFade", state, &this->disable_player_cutout));
     }
     if (this->distance_fade_end_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("FadeFar", &state, &this->distance_fade_end));
+        xml_node_contents.push_back(float_to_xml_attribute("FadeFar", state, &this->distance_fade_end));
     }
     if (this->distance_fade_start_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("FadeNear", &state, &this->distance_fade_start));
+        xml_node_contents.push_back(float_to_xml_attribute("FadeNear", state, &this->distance_fade_start));
     }
     if (this->festival_filter_is_set) {
-        xml_node_contents.push_back(festival_filter_to_xml_attribute("Festival", &state, &this->festival_filter));
+        xml_node_contents.push_back(festival_filter_to_xml_attribute("Festival", state, &this->festival_filter));
     }
     if (this->guid_is_set) {
-        xml_node_contents.push_back(unique_id_to_xml_attribute("GUID", &state, &this->guid));
+        xml_node_contents.push_back(unique_id_to_xml_attribute("GUID", state, &this->guid));
     }
     if (this->has_countdown_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("HasCountdown", &state, &this->has_countdown));
+        xml_node_contents.push_back(bool_to_xml_attribute("HasCountdown", state, &this->has_countdown));
     }
     if (this->height_offset_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("HeightOffset", &state, &this->height_offset));
+        xml_node_contents.push_back(float_to_xml_attribute("HeightOffset", state, &this->height_offset));
     }
     if (this->hide_category_is_set) {
-        xml_node_contents.push_back(marker_category_to_xml_attribute("Hide", &state, &this->hide_category));
+        xml_node_contents.push_back(marker_category_to_xml_attribute("Hide", state, &this->hide_category));
     }
     if (this->icon_is_set) {
-        xml_node_contents.push_back(image_to_xml_attribute("IconFile", &state, &this->icon));
+        xml_node_contents.push_back(image_to_xml_attribute("IconFile", state, &this->icon));
     }
     if (this->icon_size_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("IconSize", &state, &this->icon_size));
+        xml_node_contents.push_back(float_to_xml_attribute("IconSize", state, &this->icon_size));
     }
     if (this->info_message_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("Info", &state, &this->info_message));
+        xml_node_contents.push_back(string_to_xml_attribute("Info", state, &this->info_message));
     }
     if (this->invert_visibility_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("InvertBehavior", &state, &this->invert_visibility));
+        xml_node_contents.push_back(bool_to_xml_attribute("InvertBehavior", state, &this->invert_visibility));
     }
     if (this->map_display_size_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MapDisplaySize", &state, &this->map_display_size));
+        xml_node_contents.push_back(int_to_xml_attribute("MapDisplaySize", state, &this->map_display_size));
     }
     if (this->map_id_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MapID", &state, &this->map_id));
+        xml_node_contents.push_back(int_to_xml_attribute("MapID", state, &this->map_id));
     }
     if (this->map_type_filter_is_set) {
-        xml_node_contents.push_back(map_type_filter_to_xml_attribute("MapType", &state, &this->map_type_filter));
+        xml_node_contents.push_back(map_type_filter_to_xml_attribute("MapType", state, &this->map_type_filter));
     }
     if (this->maximum_size_on_screen_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MaxSize", &state, &this->maximum_size_on_screen));
+        xml_node_contents.push_back(int_to_xml_attribute("MaxSize", state, &this->maximum_size_on_screen));
     }
     if (this->minimum_size_on_screen_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MinSize", &state, &this->minimum_size_on_screen));
+        xml_node_contents.push_back(int_to_xml_attribute("MinSize", state, &this->minimum_size_on_screen));
     }
     if (this->mount_filter_is_set) {
-        xml_node_contents.push_back(mount_filter_to_xml_attribute("Mount", &state, &this->mount_filter));
+        xml_node_contents.push_back(mount_filter_to_xml_attribute("Mount", state, &this->mount_filter));
     }
     if (this->position_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("XPos", &state, &this->position.x_position));
+        xml_node_contents.push_back(float_to_xml_attribute("XPos", state, &this->position.x_position));
     }
     if (this->position_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("YPos", &state, &this->position.y_position));
+        xml_node_contents.push_back(float_to_xml_attribute("YPos", state, &this->position.y_position));
     }
     if (this->position_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("ZPos", &state, &this->position.z_position));
+        xml_node_contents.push_back(float_to_xml_attribute("ZPos", state, &this->position.z_position));
     }
     if (this->profession_filter_is_set) {
-        xml_node_contents.push_back(profession_filter_to_xml_attribute("Profession", &state, &this->profession_filter));
+        xml_node_contents.push_back(profession_filter_to_xml_attribute("Profession", state, &this->profession_filter));
     }
     if (this->render_ingame_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("IngameVisibility", &state, &this->render_ingame));
+        xml_node_contents.push_back(bool_to_xml_attribute("IngameVisibility", state, &this->render_ingame));
     }
     if (this->render_on_map_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("MapVisibility", &state, &this->render_on_map));
+        xml_node_contents.push_back(bool_to_xml_attribute("MapVisibility", state, &this->render_on_map));
     }
     if (this->render_on_minimap_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("MinimapVisibility", &state, &this->render_on_minimap));
+        xml_node_contents.push_back(bool_to_xml_attribute("MinimapVisibility", state, &this->render_on_minimap));
     }
     if (this->reset_behavior_is_set) {
-        xml_node_contents.push_back(reset_behavior_to_xml_attribute("Behavior", &state, &this->reset_behavior));
+        xml_node_contents.push_back(reset_behavior_to_xml_attribute("Behavior", state, &this->reset_behavior));
     }
     if (this->reset_length_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("ResetLength", &state, &this->reset_length));
+        xml_node_contents.push_back(float_to_xml_attribute("ResetLength", state, &this->reset_length));
     }
     if (this->scale_on_map_with_zoom_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("ScaleOnMapWithZoom", &state, &this->scale_on_map_with_zoom));
+        xml_node_contents.push_back(bool_to_xml_attribute("ScaleOnMapWithZoom", state, &this->scale_on_map_with_zoom));
     }
     if (this->schedule_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("Schedule", &state, &this->schedule));
+        xml_node_contents.push_back(string_to_xml_attribute("Schedule", state, &this->schedule));
     }
     if (this->schedule_duration_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("ScheduleDuration", &state, &this->schedule_duration));
+        xml_node_contents.push_back(float_to_xml_attribute("ScheduleDuration", state, &this->schedule_duration));
     }
     if (this->show_category_is_set) {
-        xml_node_contents.push_back(marker_category_to_xml_attribute("Show", &state, &this->show_category));
+        xml_node_contents.push_back(marker_category_to_xml_attribute("Show", state, &this->show_category));
     }
     if (this->specialization_filter_is_set) {
-        xml_node_contents.push_back(specialization_filter_to_xml_attribute("Specialization", &state, &this->specialization_filter));
+        xml_node_contents.push_back(specialization_filter_to_xml_attribute("Specialization", state, &this->specialization_filter));
     }
     if (this->species_filter_is_set) {
-        xml_node_contents.push_back(species_filter_to_xml_attribute("Race", &state, &this->species_filter));
+        xml_node_contents.push_back(species_filter_to_xml_attribute("Race", state, &this->species_filter));
     }
     if (this->toggle_category_is_set) {
-        xml_node_contents.push_back(marker_category_to_xml_attribute("Toggle", &state, &this->toggle_category));
+        xml_node_contents.push_back(marker_category_to_xml_attribute("Toggle", state, &this->toggle_category));
     }
     if (this->tooltip_description_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("TipDescription", &state, &this->tooltip_description));
+        xml_node_contents.push_back(string_to_xml_attribute("TipDescription", state, &this->tooltip_description));
     }
     if (this->tooltip_name_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("TipName", &state, &this->tooltip_name));
+        xml_node_contents.push_back(string_to_xml_attribute("TipName", state, &this->tooltip_name));
     }
     if (this->trigger_range_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("TriggerRange", &state, &this->trigger_range));
+        xml_node_contents.push_back(float_to_xml_attribute("TriggerRange", state, &this->trigger_range));
     }
     xml_node_contents.push_back("/>");
     return xml_node_contents;
 }
 
-waypoint::Icon Icon::as_protobuf() const {
-    ProtoWriterState state;
+waypoint::Icon Icon::as_protobuf(ProtoWriterState* state) const {
     waypoint::Icon proto_icon;
     if (this->achievement_bitmask_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_achievement_bit(val); };
-        int_to_proto(this->achievement_bitmask, &state, setter);
+        int_to_proto(this->achievement_bitmask, state, setter);
     }
     if (this->achievement_id_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_achievement_id(val); };
-        int_to_proto(this->achievement_id, &state, setter);
+        int_to_proto(this->achievement_id, state, setter);
     }
     if (this->auto_trigger_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.mutable_trigger()->set_auto_trigger(val); };
-        bool_to_proto(this->auto_trigger, &state, setter);
+        bool_to_proto(this->auto_trigger, state, setter);
     }
     if (this->bounce_delay_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_bounce_delay(val); };
-        float_to_proto(this->bounce_delay, &state, setter);
+        float_to_proto(this->bounce_delay, state, setter);
     }
     if (this->bounce_duration_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_bounce_duration(val); };
-        float_to_proto(this->bounce_duration, &state, setter);
+        float_to_proto(this->bounce_duration, state, setter);
     }
     if (this->bounce_height_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_bounce_height(val); };
-        float_to_proto(this->bounce_height, &state, setter);
+        float_to_proto(this->bounce_height, state, setter);
     }
     if (this->category_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_category(val); };
-        do_nothing(this->category, &state, setter);
+        do_nothing(this->category, state, setter);
     }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_icon](waypoint::RGBAColor* val) { proto_icon.set_allocated_rgba_color(val); };
-        color_to_proto(this->color, &state, setter);
+        color_to_proto(this->color, state, setter);
     }
     if (this->copy_clipboard_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.mutable_trigger()->set_action_copy_clipboard(val); };
-        string_to_proto(this->copy_clipboard, &state, setter);
+        string_to_proto(this->copy_clipboard, state, setter);
     }
     if (this->copy_message_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.mutable_trigger()->set_action_copy_message(val); };
-        string_to_proto(this->copy_message, &state, setter);
+        string_to_proto(this->copy_message, state, setter);
     }
     if (this->cull_chirality_is_set) {
         std::function<void(waypoint::CullChirality)> setter = [&proto_icon](waypoint::CullChirality val) { proto_icon.set_cull_chirality(val); };
-        cull_chirality_to_proto(this->cull_chirality, &state, setter);
+        cull_chirality_to_proto(this->cull_chirality, state, setter);
     }
     if (this->disable_player_cutout_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_disable_player_cutout(val); };
-        bool_to_proto(this->disable_player_cutout, &state, setter);
+        bool_to_proto(this->disable_player_cutout, state, setter);
     }
     if (this->distance_fade_end_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.set_distance_fade_end(val); };
-        float_to_proto(this->distance_fade_end, &state, setter);
+        float_to_proto(this->distance_fade_end, state, setter);
     }
     if (this->distance_fade_start_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.set_distance_fade_start(val); };
-        float_to_proto(this->distance_fade_start, &state, setter);
+        float_to_proto(this->distance_fade_start, state, setter);
     }
     if (this->euler_rotation_is_set) {
         std::function<void(waypoint::EulerRotation*)> setter = [&proto_icon](waypoint::EulerRotation* val) { proto_icon.set_allocated_euler_rotation(val); };
-        euler_rotation_to_proto(this->euler_rotation, &state, setter);
+        euler_rotation_to_proto(this->euler_rotation, state, setter);
     }
     if (this->festival_filter_is_set) {
         std::function<void(waypoint::FestivalFilter*)> setter = [&proto_icon](waypoint::FestivalFilter* val) { proto_icon.set_allocated_festival_filter(val); };
-        festival_filter_to_proto(this->festival_filter, &state, setter);
+        festival_filter_to_proto(this->festival_filter, state, setter);
     }
     if (this->guid_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.set_guid(val); };
-        unique_id_to_proto(this->guid, &state, setter);
+        unique_id_to_proto(this->guid, state, setter);
     }
     if (this->has_countdown_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.mutable_trigger()->set_has_countdown(val); };
-        bool_to_proto(this->has_countdown, &state, setter);
+        bool_to_proto(this->has_countdown, state, setter);
     }
     if (this->height_offset_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.set_height_offset(val); };
-        float_to_proto(this->height_offset, &state, setter);
+        float_to_proto(this->height_offset, state, setter);
     }
     if (this->hide_category_is_set) {
         std::function<void(waypoint::Category*)> setter = [&proto_icon](waypoint::Category* val) { proto_icon.mutable_trigger()->set_allocated_action_hide_category(val); };
-        marker_category_to_proto(this->hide_category, &state, setter);
+        marker_category_to_proto(this->hide_category, state, setter);
     }
     if (this->icon_is_set) {
         std::function<void(waypoint::TexturePath*)> setter = [&proto_icon](waypoint::TexturePath* val) { proto_icon.set_allocated_texture_path(val); };
-        image_to_proto(this->icon, &state, setter);
+        image_to_proto(this->icon, state, setter);
     }
     if (this->icon_size_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.set_tentative__scale(val); };
-        float_to_proto(this->icon_size, &state, setter);
+        float_to_proto(this->icon_size, state, setter);
     }
     if (this->info_message_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.mutable_trigger()->set_action_info_message(val); };
-        string_to_proto(this->info_message, &state, setter);
+        string_to_proto(this->info_message, state, setter);
     }
     if (this->invert_visibility_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.mutable_trigger()->set_invert_display(val); };
-        bool_to_proto(this->invert_visibility, &state, setter);
+        bool_to_proto(this->invert_visibility, state, setter);
     }
     if (this->map_display_size_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_map_display_size(val); };
-        int_to_proto(this->map_display_size, &state, setter);
+        int_to_proto(this->map_display_size, state, setter);
     }
     if (this->map_id_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_map_id(val); };
-        int_to_proto(this->map_id, &state, setter);
+        int_to_proto(this->map_id, state, setter);
     }
     if (this->map_type_filter_is_set) {
         std::function<void(waypoint::MapTypeFilter*)> setter = [&proto_icon](waypoint::MapTypeFilter* val) { proto_icon.set_allocated_map_type_filter(val); };
-        map_type_filter_to_proto(this->map_type_filter, &state, setter);
+        map_type_filter_to_proto(this->map_type_filter, state, setter);
     }
     if (this->maximum_size_on_screen_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_maximum_size_on_screen(val); };
-        int_to_proto(this->maximum_size_on_screen, &state, setter);
+        int_to_proto(this->maximum_size_on_screen, state, setter);
     }
     if (this->minimum_size_on_screen_is_set) {
         std::function<void(int)> setter = [&proto_icon](int val) { proto_icon.set_minimum_size_on_screen(val); };
-        int_to_proto(this->minimum_size_on_screen, &state, setter);
+        int_to_proto(this->minimum_size_on_screen, state, setter);
     }
     if (this->mount_filter_is_set) {
         std::function<void(waypoint::MountFilter*)> setter = [&proto_icon](waypoint::MountFilter* val) { proto_icon.set_allocated_mount_filter(val); };
-        mount_filter_to_proto(this->mount_filter, &state, setter);
+        mount_filter_to_proto(this->mount_filter, state, setter);
     }
     if (this->position_is_set) {
         std::function<void(waypoint::Position*)> setter = [&proto_icon](waypoint::Position* val) { proto_icon.set_allocated_position(val); };
-        position_to_proto(this->position, &state, setter);
+        position_to_proto(this->position, state, setter);
     }
     if (this->profession_filter_is_set) {
         std::function<void(waypoint::ProfessionFilter*)> setter = [&proto_icon](waypoint::ProfessionFilter* val) { proto_icon.set_allocated_profession_filter(val); };
-        profession_filter_to_proto(this->profession_filter, &state, setter);
+        profession_filter_to_proto(this->profession_filter, state, setter);
     }
     if (this->render_ingame_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_tentative__render_ingame(val); };
-        bool_to_proto(this->render_ingame, &state, setter);
+        bool_to_proto(this->render_ingame, state, setter);
     }
     if (this->render_on_map_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_tentative__render_on_map(val); };
-        bool_to_proto(this->render_on_map, &state, setter);
+        bool_to_proto(this->render_on_map, state, setter);
     }
     if (this->render_on_minimap_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_tentative__render_on_minimap(val); };
-        bool_to_proto(this->render_on_minimap, &state, setter);
+        bool_to_proto(this->render_on_minimap, state, setter);
     }
     if (this->reset_behavior_is_set) {
         std::function<void(waypoint::ResetBehavior)> setter = [&proto_icon](waypoint::ResetBehavior val) { proto_icon.mutable_trigger()->set_reset_behavior(val); };
-        reset_behavior_to_proto(this->reset_behavior, &state, setter);
+        reset_behavior_to_proto(this->reset_behavior, state, setter);
     }
     if (this->reset_length_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_reset_length(val); };
-        float_to_proto(this->reset_length, &state, setter);
+        float_to_proto(this->reset_length, state, setter);
     }
     if (this->scale_on_map_with_zoom_is_set) {
         std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_scale_on_map_with_zoom(val); };
-        bool_to_proto(this->scale_on_map_with_zoom, &state, setter);
+        bool_to_proto(this->scale_on_map_with_zoom, state, setter);
     }
     if (this->schedule_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.set_bhdraft__schedule(val); };
-        string_to_proto(this->schedule, &state, setter);
+        string_to_proto(this->schedule, state, setter);
     }
     if (this->schedule_duration_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.set_bhdraft__schedule_duration(val); };
-        float_to_proto(this->schedule_duration, &state, setter);
+        float_to_proto(this->schedule_duration, state, setter);
     }
     if (this->show_category_is_set) {
         std::function<void(waypoint::Category*)> setter = [&proto_icon](waypoint::Category* val) { proto_icon.mutable_trigger()->set_allocated_action_show_category(val); };
-        marker_category_to_proto(this->show_category, &state, setter);
+        marker_category_to_proto(this->show_category, state, setter);
     }
     if (this->specialization_filter_is_set) {
         std::function<void(waypoint::SpecializationFilter*)> setter = [&proto_icon](waypoint::SpecializationFilter* val) { proto_icon.set_allocated_specialization_filter(val); };
-        specialization_filter_to_proto(this->specialization_filter, &state, setter);
+        specialization_filter_to_proto(this->specialization_filter, state, setter);
     }
     if (this->species_filter_is_set) {
         std::function<void(waypoint::SpeciesFilter*)> setter = [&proto_icon](waypoint::SpeciesFilter* val) { proto_icon.set_allocated_species_filter(val); };
-        species_filter_to_proto(this->species_filter, &state, setter);
+        species_filter_to_proto(this->species_filter, state, setter);
     }
     if (this->toggle_category_is_set) {
         std::function<void(waypoint::Category*)> setter = [&proto_icon](waypoint::Category* val) { proto_icon.mutable_trigger()->set_allocated_action_toggle_category(val); };
-        marker_category_to_proto(this->toggle_category, &state, setter);
+        marker_category_to_proto(this->toggle_category, state, setter);
     }
     if (this->tooltip_description_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.set_tip_description(val); };
-        string_to_proto(this->tooltip_description, &state, setter);
+        string_to_proto(this->tooltip_description, state, setter);
     }
     if (this->tooltip_name_is_set) {
         std::function<void(std::string)> setter = [&proto_icon](std::string val) { proto_icon.set_tip_name(val); };
-        string_to_proto(this->tooltip_name, &state, setter);
+        string_to_proto(this->tooltip_name, state, setter);
     }
     if (this->trigger_range_is_set) {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_range(val); };
-        float_to_proto(this->trigger_range, &state, setter);
+        float_to_proto(this->trigger_range, state, setter);
     }
     return proto_icon;
 }
 
-void Icon::parse_protobuf(waypoint::Icon proto_icon) {
-    ProtoReaderState state;
+void Icon::parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state) {
     if (proto_icon.achievement_bit() != 0) {
-        proto_to_int(proto_icon.achievement_bit(), &state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
+        proto_to_int(proto_icon.achievement_bit(), state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
     }
     if (proto_icon.achievement_id() != 0) {
-        proto_to_int(proto_icon.achievement_id(), &state, &(this->achievement_id), &(this->achievement_id_is_set));
+        proto_to_int(proto_icon.achievement_id(), state, &(this->achievement_id), &(this->achievement_id_is_set));
     }
     if (proto_icon.trigger().auto_trigger() != 0) {
-        proto_to_bool(proto_icon.trigger().auto_trigger(), &state, &(this->auto_trigger), &(this->auto_trigger_is_set));
+        proto_to_bool(proto_icon.trigger().auto_trigger(), state, &(this->auto_trigger), &(this->auto_trigger_is_set));
     }
     if (proto_icon.trigger().bounce_delay() != 0) {
-        proto_to_float(proto_icon.trigger().bounce_delay(), &state, &(this->bounce_delay), &(this->bounce_delay_is_set));
+        proto_to_float(proto_icon.trigger().bounce_delay(), state, &(this->bounce_delay), &(this->bounce_delay_is_set));
     }
     if (proto_icon.trigger().bounce_duration() != 0) {
-        proto_to_float(proto_icon.trigger().bounce_duration(), &state, &(this->bounce_duration), &(this->bounce_duration_is_set));
+        proto_to_float(proto_icon.trigger().bounce_duration(), state, &(this->bounce_duration), &(this->bounce_duration_is_set));
     }
     if (proto_icon.trigger().bounce_height() != 0) {
-        proto_to_float(proto_icon.trigger().bounce_height(), &state, &(this->bounce_height), &(this->bounce_height_is_set));
+        proto_to_float(proto_icon.trigger().bounce_height(), state, &(this->bounce_height), &(this->bounce_height_is_set));
     }
     if (proto_icon.category() != 0) {
-        do_nothing(proto_icon.category(), &state, &(this->category), &(this->category_is_set));
+        do_nothing(proto_icon.category(), state, &(this->category), &(this->category_is_set));
     }
     if (proto_icon.has_rgba_color()) {
-        proto_to_color(proto_icon.rgba_color(), &state, &(this->color), &(this->color_is_set));
+        proto_to_color(proto_icon.rgba_color(), state, &(this->color), &(this->color_is_set));
     }
     if (proto_icon.trigger().action_copy_clipboard() != "") {
-        proto_to_string(proto_icon.trigger().action_copy_clipboard(), &state, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
+        proto_to_string(proto_icon.trigger().action_copy_clipboard(), state, &(this->copy_clipboard), &(this->copy_clipboard_is_set));
     }
     if (proto_icon.trigger().action_copy_message() != "") {
-        proto_to_string(proto_icon.trigger().action_copy_message(), &state, &(this->copy_message), &(this->copy_message_is_set));
+        proto_to_string(proto_icon.trigger().action_copy_message(), state, &(this->copy_message), &(this->copy_message_is_set));
     }
     if (proto_icon.cull_chirality() != 0) {
-        proto_to_cull_chirality(proto_icon.cull_chirality(), &state, &(this->cull_chirality), &(this->cull_chirality_is_set));
+        proto_to_cull_chirality(proto_icon.cull_chirality(), state, &(this->cull_chirality), &(this->cull_chirality_is_set));
     }
     if (proto_icon.disable_player_cutout() != 0) {
-        proto_to_bool(proto_icon.disable_player_cutout(), &state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
+        proto_to_bool(proto_icon.disable_player_cutout(), state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
     }
     if (proto_icon.distance_fade_end() != 0) {
-        proto_to_float(proto_icon.distance_fade_end(), &state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        proto_to_float(proto_icon.distance_fade_end(), state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     if (proto_icon.distance_fade_start() != 0) {
-        proto_to_float(proto_icon.distance_fade_start(), &state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        proto_to_float(proto_icon.distance_fade_start(), state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     if (proto_icon.has_euler_rotation()) {
-        proto_to_euler_rotation(proto_icon.euler_rotation(), &state, &(this->euler_rotation), &(this->euler_rotation_is_set));
+        proto_to_euler_rotation(proto_icon.euler_rotation(), state, &(this->euler_rotation), &(this->euler_rotation_is_set));
     }
     if (proto_icon.has_festival_filter()) {
-        proto_to_festival_filter(proto_icon.festival_filter(), &state, &(this->festival_filter), &(this->festival_filter_is_set));
+        proto_to_festival_filter(proto_icon.festival_filter(), state, &(this->festival_filter), &(this->festival_filter_is_set));
     }
     if (proto_icon.guid() != "") {
-        proto_to_unique_id(proto_icon.guid(), &state, &(this->guid), &(this->guid_is_set));
+        proto_to_unique_id(proto_icon.guid(), state, &(this->guid), &(this->guid_is_set));
     }
     if (proto_icon.trigger().has_countdown() != 0) {
-        proto_to_bool(proto_icon.trigger().has_countdown(), &state, &(this->has_countdown), &(this->has_countdown_is_set));
+        proto_to_bool(proto_icon.trigger().has_countdown(), state, &(this->has_countdown), &(this->has_countdown_is_set));
     }
     if (proto_icon.height_offset() != 0) {
-        proto_to_float(proto_icon.height_offset(), &state, &(this->height_offset), &(this->height_offset_is_set));
+        proto_to_float(proto_icon.height_offset(), state, &(this->height_offset), &(this->height_offset_is_set));
     }
     if (proto_icon.trigger().has_action_hide_category()) {
-        proto_to_marker_category(proto_icon.trigger().action_hide_category(), &state, &(this->hide_category), &(this->hide_category_is_set));
+        proto_to_marker_category(proto_icon.trigger().action_hide_category(), state, &(this->hide_category), &(this->hide_category_is_set));
     }
     if (proto_icon.has_texture_path()) {
-        proto_to_image(proto_icon.texture_path(), &state, &(this->icon), &(this->icon_is_set));
+        proto_to_image(proto_icon.texture_path(), state, &(this->icon), &(this->icon_is_set));
     }
     if (proto_icon.tentative__scale() != 0) {
-        proto_to_float(proto_icon.tentative__scale(), &state, &(this->icon_size), &(this->icon_size_is_set));
+        proto_to_float(proto_icon.tentative__scale(), state, &(this->icon_size), &(this->icon_size_is_set));
     }
     if (proto_icon.trigger().action_info_message() != "") {
-        proto_to_string(proto_icon.trigger().action_info_message(), &state, &(this->info_message), &(this->info_message_is_set));
+        proto_to_string(proto_icon.trigger().action_info_message(), state, &(this->info_message), &(this->info_message_is_set));
     }
     if (proto_icon.trigger().invert_display() != 0) {
-        proto_to_bool(proto_icon.trigger().invert_display(), &state, &(this->invert_visibility), &(this->invert_visibility_is_set));
+        proto_to_bool(proto_icon.trigger().invert_display(), state, &(this->invert_visibility), &(this->invert_visibility_is_set));
     }
     if (proto_icon.map_display_size() != 0) {
-        proto_to_int(proto_icon.map_display_size(), &state, &(this->map_display_size), &(this->map_display_size_is_set));
+        proto_to_int(proto_icon.map_display_size(), state, &(this->map_display_size), &(this->map_display_size_is_set));
     }
     if (proto_icon.map_id() != 0) {
-        proto_to_int(proto_icon.map_id(), &state, &(this->map_id), &(this->map_id_is_set));
+        proto_to_int(proto_icon.map_id(), state, &(this->map_id), &(this->map_id_is_set));
     }
     if (proto_icon.has_map_type_filter()) {
-        proto_to_map_type_filter(proto_icon.map_type_filter(), &state, &(this->map_type_filter), &(this->map_type_filter_is_set));
+        proto_to_map_type_filter(proto_icon.map_type_filter(), state, &(this->map_type_filter), &(this->map_type_filter_is_set));
     }
     if (proto_icon.maximum_size_on_screen() != 0) {
-        proto_to_int(proto_icon.maximum_size_on_screen(), &state, &(this->maximum_size_on_screen), &(this->maximum_size_on_screen_is_set));
+        proto_to_int(proto_icon.maximum_size_on_screen(), state, &(this->maximum_size_on_screen), &(this->maximum_size_on_screen_is_set));
     }
     if (proto_icon.minimum_size_on_screen() != 0) {
-        proto_to_int(proto_icon.minimum_size_on_screen(), &state, &(this->minimum_size_on_screen), &(this->minimum_size_on_screen_is_set));
+        proto_to_int(proto_icon.minimum_size_on_screen(), state, &(this->minimum_size_on_screen), &(this->minimum_size_on_screen_is_set));
     }
     if (proto_icon.has_mount_filter()) {
-        proto_to_mount_filter(proto_icon.mount_filter(), &state, &(this->mount_filter), &(this->mount_filter_is_set));
+        proto_to_mount_filter(proto_icon.mount_filter(), state, &(this->mount_filter), &(this->mount_filter_is_set));
     }
     if (proto_icon.has_position()) {
-        proto_to_position(proto_icon.position(), &state, &(this->position), &(this->position_is_set));
+        proto_to_position(proto_icon.position(), state, &(this->position), &(this->position_is_set));
     }
     if (proto_icon.has_profession_filter()) {
-        proto_to_profession_filter(proto_icon.profession_filter(), &state, &(this->profession_filter), &(this->profession_filter_is_set));
+        proto_to_profession_filter(proto_icon.profession_filter(), state, &(this->profession_filter), &(this->profession_filter_is_set));
     }
     if (proto_icon.tentative__render_ingame() != 0) {
-        proto_to_bool(proto_icon.tentative__render_ingame(), &state, &(this->render_ingame), &(this->render_ingame_is_set));
+        proto_to_bool(proto_icon.tentative__render_ingame(), state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     if (proto_icon.tentative__render_on_map() != 0) {
-        proto_to_bool(proto_icon.tentative__render_on_map(), &state, &(this->render_on_map), &(this->render_on_map_is_set));
+        proto_to_bool(proto_icon.tentative__render_on_map(), state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     if (proto_icon.tentative__render_on_minimap() != 0) {
-        proto_to_bool(proto_icon.tentative__render_on_minimap(), &state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        proto_to_bool(proto_icon.tentative__render_on_minimap(), state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     if (proto_icon.trigger().reset_behavior() != 0) {
-        proto_to_reset_behavior(proto_icon.trigger().reset_behavior(), &state, &(this->reset_behavior), &(this->reset_behavior_is_set));
+        proto_to_reset_behavior(proto_icon.trigger().reset_behavior(), state, &(this->reset_behavior), &(this->reset_behavior_is_set));
     }
     if (proto_icon.trigger().reset_length() != 0) {
-        proto_to_float(proto_icon.trigger().reset_length(), &state, &(this->reset_length), &(this->reset_length_is_set));
+        proto_to_float(proto_icon.trigger().reset_length(), state, &(this->reset_length), &(this->reset_length_is_set));
     }
     if (proto_icon.scale_on_map_with_zoom() != 0) {
-        proto_to_bool(proto_icon.scale_on_map_with_zoom(), &state, &(this->scale_on_map_with_zoom), &(this->scale_on_map_with_zoom_is_set));
+        proto_to_bool(proto_icon.scale_on_map_with_zoom(), state, &(this->scale_on_map_with_zoom), &(this->scale_on_map_with_zoom_is_set));
     }
     if (proto_icon.bhdraft__schedule() != "") {
-        proto_to_string(proto_icon.bhdraft__schedule(), &state, &(this->schedule), &(this->schedule_is_set));
+        proto_to_string(proto_icon.bhdraft__schedule(), state, &(this->schedule), &(this->schedule_is_set));
     }
     if (proto_icon.bhdraft__schedule_duration() != 0) {
-        proto_to_float(proto_icon.bhdraft__schedule_duration(), &state, &(this->schedule_duration), &(this->schedule_duration_is_set));
+        proto_to_float(proto_icon.bhdraft__schedule_duration(), state, &(this->schedule_duration), &(this->schedule_duration_is_set));
     }
     if (proto_icon.trigger().has_action_show_category()) {
-        proto_to_marker_category(proto_icon.trigger().action_show_category(), &state, &(this->show_category), &(this->show_category_is_set));
+        proto_to_marker_category(proto_icon.trigger().action_show_category(), state, &(this->show_category), &(this->show_category_is_set));
     }
     if (proto_icon.has_specialization_filter()) {
-        proto_to_specialization_filter(proto_icon.specialization_filter(), &state, &(this->specialization_filter), &(this->specialization_filter_is_set));
+        proto_to_specialization_filter(proto_icon.specialization_filter(), state, &(this->specialization_filter), &(this->specialization_filter_is_set));
     }
     if (proto_icon.has_species_filter()) {
-        proto_to_species_filter(proto_icon.species_filter(), &state, &(this->species_filter), &(this->species_filter_is_set));
+        proto_to_species_filter(proto_icon.species_filter(), state, &(this->species_filter), &(this->species_filter_is_set));
     }
     if (proto_icon.trigger().has_action_toggle_category()) {
-        proto_to_marker_category(proto_icon.trigger().action_toggle_category(), &state, &(this->toggle_category), &(this->toggle_category_is_set));
+        proto_to_marker_category(proto_icon.trigger().action_toggle_category(), state, &(this->toggle_category), &(this->toggle_category_is_set));
     }
     if (proto_icon.tip_description() != "") {
-        proto_to_string(proto_icon.tip_description(), &state, &(this->tooltip_description), &(this->tooltip_description_is_set));
+        proto_to_string(proto_icon.tip_description(), state, &(this->tooltip_description), &(this->tooltip_description_is_set));
     }
     if (proto_icon.tip_name() != "") {
-        proto_to_string(proto_icon.tip_name(), &state, &(this->tooltip_name), &(this->tooltip_name_is_set));
+        proto_to_string(proto_icon.tip_name(), state, &(this->tooltip_name), &(this->tooltip_name_is_set));
     }
     if (proto_icon.trigger().range() != 0) {
-        proto_to_float(proto_icon.trigger().range(), &state, &(this->trigger_range), &(this->trigger_range_is_set));
+        proto_to_float(proto_icon.trigger().range(), state, &(this->trigger_range), &(this->trigger_range_is_set));
     }
 }

--- a/xml_converter/src/icon_gen.hpp
+++ b/xml_converter/src/icon_gen.hpp
@@ -121,10 +121,10 @@ class Icon : public Parseable {
     bool tooltip_description_is_set = false;
     bool tooltip_name_is_set = false;
     bool trigger_range_is_set = false;
-    virtual std::vector<std::string> as_xml() const;
+    virtual std::vector<std::string> as_xml(XMLWriterState* state) const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState* state);
-    waypoint::Icon as_protobuf() const;
-    void parse_protobuf(waypoint::Icon proto_icon);
+    waypoint::Icon as_protobuf(ProtoWriterState* state) const;
+    void parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state);
     bool validate_attributes_of_type_marker_category();
 };

--- a/xml_converter/src/packaging_xml.cpp
+++ b/xml_converter/src/packaging_xml.cpp
@@ -165,12 +165,14 @@ void write_xml_file(string xml_filepath, map<string, Category>* marker_categorie
     ofstream outfile;
     string tab_string;
 
+    XMLWriterState state;
+
     outfile.open(xml_filepath, ios::out);
 
     outfile << "<OverlayData>\n";
     for (const auto& category : *marker_categories) {
         string text;
-        for (const auto& s : category.second.as_xml()) {
+        for (const auto& s : category.second.as_xml(&state)) {
             text += s;
         }
         outfile << text + "\n";
@@ -179,7 +181,7 @@ void write_xml_file(string xml_filepath, map<string, Category>* marker_categorie
     outfile << "<POIs>\n";
     for (const auto& parsed_poi : *parsed_pois) {
         string text;
-        for (const auto& s : parsed_poi->as_xml()) {
+        for (const auto& s : parsed_poi->as_xml(&state)) {
             text += s;
         }
         outfile << text + "\n";

--- a/xml_converter/src/parseable.cpp
+++ b/xml_converter/src/parseable.cpp
@@ -6,6 +6,7 @@
 
 #include "rapid_helpers.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
+#include "state_structs/xml_writer_state.hpp"
 
 std::string Parseable::classname() {
     return "Parseable";
@@ -32,7 +33,7 @@ bool Parseable::init_xml_attribute(rapidxml::xml_attribute<>*, std::vector<XMLEr
     return false;
 }
 
-std::vector<std::string> Parseable::as_xml() const {
+std::vector<std::string> Parseable::as_xml(XMLWriterState*) const {
     throw std::runtime_error("error: Parseable::as_xml() should not be called");
     std::vector<std::string> result;
     return result;

--- a/xml_converter/src/parseable.hpp
+++ b/xml_converter/src/parseable.hpp
@@ -5,6 +5,7 @@
 
 #include "rapidxml-1.13/rapidxml.hpp"
 #include "state_structs/xml_reader_state.hpp"
+#include "state_structs/xml_writer_state.hpp"
 
 class XMLError;
 
@@ -19,5 +20,5 @@ class Parseable {
     // A default parser function to parse a single XML attribute into the class.
     virtual bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState*);
 
-    virtual std::vector<std::string> as_xml() const;
+    virtual std::vector<std::string> as_xml(XMLWriterState* state) const;
 };

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -153,293 +153,290 @@ bool Trail::validate_attributes_of_type_marker_category() {
     return true;
 }
 
-vector<string> Trail::as_xml() const {
-    XMLWriterState state;
+vector<string> Trail::as_xml(XMLWriterState* state) const {
     vector<string> xml_node_contents;
     xml_node_contents.push_back("<Trail ");
     if (this->achievement_bitmask_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("AchievementBit", &state, &this->achievement_bitmask));
+        xml_node_contents.push_back(int_to_xml_attribute("AchievementBit", state, &this->achievement_bitmask));
     }
     if (this->achievement_id_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("AchievementId", &state, &this->achievement_id));
+        xml_node_contents.push_back(int_to_xml_attribute("AchievementId", state, &this->achievement_id));
     }
     if (this->animation_speed_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("AnimSpeed", &state, &this->animation_speed));
+        xml_node_contents.push_back(float_to_xml_attribute("AnimSpeed", state, &this->animation_speed));
     }
     if (this->category_is_set) {
-        xml_node_contents.push_back(marker_category_to_xml_attribute("Type", &state, &this->category));
+        xml_node_contents.push_back(marker_category_to_xml_attribute("Type", state, &this->category));
     }
     if (this->color_is_set) {
-        xml_node_contents.push_back(color_to_xml_attribute("Color", &state, &this->color));
+        xml_node_contents.push_back(color_to_xml_attribute("Color", state, &this->color));
     }
     if (this->color_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("Alpha", &state, &this->color.alpha));
+        xml_node_contents.push_back(float_to_xml_attribute("Alpha", state, &this->color.alpha));
     }
     if (this->cull_chirality_is_set) {
-        xml_node_contents.push_back(cull_chirality_to_xml_attribute("Cull", &state, &this->cull_chirality));
+        xml_node_contents.push_back(cull_chirality_to_xml_attribute("Cull", state, &this->cull_chirality));
     }
     if (this->disable_player_cutout_is_set) {
-        xml_node_contents.push_back(bool_to_inverted_xml_attribute("CanFade", &state, &this->disable_player_cutout));
+        xml_node_contents.push_back(bool_to_inverted_xml_attribute("CanFade", state, &this->disable_player_cutout));
     }
     if (this->distance_fade_end_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("FadeFar", &state, &this->distance_fade_end));
+        xml_node_contents.push_back(float_to_xml_attribute("FadeFar", state, &this->distance_fade_end));
     }
     if (this->distance_fade_start_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("FadeNear", &state, &this->distance_fade_start));
+        xml_node_contents.push_back(float_to_xml_attribute("FadeNear", state, &this->distance_fade_start));
     }
     if (this->festival_filter_is_set) {
-        xml_node_contents.push_back(festival_filter_to_xml_attribute("Festival", &state, &this->festival_filter));
+        xml_node_contents.push_back(festival_filter_to_xml_attribute("Festival", state, &this->festival_filter));
     }
     if (this->guid_is_set) {
-        xml_node_contents.push_back(unique_id_to_xml_attribute("GUID", &state, &this->guid));
+        xml_node_contents.push_back(unique_id_to_xml_attribute("GUID", state, &this->guid));
     }
     if (this->is_wall_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("IsWall", &state, &this->is_wall));
+        xml_node_contents.push_back(bool_to_xml_attribute("IsWall", state, &this->is_wall));
     }
     if (this->map_display_size_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MapDisplaySize", &state, &this->map_display_size));
+        xml_node_contents.push_back(int_to_xml_attribute("MapDisplaySize", state, &this->map_display_size));
     }
     if (this->map_id_is_set) {
-        xml_node_contents.push_back(int_to_xml_attribute("MapID", &state, &this->map_id));
+        xml_node_contents.push_back(int_to_xml_attribute("MapID", state, &this->map_id));
     }
     if (this->map_type_filter_is_set) {
-        xml_node_contents.push_back(map_type_filter_to_xml_attribute("MapType", &state, &this->map_type_filter));
+        xml_node_contents.push_back(map_type_filter_to_xml_attribute("MapType", state, &this->map_type_filter));
     }
     if (this->mount_filter_is_set) {
-        xml_node_contents.push_back(mount_filter_to_xml_attribute("Mount", &state, &this->mount_filter));
+        xml_node_contents.push_back(mount_filter_to_xml_attribute("Mount", state, &this->mount_filter));
     }
     if (this->profession_filter_is_set) {
-        xml_node_contents.push_back(profession_filter_to_xml_attribute("Profession", &state, &this->profession_filter));
+        xml_node_contents.push_back(profession_filter_to_xml_attribute("Profession", state, &this->profession_filter));
     }
     if (this->render_ingame_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("IngameVisibility", &state, &this->render_ingame));
+        xml_node_contents.push_back(bool_to_xml_attribute("IngameVisibility", state, &this->render_ingame));
     }
     if (this->render_on_map_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("MapVisibility", &state, &this->render_on_map));
+        xml_node_contents.push_back(bool_to_xml_attribute("MapVisibility", state, &this->render_on_map));
     }
     if (this->render_on_minimap_is_set) {
-        xml_node_contents.push_back(bool_to_xml_attribute("MinimapVisibility", &state, &this->render_on_minimap));
+        xml_node_contents.push_back(bool_to_xml_attribute("MinimapVisibility", state, &this->render_on_minimap));
     }
     if (this->schedule_is_set) {
-        xml_node_contents.push_back(string_to_xml_attribute("Schedule", &state, &this->schedule));
+        xml_node_contents.push_back(string_to_xml_attribute("Schedule", state, &this->schedule));
     }
     if (this->schedule_duration_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("ScheduleDuration", &state, &this->schedule_duration));
+        xml_node_contents.push_back(float_to_xml_attribute("ScheduleDuration", state, &this->schedule_duration));
     }
     if (this->specialization_filter_is_set) {
-        xml_node_contents.push_back(specialization_filter_to_xml_attribute("Specialization", &state, &this->specialization_filter));
+        xml_node_contents.push_back(specialization_filter_to_xml_attribute("Specialization", state, &this->specialization_filter));
     }
     if (this->species_filter_is_set) {
-        xml_node_contents.push_back(species_filter_to_xml_attribute("Race", &state, &this->species_filter));
+        xml_node_contents.push_back(species_filter_to_xml_attribute("Race", state, &this->species_filter));
     }
     if (this->texture_is_set) {
-        xml_node_contents.push_back(image_to_xml_attribute("Texture", &state, &this->texture));
+        xml_node_contents.push_back(image_to_xml_attribute("Texture", state, &this->texture));
     }
     if (this->trail_data_is_set) {
-        xml_node_contents.push_back(trail_data_to_xml_attribute("TrailData", &state, &this->trail_data));
+        xml_node_contents.push_back(trail_data_to_xml_attribute("TrailData", state, &this->trail_data));
     }
     if (this->trail_scale_is_set) {
-        xml_node_contents.push_back(float_to_xml_attribute("TrailScale", &state, &this->trail_scale));
+        xml_node_contents.push_back(float_to_xml_attribute("TrailScale", state, &this->trail_scale));
     }
     xml_node_contents.push_back("/>");
     return xml_node_contents;
 }
 
-waypoint::Trail Trail::as_protobuf() const {
-    ProtoWriterState state;
+waypoint::Trail Trail::as_protobuf(ProtoWriterState* state) const {
     waypoint::Trail proto_trail;
     if (this->achievement_bitmask_is_set) {
         std::function<void(int)> setter = [&proto_trail](int val) { proto_trail.set_achievement_bit(val); };
-        int_to_proto(this->achievement_bitmask, &state, setter);
+        int_to_proto(this->achievement_bitmask, state, setter);
     }
     if (this->achievement_id_is_set) {
         std::function<void(int)> setter = [&proto_trail](int val) { proto_trail.set_achievement_id(val); };
-        int_to_proto(this->achievement_id, &state, setter);
+        int_to_proto(this->achievement_id, state, setter);
     }
     if (this->animation_speed_is_set) {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_animation_speed(val); };
-        float_to_proto(this->animation_speed, &state, setter);
+        float_to_proto(this->animation_speed, state, setter);
     }
     if (this->category_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_category(val); };
-        do_nothing(this->category, &state, setter);
+        do_nothing(this->category, state, setter);
     }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_trail](waypoint::RGBAColor* val) { proto_trail.set_allocated_rgba_color(val); };
-        color_to_proto(this->color, &state, setter);
+        color_to_proto(this->color, state, setter);
     }
     if (this->cull_chirality_is_set) {
         std::function<void(waypoint::CullChirality)> setter = [&proto_trail](waypoint::CullChirality val) { proto_trail.set_cull_chirality(val); };
-        cull_chirality_to_proto(this->cull_chirality, &state, setter);
+        cull_chirality_to_proto(this->cull_chirality, state, setter);
     }
     if (this->disable_player_cutout_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_disable_player_cutout(val); };
-        bool_to_proto(this->disable_player_cutout, &state, setter);
+        bool_to_proto(this->disable_player_cutout, state, setter);
     }
     if (this->distance_fade_end_is_set) {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_distance_fade_end(val); };
-        float_to_proto(this->distance_fade_end, &state, setter);
+        float_to_proto(this->distance_fade_end, state, setter);
     }
     if (this->distance_fade_start_is_set) {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_distance_fade_start(val); };
-        float_to_proto(this->distance_fade_start, &state, setter);
+        float_to_proto(this->distance_fade_start, state, setter);
     }
     if (this->festival_filter_is_set) {
         std::function<void(waypoint::FestivalFilter*)> setter = [&proto_trail](waypoint::FestivalFilter* val) { proto_trail.set_allocated_festival_filter(val); };
-        festival_filter_to_proto(this->festival_filter, &state, setter);
+        festival_filter_to_proto(this->festival_filter, state, setter);
     }
     if (this->guid_is_set) {
         std::function<void(std::string)> setter = [&proto_trail](std::string val) { proto_trail.set_guid(val); };
-        unique_id_to_proto(this->guid, &state, setter);
+        unique_id_to_proto(this->guid, state, setter);
     }
     if (this->is_wall_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_is_wall(val); };
-        bool_to_proto(this->is_wall, &state, setter);
+        bool_to_proto(this->is_wall, state, setter);
     }
     if (this->map_display_size_is_set) {
         std::function<void(int)> setter = [&proto_trail](int val) { proto_trail.set_map_display_size(val); };
-        int_to_proto(this->map_display_size, &state, setter);
+        int_to_proto(this->map_display_size, state, setter);
     }
     if (this->map_id_is_set) {
         std::function<void(int)> setter = [&proto_trail](int val) { proto_trail.set_map_id(val); };
-        int_to_proto(this->map_id, &state, setter);
+        int_to_proto(this->map_id, state, setter);
     }
     if (this->map_type_filter_is_set) {
         std::function<void(waypoint::MapTypeFilter*)> setter = [&proto_trail](waypoint::MapTypeFilter* val) { proto_trail.set_allocated_map_type_filter(val); };
-        map_type_filter_to_proto(this->map_type_filter, &state, setter);
+        map_type_filter_to_proto(this->map_type_filter, state, setter);
     }
     if (this->mount_filter_is_set) {
         std::function<void(waypoint::MountFilter*)> setter = [&proto_trail](waypoint::MountFilter* val) { proto_trail.set_allocated_mount_filter(val); };
-        mount_filter_to_proto(this->mount_filter, &state, setter);
+        mount_filter_to_proto(this->mount_filter, state, setter);
     }
     if (this->profession_filter_is_set) {
         std::function<void(waypoint::ProfessionFilter*)> setter = [&proto_trail](waypoint::ProfessionFilter* val) { proto_trail.set_allocated_profession_filter(val); };
-        profession_filter_to_proto(this->profession_filter, &state, setter);
+        profession_filter_to_proto(this->profession_filter, state, setter);
     }
     if (this->render_ingame_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_tentative__render_ingame(val); };
-        bool_to_proto(this->render_ingame, &state, setter);
+        bool_to_proto(this->render_ingame, state, setter);
     }
     if (this->render_on_map_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_tentative__render_on_map(val); };
-        bool_to_proto(this->render_on_map, &state, setter);
+        bool_to_proto(this->render_on_map, state, setter);
     }
     if (this->render_on_minimap_is_set) {
         std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_tentative__render_on_minimap(val); };
-        bool_to_proto(this->render_on_minimap, &state, setter);
+        bool_to_proto(this->render_on_minimap, state, setter);
     }
     if (this->schedule_is_set) {
         std::function<void(std::string)> setter = [&proto_trail](std::string val) { proto_trail.set_bhdraft__schedule(val); };
-        string_to_proto(this->schedule, &state, setter);
+        string_to_proto(this->schedule, state, setter);
     }
     if (this->schedule_duration_is_set) {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_bhdraft__schedule_duration(val); };
-        float_to_proto(this->schedule_duration, &state, setter);
+        float_to_proto(this->schedule_duration, state, setter);
     }
     if (this->specialization_filter_is_set) {
         std::function<void(waypoint::SpecializationFilter*)> setter = [&proto_trail](waypoint::SpecializationFilter* val) { proto_trail.set_allocated_specialization_filter(val); };
-        specialization_filter_to_proto(this->specialization_filter, &state, setter);
+        specialization_filter_to_proto(this->specialization_filter, state, setter);
     }
     if (this->species_filter_is_set) {
         std::function<void(waypoint::SpeciesFilter*)> setter = [&proto_trail](waypoint::SpeciesFilter* val) { proto_trail.set_allocated_species_filter(val); };
-        species_filter_to_proto(this->species_filter, &state, setter);
+        species_filter_to_proto(this->species_filter, state, setter);
     }
     if (this->texture_is_set) {
         std::function<void(waypoint::TexturePath*)> setter = [&proto_trail](waypoint::TexturePath* val) { proto_trail.set_allocated_texture_path(val); };
-        image_to_proto(this->texture, &state, setter);
+        image_to_proto(this->texture, state, setter);
     }
     if (this->trail_data_is_set) {
         std::function<void(waypoint::TrailData*)> setter = [&proto_trail](waypoint::TrailData* val) { proto_trail.set_allocated_trail_data(val); };
-        trail_data_to_proto(this->trail_data, &state, setter);
+        trail_data_to_proto(this->trail_data, state, setter);
     }
     if (this->trail_scale_is_set) {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_scale(val); };
-        float_to_proto(this->trail_scale, &state, setter);
+        float_to_proto(this->trail_scale, state, setter);
     }
     return proto_trail;
 }
 
-void Trail::parse_protobuf(waypoint::Trail proto_trail) {
-    ProtoReaderState state;
+void Trail::parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state) {
     if (proto_trail.achievement_bit() != 0) {
-        proto_to_int(proto_trail.achievement_bit(), &state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
+        proto_to_int(proto_trail.achievement_bit(), state, &(this->achievement_bitmask), &(this->achievement_bitmask_is_set));
     }
     if (proto_trail.achievement_id() != 0) {
-        proto_to_int(proto_trail.achievement_id(), &state, &(this->achievement_id), &(this->achievement_id_is_set));
+        proto_to_int(proto_trail.achievement_id(), state, &(this->achievement_id), &(this->achievement_id_is_set));
     }
     if (proto_trail.animation_speed() != 0) {
-        proto_to_float(proto_trail.animation_speed(), &state, &(this->animation_speed), &(this->animation_speed_is_set));
+        proto_to_float(proto_trail.animation_speed(), state, &(this->animation_speed), &(this->animation_speed_is_set));
     }
     if (proto_trail.category() != 0) {
-        do_nothing(proto_trail.category(), &state, &(this->category), &(this->category_is_set));
+        do_nothing(proto_trail.category(), state, &(this->category), &(this->category_is_set));
     }
     if (proto_trail.has_rgba_color()) {
-        proto_to_color(proto_trail.rgba_color(), &state, &(this->color), &(this->color_is_set));
+        proto_to_color(proto_trail.rgba_color(), state, &(this->color), &(this->color_is_set));
     }
     if (proto_trail.cull_chirality() != 0) {
-        proto_to_cull_chirality(proto_trail.cull_chirality(), &state, &(this->cull_chirality), &(this->cull_chirality_is_set));
+        proto_to_cull_chirality(proto_trail.cull_chirality(), state, &(this->cull_chirality), &(this->cull_chirality_is_set));
     }
     if (proto_trail.disable_player_cutout() != 0) {
-        proto_to_bool(proto_trail.disable_player_cutout(), &state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
+        proto_to_bool(proto_trail.disable_player_cutout(), state, &(this->disable_player_cutout), &(this->disable_player_cutout_is_set));
     }
     if (proto_trail.distance_fade_end() != 0) {
-        proto_to_float(proto_trail.distance_fade_end(), &state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
+        proto_to_float(proto_trail.distance_fade_end(), state, &(this->distance_fade_end), &(this->distance_fade_end_is_set));
     }
     if (proto_trail.distance_fade_start() != 0) {
-        proto_to_float(proto_trail.distance_fade_start(), &state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
+        proto_to_float(proto_trail.distance_fade_start(), state, &(this->distance_fade_start), &(this->distance_fade_start_is_set));
     }
     if (proto_trail.has_festival_filter()) {
-        proto_to_festival_filter(proto_trail.festival_filter(), &state, &(this->festival_filter), &(this->festival_filter_is_set));
+        proto_to_festival_filter(proto_trail.festival_filter(), state, &(this->festival_filter), &(this->festival_filter_is_set));
     }
     if (proto_trail.guid() != "") {
-        proto_to_unique_id(proto_trail.guid(), &state, &(this->guid), &(this->guid_is_set));
+        proto_to_unique_id(proto_trail.guid(), state, &(this->guid), &(this->guid_is_set));
     }
     if (proto_trail.is_wall() != 0) {
-        proto_to_bool(proto_trail.is_wall(), &state, &(this->is_wall), &(this->is_wall_is_set));
+        proto_to_bool(proto_trail.is_wall(), state, &(this->is_wall), &(this->is_wall_is_set));
     }
     if (proto_trail.map_display_size() != 0) {
-        proto_to_int(proto_trail.map_display_size(), &state, &(this->map_display_size), &(this->map_display_size_is_set));
+        proto_to_int(proto_trail.map_display_size(), state, &(this->map_display_size), &(this->map_display_size_is_set));
     }
     if (proto_trail.map_id() != 0) {
-        proto_to_int(proto_trail.map_id(), &state, &(this->map_id), &(this->map_id_is_set));
+        proto_to_int(proto_trail.map_id(), state, &(this->map_id), &(this->map_id_is_set));
     }
     if (proto_trail.has_map_type_filter()) {
-        proto_to_map_type_filter(proto_trail.map_type_filter(), &state, &(this->map_type_filter), &(this->map_type_filter_is_set));
+        proto_to_map_type_filter(proto_trail.map_type_filter(), state, &(this->map_type_filter), &(this->map_type_filter_is_set));
     }
     if (proto_trail.has_mount_filter()) {
-        proto_to_mount_filter(proto_trail.mount_filter(), &state, &(this->mount_filter), &(this->mount_filter_is_set));
+        proto_to_mount_filter(proto_trail.mount_filter(), state, &(this->mount_filter), &(this->mount_filter_is_set));
     }
     if (proto_trail.has_profession_filter()) {
-        proto_to_profession_filter(proto_trail.profession_filter(), &state, &(this->profession_filter), &(this->profession_filter_is_set));
+        proto_to_profession_filter(proto_trail.profession_filter(), state, &(this->profession_filter), &(this->profession_filter_is_set));
     }
     if (proto_trail.tentative__render_ingame() != 0) {
-        proto_to_bool(proto_trail.tentative__render_ingame(), &state, &(this->render_ingame), &(this->render_ingame_is_set));
+        proto_to_bool(proto_trail.tentative__render_ingame(), state, &(this->render_ingame), &(this->render_ingame_is_set));
     }
     if (proto_trail.tentative__render_on_map() != 0) {
-        proto_to_bool(proto_trail.tentative__render_on_map(), &state, &(this->render_on_map), &(this->render_on_map_is_set));
+        proto_to_bool(proto_trail.tentative__render_on_map(), state, &(this->render_on_map), &(this->render_on_map_is_set));
     }
     if (proto_trail.tentative__render_on_minimap() != 0) {
-        proto_to_bool(proto_trail.tentative__render_on_minimap(), &state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
+        proto_to_bool(proto_trail.tentative__render_on_minimap(), state, &(this->render_on_minimap), &(this->render_on_minimap_is_set));
     }
     if (proto_trail.bhdraft__schedule() != "") {
-        proto_to_string(proto_trail.bhdraft__schedule(), &state, &(this->schedule), &(this->schedule_is_set));
+        proto_to_string(proto_trail.bhdraft__schedule(), state, &(this->schedule), &(this->schedule_is_set));
     }
     if (proto_trail.bhdraft__schedule_duration() != 0) {
-        proto_to_float(proto_trail.bhdraft__schedule_duration(), &state, &(this->schedule_duration), &(this->schedule_duration_is_set));
+        proto_to_float(proto_trail.bhdraft__schedule_duration(), state, &(this->schedule_duration), &(this->schedule_duration_is_set));
     }
     if (proto_trail.has_specialization_filter()) {
-        proto_to_specialization_filter(proto_trail.specialization_filter(), &state, &(this->specialization_filter), &(this->specialization_filter_is_set));
+        proto_to_specialization_filter(proto_trail.specialization_filter(), state, &(this->specialization_filter), &(this->specialization_filter_is_set));
     }
     if (proto_trail.has_species_filter()) {
-        proto_to_species_filter(proto_trail.species_filter(), &state, &(this->species_filter), &(this->species_filter_is_set));
+        proto_to_species_filter(proto_trail.species_filter(), state, &(this->species_filter), &(this->species_filter_is_set));
     }
     if (proto_trail.has_texture_path()) {
-        proto_to_image(proto_trail.texture_path(), &state, &(this->texture), &(this->texture_is_set));
+        proto_to_image(proto_trail.texture_path(), state, &(this->texture), &(this->texture_is_set));
     }
     if (proto_trail.has_trail_data()) {
-        proto_to_trail_data(proto_trail.trail_data(), &state, &(this->trail_data), &(this->trail_data_is_set));
+        proto_to_trail_data(proto_trail.trail_data(), state, &(this->trail_data), &(this->trail_data_is_set));
     }
     if (proto_trail.scale() != 0) {
-        proto_to_float(proto_trail.scale(), &state, &(this->trail_scale), &(this->trail_scale_is_set));
+        proto_to_float(proto_trail.scale(), state, &(this->trail_scale), &(this->trail_scale_is_set));
     }
 }

--- a/xml_converter/src/trail_gen.hpp
+++ b/xml_converter/src/trail_gen.hpp
@@ -79,10 +79,10 @@ class Trail : public Parseable {
     bool texture_is_set = false;
     bool trail_data_is_set = false;
     bool trail_scale_is_set = false;
-    virtual std::vector<std::string> as_xml() const;
+    virtual std::vector<std::string> as_xml(XMLWriterState* state) const;
     virtual std::string classname();
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState* state);
-    waypoint::Trail as_protobuf() const;
-    void parse_protobuf(waypoint::Trail proto_trail);
+    waypoint::Trail as_protobuf(ProtoWriterState* state) const;
+    void parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state);
     bool validate_attributes_of_type_marker_category();
 };


### PR DESCRIPTION
The state was not being used really yet but if it were it would have been cleared once the node was finished processing. This is not super useful for many of the things the state variables are intended to be used for.