### PR TITLE
Pruning usage of AttributeVariable and cleaning up associated code

### DIFF
--- a/xml_converter/generators/cpp_templates/attribute_template.hpp
+++ b/xml_converter/generators/cpp_templates/attribute_template.hpp
@@ -15,8 +15,8 @@
     class XMLError;
 
     enum {{class_name}} {
-        {% for attribute_variable in attribute_components %}
-            {{attribute_variable.attribute_name}},
+        {% for attribute_component in attribute_components %}
+            {{attribute_component.attribute_name}},
         {% endfor %}
     };
 {% elif type in ["CompoundValue", "MultiflagValue"] %}
@@ -26,8 +26,8 @@
 
     class {{class_name}} {
      public:
-        {% for attribute_variable in attribute_components %}
-            {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
+        {% for attribute_component in attribute_components %}
+            {{attribute_component.cpp_type}} {{attribute_component.attribute_name}};
         {% endfor %}
 
         virtual std::string classname() {

--- a/xml_converter/generators/cpp_templates/attribute_template.hpp
+++ b/xml_converter/generators/cpp_templates/attribute_template.hpp
@@ -15,19 +15,19 @@
     class XMLError;
 
     enum {{class_name}} {
-        {% for attribute_variable in attribute_variables: %}
-        {{attribute_variable.attribute_name}},
+        {% for attribute_variable in attribute_components %}
+            {{attribute_variable.attribute_name}},
         {% endfor %}
     };
-{% else %}
+{% elif type in ["CompoundValue", "MultiflagValue"] %}
 
     class XMLError;
     {{proto_field_cpp_type_prototype}}
 
     class {{class_name}} {
      public:
-        {% for attribute_variable in attribute_variables: %}
-        {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
+        {% for attribute_variable in attribute_components %}
+            {{attribute_variable.cpp_type}} {{attribute_variable.attribute_name}};
         {% endfor %}
 
         virtual std::string classname() {

--- a/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
@@ -20,14 +20,14 @@ void xml_attribute_to_{{attribute_name}}(
     {{class_name}} {{attribute_name}};
     vector<string> compound_values;
     string attributename;
-    {% for attribute_variable in attribute_components %}
-        {{attribute_name}}.{{attribute_variable.attribute_name}} = 0;
+    {% for attribute_component in attribute_components %}
+        {{attribute_name}}.{{attribute_component.attribute_name}} = 0;
     {% endfor %}
     attributename = get_attribute_name(input);
     compound_values = split(get_attribute_value(input), ",");
     if (compound_values.size() == {{ attribute_components|length }}) {
-        {% for n, attribute_variable in enumerate(attribute_components) %}
-            {{attribute_name}}.{{attribute_variable.attribute_name}} = std::stof(compound_values[{{n}}]);
+        {% for n, attribute_component in enumerate(attribute_components) %}
+            {{attribute_name}}.{{attribute_component.attribute_name}} = std::stof(compound_values[{{n}}]);
         {% endfor %}
     }
     *value = {{attribute_name}};
@@ -39,12 +39,12 @@ void xml_attribute_to_{{attribute_name}}(
         XMLWriterState* state,
         const {{class_name}}* value) {
         string output;
-        {% for n, attribute_variable in enumerate(attribute_components) %}
-            {% if attribute_variable.attribute_name in xml_bundled_components %}
+        {% for n, attribute_component in enumerate(attribute_components) %}
+            {% if attribute_component.attribute_name in xml_bundled_components %}
                 {% if n == 0 %}
-                    output = to_string(value->{{attribute_variable.attribute_name}});
+                    output = to_string(value->{{attribute_component.attribute_name}});
                 {% else %}
-                    output = output + "," + to_string(value->{{attribute_variable.attribute_name}});
+                    output = output + "," + to_string(value->{{attribute_component.attribute_name}});
                 {% endif %}
             {% endif %}
         {% endfor %}
@@ -58,8 +58,8 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};
-    {% for attribute_variable in attribute_components %}
-        {{attribute_name}}.{{attribute_variable.attribute_name}} = input.{{attribute_variable.protobuf_field}}();
+    {% for attribute_component in attribute_components %}
+        {{attribute_name}}.{{attribute_component.attribute_name}} = input.{{attribute_component.protobuf_field}}();
     {% endfor %}
     *value = {{attribute_name}};
     *is_set = true;
@@ -70,8 +70,8 @@ void {{attribute_name}}_to_proto(
     ProtoWriterState* state,
     std::function<void({{proto_field_cpp_type}}*)> setter) {
     {{proto_field_cpp_type}}* proto_{{attribute_name}} = new {{proto_field_cpp_type}}();
-    {% for attribute_variable in attribute_components %}
-        proto_{{attribute_name}}->set_{{attribute_variable.protobuf_field}}(value.{{attribute_variable.attribute_name}});
+    {% for attribute_component in attribute_components %}
+        proto_{{attribute_name}}->set_{{attribute_component.protobuf_field}}(value.{{attribute_component.attribute_name}});
     {% endfor %}
     setter(proto_{{attribute_name}});
 }

--- a/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
@@ -20,13 +20,13 @@ void xml_attribute_to_{{attribute_name}}(
     {{class_name}} {{attribute_name}};
     vector<string> compound_values;
     string attributename;
-    {% for attribute_variable in attribute_variables: %}
+    {% for attribute_variable in attribute_components %}
         {{attribute_name}}.{{attribute_variable.attribute_name}} = 0;
     {% endfor %}
     attributename = get_attribute_name(input);
     compound_values = split(get_attribute_value(input), ",");
-    if (compound_values.size() == {{ attribute_variables|length }}) {
-        {% for n, attribute_variable in enumerate(attribute_variables) %}
+    if (compound_values.size() == {{ attribute_components|length }}) {
+        {% for n, attribute_variable in enumerate(attribute_components) %}
             {{attribute_name}}.{{attribute_variable.attribute_name}} = std::stof(compound_values[{{n}}]);
         {% endfor %}
     }
@@ -39,9 +39,9 @@ void xml_attribute_to_{{attribute_name}}(
         XMLWriterState* state,
         const {{class_name}}* value) {
         string output;
-        {% for n, attribute_variable in enumerate(attribute_variables) %}
+        {% for n, attribute_variable in enumerate(attribute_components) %}
             {% if attribute_variable.attribute_name in xml_bundled_components %}
-                {% if n == 0: %}
+                {% if n == 0 %}
                     output = to_string(value->{{attribute_variable.attribute_name}});
                 {% else %}
                     output = output + "," + to_string(value->{{attribute_variable.attribute_name}});
@@ -58,7 +58,7 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};
-    {% for attribute_variable in attribute_variables: %}
+    {% for attribute_variable in attribute_components %}
         {{attribute_name}}.{{attribute_variable.attribute_name}} = input.{{attribute_variable.protobuf_field}}();
     {% endfor %}
     *value = {{attribute_name}};
@@ -70,7 +70,7 @@ void {{attribute_name}}_to_proto(
     ProtoWriterState* state,
     std::function<void({{proto_field_cpp_type}}*)> setter) {
     {{proto_field_cpp_type}}* proto_{{attribute_name}} = new {{proto_field_cpp_type}}();
-    {% for attribute_variable in attribute_variables %}
+    {% for attribute_variable in attribute_components %}
         proto_{{attribute_name}}->set_{{attribute_variable.protobuf_field}}(value.{{attribute_variable.attribute_name}});
     {% endfor %}
     setter(proto_{{attribute_name}});

--- a/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
@@ -20,15 +20,15 @@ void xml_attribute_to_{{attribute_name}}(
     bool* is_set) {
     {{class_name}} {{attribute_name}};
     string normalized_value = normalize(get_attribute_value(input));
-    {% for n, attribute_variable in enumerate(attribute_components) %}
-        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+    {% for n, attribute_component in enumerate(attribute_components) %}
+        {% for i, value in enumerate(attribute_component.xml_fields) %}
             {% if i == 0 and n == 0 %}
                 if (normalized_value == "{{value}}") {
-                    {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
+                    {{attribute_name}} = {{class_name}}::{{attribute_component.attribute_name}};
                 }
             {% else %}
                 else if (normalized_value == "{{value}}") {
-                    {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
+                    {{attribute_name}} = {{class_name}}::{{attribute_component.attribute_name}};
                 }
             {% endif %}
         {% endfor %}
@@ -45,12 +45,12 @@ string {{attribute_name}}_to_xml_attribute(
     const std::string& attribute_name,
     XMLWriterState* state,
     const {{class_name}}* value) {
-    {% for n, attribute_variable in enumerate(attribute_components) %}
-        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+    {% for n, attribute_component in enumerate(attribute_components) %}
+        {% for i, value in enumerate(attribute_component.xml_fields) %}
             {%-if i == 0 and n == 0:%}
-                if (*value == {{class_name}}::{{attribute_variable.attribute_name}}) {
+                if (*value == {{class_name}}::{{attribute_component.attribute_name}}) {
             {% else %}
-                else if (*value == {{class_name}}::{{attribute_variable.attribute_name}}) {
+                else if (*value == {{class_name}}::{{attribute_component.attribute_name}}) {
             {%  endif %}
                 return " " + attribute_name + "=\"" + "{{value}}" + "\"";
             }
@@ -67,9 +67,9 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     switch (input) {
-        {% for attribute_variable in attribute_components %}
-            case {{proto_field_cpp_type}}::{{attribute_variable.attribute_name}}:
-                *value = {{class_name}}::{{attribute_variable.attribute_name}};
+        {% for attribute_component in attribute_components %}
+            case {{proto_field_cpp_type}}::{{attribute_component.attribute_name}}:
+                *value = {{class_name}}::{{attribute_component.attribute_name}};
                 *is_set = true;
                 break;
         {% endfor %}
@@ -85,9 +85,9 @@ void {{attribute_name}}_to_proto(
     ProtoWriterState* state,
     std::function<void({{proto_field_cpp_type}})> setter) {
     switch (value) {
-        {% for attribute_variable in attribute_components %}
-            case {{class_name}}::{{attribute_variable.attribute_name}}:
-                setter({{proto_field_cpp_type}}::{{attribute_variable.attribute_name}});
+        {% for attribute_component in attribute_components %}
+            case {{class_name}}::{{attribute_component.attribute_name}}:
+                setter({{proto_field_cpp_type}}::{{attribute_component.attribute_name}});
                 break;
         {% endfor %}
         default:

--- a/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
@@ -20,9 +20,9 @@ void xml_attribute_to_{{attribute_name}}(
     bool* is_set) {
     {{class_name}} {{attribute_name}};
     string normalized_value = normalize(get_attribute_value(input));
-    {% for n, attribute_variable in enumerate(attribute_variables) %}
+    {% for n, attribute_variable in enumerate(attribute_components) %}
         {% for i, value in enumerate(attribute_variable.xml_fields) %}
-            {% if i == 0 and n == 0: %}
+            {% if i == 0 and n == 0 %}
                 if (normalized_value == "{{value}}") {
                     {{attribute_name}} = {{class_name}}::{{attribute_variable.attribute_name}};
                 }
@@ -35,7 +35,7 @@ void xml_attribute_to_{{attribute_name}}(
     {% endfor %}
     else {
         errors->push_back(new XMLAttributeValueError("Found an invalid value that was not in the Enum {{class_name}}", input));
-        {{attribute_name}} = {{class_name}}::{{attribute_variables[0].attribute_name}};
+        {{attribute_name}} = {{class_name}}::{{attribute_components[0].attribute_name}};
     }
     *value = {{attribute_name}};
     *is_set = true;
@@ -45,7 +45,7 @@ string {{attribute_name}}_to_xml_attribute(
     const std::string& attribute_name,
     XMLWriterState* state,
     const {{class_name}}* value) {
-    {% for n, attribute_variable in enumerate(attribute_variables) %}
+    {% for n, attribute_variable in enumerate(attribute_components) %}
         {% for i, value in enumerate(attribute_variable.xml_fields) %}
             {%-if i == 0 and n == 0:%}
                 if (*value == {{class_name}}::{{attribute_variable.attribute_name}}) {
@@ -57,7 +57,7 @@ string {{attribute_name}}_to_xml_attribute(
         {%  endfor %}
     {%  endfor %}
     else {
-        return " " + attribute_name + "=\"" + "{{class_name}}::{{attribute_variables[0].xml_fields[0]}}" + "\"";
+        return " " + attribute_name + "=\"" + "{{class_name}}::{{attribute_components[0].xml_fields[0]}}" + "\"";
     }
 }
 
@@ -67,14 +67,14 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     switch (input) {
-        {% for attribute_variable in attribute_variables %}
+        {% for attribute_variable in attribute_components %}
             case {{proto_field_cpp_type}}::{{attribute_variable.attribute_name}}:
                 *value = {{class_name}}::{{attribute_variable.attribute_name}};
                 *is_set = true;
                 break;
         {% endfor %}
         default:
-            *value = {{class_name}}::{{attribute_variables[0].attribute_name}};
+            *value = {{class_name}}::{{attribute_components[0].attribute_name}};
             *is_set = true;
             break;
     }
@@ -85,13 +85,13 @@ void {{attribute_name}}_to_proto(
     ProtoWriterState* state,
     std::function<void({{proto_field_cpp_type}})> setter) {
     switch (value) {
-        {% for attribute_variable in attribute_variables %}
+        {% for attribute_variable in attribute_components %}
             case {{class_name}}::{{attribute_variable.attribute_name}}:
                 setter({{proto_field_cpp_type}}::{{attribute_variable.attribute_name}});
                 break;
         {% endfor %}
         default:
-            setter({{proto_field_cpp_type}}::{{attribute_variables[0].attribute_name}});
+            setter({{proto_field_cpp_type}}::{{attribute_components[0].attribute_name}});
             break;
     }
 }

--- a/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
@@ -21,21 +21,21 @@ void xml_attribute_to_{{attribute_name}}(
     {{class_name}} {{attribute_name}};
     vector<string> flag_values;
     flag_values = split(get_attribute_value(input), ",");
-    {% for attribute_variable in attribute_components %}
-        {{attribute_name}}.{{attribute_variable.attribute_name}} = false;
+    {% for attribute_component in attribute_components %}
+        {{attribute_name}}.{{attribute_component.attribute_name}} = false;
     {% endfor %}
 
     for (string flag_value : flag_values) {
         string normalized_flag_value = normalize(flag_value);
-        {% for n, attribute_variable in enumerate(attribute_components) %}
-            {% for i, value in enumerate(attribute_variable.xml_fields) %}
+        {% for n, attribute_component in enumerate(attribute_components) %}
+            {% for i, value in enumerate(attribute_component.xml_fields) %}
                 {% if i == 0 and n == 0 %}
                     if (normalized_flag_value == "{{value}}") {
-                        {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
+                        {{attribute_name}}.{{attribute_component.attribute_name}} = true;
                     }
                 {% else %}
                     else if (normalized_flag_value == "{{value}}") {
-                        {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
+                        {{attribute_name}}.{{attribute_component.attribute_name}} = true;
                     }
                 {% endif %}
             {%- endfor %}
@@ -54,9 +54,9 @@ string {{attribute_name}}_to_xml_attribute(
     XMLWriterState* state,
     const {{class_name}}* value) {
     vector<string> flag_values;
-    {% for n, attribute_variable in enumerate(attribute_components) %}
-        if (value->{{attribute_variable.attribute_name}} == true) {
-            flag_values.push_back("{{attribute_variable.xml_fields[0]}}");
+    {% for n, attribute_component in enumerate(attribute_components) %}
+        if (value->{{attribute_component.attribute_name}} == true) {
+            flag_values.push_back("{{attribute_component.xml_fields[0]}}");
         }
     {% endfor %}
     string output = join(flag_values, ",");
@@ -69,8 +69,8 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};
-    {% for n, attribute_variable in enumerate(attribute_components) %}
-        {{attribute_name}}.{{attribute_variable.attribute_name}} = input.{{attribute_variable.attribute_name}}();
+    {% for n, attribute_component in enumerate(attribute_components) %}
+        {{attribute_name}}.{{attribute_component.attribute_name}} = input.{{attribute_component.attribute_name}}();
     {% endfor %}
     *value = {{attribute_name}};
     *is_set = true;
@@ -82,9 +82,9 @@ void {{attribute_name}}_to_proto(
     std::function<void({{proto_field_cpp_type}}*)> setter) {
     {{proto_field_cpp_type}}* proto_{{attribute_name}} = new {{proto_field_cpp_type}}();
     bool should_write = false;
-    {% for n, attribute_variable in enumerate(attribute_components) %}
-        proto_{{attribute_name}}->set_{{attribute_variable.attribute_name}}(value.{{attribute_variable.attribute_name}});
-        should_write |= value.{{attribute_variable.attribute_name}};
+    {% for n, attribute_component in enumerate(attribute_components) %}
+        proto_{{attribute_name}}->set_{{attribute_component.attribute_name}}(value.{{attribute_component.attribute_name}});
+        should_write |= value.{{attribute_component.attribute_name}};
     {% endfor %}
     if (should_write) {
         setter(proto_{{attribute_name}});

--- a/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
@@ -21,19 +21,19 @@ void xml_attribute_to_{{attribute_name}}(
     {{class_name}} {{attribute_name}};
     vector<string> flag_values;
     flag_values = split(get_attribute_value(input), ",");
-    {% for attribute_variable in attribute_variables %}
+    {% for attribute_variable in attribute_components %}
         {{attribute_name}}.{{attribute_variable.attribute_name}} = false;
     {% endfor %}
 
     for (string flag_value : flag_values) {
         string normalized_flag_value = normalize(flag_value);
-        {% for n, attribute_variable in enumerate(attribute_variables) %}
+        {% for n, attribute_variable in enumerate(attribute_components) %}
             {% for i, value in enumerate(attribute_variable.xml_fields) %}
-                {% if i == 0 and n == 0: %}
+                {% if i == 0 and n == 0 %}
                     if (normalized_flag_value == "{{value}}") {
                         {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
                     }
-                {% else: %}
+                {% else %}
                     else if (normalized_flag_value == "{{value}}") {
                         {{attribute_name}}.{{attribute_variable.attribute_name}} = true;
                     }
@@ -54,7 +54,7 @@ string {{attribute_name}}_to_xml_attribute(
     XMLWriterState* state,
     const {{class_name}}* value) {
     vector<string> flag_values;
-    {% for n, attribute_variable in enumerate(attribute_variables)%}
+    {% for n, attribute_variable in enumerate(attribute_components) %}
         if (value->{{attribute_variable.attribute_name}} == true) {
             flag_values.push_back("{{attribute_variable.xml_fields[0]}}");
         }
@@ -69,7 +69,7 @@ void proto_to_{{attribute_name}}(
     {{class_name}}* value,
     bool* is_set) {
     {{class_name}} {{attribute_name}};
-    {% for n, attribute_variable in enumerate(attribute_variables)%}
+    {% for n, attribute_variable in enumerate(attribute_components) %}
         {{attribute_name}}.{{attribute_variable.attribute_name}} = input.{{attribute_variable.attribute_name}}();
     {% endfor %}
     *value = {{attribute_name}};
@@ -82,7 +82,7 @@ void {{attribute_name}}_to_proto(
     std::function<void({{proto_field_cpp_type}}*)> setter) {
     {{proto_field_cpp_type}}* proto_{{attribute_name}} = new {{proto_field_cpp_type}}();
     bool should_write = false;
-    {% for n, attribute_variable in enumerate(attribute_variables)%}
+    {% for n, attribute_variable in enumerate(attribute_components) %}
         proto_{{attribute_name}}->set_{{attribute_variable.attribute_name}}(value.{{attribute_variable.attribute_name}});
         should_write |= value.{{attribute_variable.attribute_name}};
     {% endfor %}

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -461,9 +461,9 @@ def write_attribute(output_directory: str, data: Dict[str, Document]) -> List[st
         protobuf_field: str
         _, _, protobuf_field = split_field_into_drilldown(metadata[filepath]["protobuf_field"])
 
-        xml_fields: List[str] = []
         if metadata[filepath]['type'] == "MultiflagValue":
             for flag in metadata[filepath]['flags']:
+                xml_fields = []
                 for item in metadata[filepath]['flags'][flag]:
                     xml_fields.append(normalize(item))
                 attribute_component = AttributeComponent(
@@ -476,6 +476,7 @@ def write_attribute(output_directory: str, data: Dict[str, Document]) -> List[st
 
         elif metadata[filepath]['type'] == "CompoundValue":
             for component in metadata[filepath]['components']:
+                xml_fields = []
                 if component['type'] not in documentation_type_data:
                     raise ValueError("Unexpected type for component. Look at markdown file {attribute_name}".format(
                         attribute_name=attribute_name
@@ -495,6 +496,7 @@ def write_attribute(output_directory: str, data: Dict[str, Document]) -> List[st
 
         elif metadata[filepath]['type'] == "Enum":
             for value in metadata[filepath]['values']:
+                xml_fields = []
                 for item in metadata[filepath]['values'][value]:
                     xml_fields.append(normalize(item))
                 attribute_component = AttributeComponent(

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -529,7 +529,7 @@ def write_attribute(output_directory: str, data: Dict[str, Document]) -> List[st
             cpp_filepath,
             template[metadata[filepath]['type']].render(
                 attribute_name=attribute_name,
-                # TODO: Should this attribute_variables list be sorted? The hpp one is.
+                # TODO: Should this attribute_components list be sorted? The hpp one is.
                 attribute_components=attribute_components,
                 class_name=capitalize(attribute_name, delimiter=""),
                 enumerate=enumerate,


### PR DESCRIPTION
We were using the dataclass AttributeVariable very wrongly, this cleans that up by creating a new minimal dataclass for the fields we need to pass into the attribute classes. Additionally cleans up a few other things associated with the code that needed to be changed.