### PR TITLE
Missing "name" segfault fix

### DIFF
--- a/xml_converter/integration_tests/test_cases/category_name_invalid/input/pack/xml_file.xml
+++ b/xml_converter/integration_tests/test_cases/category_name_invalid/input/pack/xml_file.xml
@@ -1,0 +1,4 @@
+<OverlayData>
+    <MarkerCategory DisplayName="My Missing Category" />
+    <MarkerCategory DisplayName="My Empty Category" Name="" />
+</OverlayData>

--- a/xml_converter/integration_tests/test_cases/category_name_invalid/output_xml/xml_file.xml
+++ b/xml_converter/integration_tests/test_cases/category_name_invalid/output_xml/xml_file.xml
@@ -1,0 +1,10 @@
+<OverlayData>
+<MarkerCategory  DisplayName="My Missing Category">
+</MarkerCategory>
+
+<MarkerCategory  DisplayName="My Empty Category" Name="">
+</MarkerCategory>
+
+<POIs>
+</POIs>
+</OverlayData>

--- a/xml_converter/integration_tests/test_cases/category_name_invalid/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/category_name_invalid/testcase.yaml
@@ -1,0 +1,13 @@
+input_paths: 
+    "pack": "xml"
+expected_stdout: |
+    Error: Category attribute 'name' is missing or is an empty string when it should be a non-empty string
+    test_cases/category_name_invalid/input/pack/xml_file.xml
+    2 |    <MarkerCategory DisplayName="My Missing Category" />
+      |     ^^^^^^^^^^^^^^
+    Error: Category attribute 'name' is missing or is an empty string when it should be a non-empty string
+    test_cases/category_name_invalid/input/pack/xml_file.xml
+    3 |    <MarkerCategory DisplayName="My Empty Category" Name="" />
+      |     ^^^^^^^^^^^^^^
+expected_stderr: |
+expected_returncode: 0

--- a/xml_converter/src/packaging_xml.cpp
+++ b/xml_converter/src/packaging_xml.cpp
@@ -13,14 +13,26 @@ using namespace std;
 ////////////////////////////////// SERIALIZE ///////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
+unsigned int UNKNOWN_CATEGORY_COUNTER = 0;
 void parse_marker_categories(rapidxml::xml_node<>* node, map<string, Category>* marker_categories, vector<XMLError*>* errors, string base_dir, int depth = 0) {
     if (get_node_name(node) == "MarkerCategory") {
+        // TODO: Eventually this process should be removed. Instead we should be
+        //       grabbing the name during the parsing of all the atrributes to
+        //       avoid doing a secondary search through the attributes, and then
+        //       we should have a method of applying the parsed node on top of
+        //       its hirearchy probably using the is_set flags.
         string name = lowercase(find_attribute_value(node, "name"));
 
         XMLReaderState state = {
             base_dir,
             marker_categories,
         };
+
+        if (name == "") {
+            errors->push_back(new XMLNodeNameError("Category attribute 'name' is missing or is an empty string when it should be a non-empty string", node));
+            name = "UNKNOWN_CATEGORY_" + to_string(UNKNOWN_CATEGORY_COUNTER);
+            UNKNOWN_CATEGORY_COUNTER++;
+        }
 
         Category* this_category = &(*marker_categories)[name];
         this_category->init_from_xml(node, errors, &state);

--- a/xml_converter/src/rapid_helpers.cpp
+++ b/xml_converter/src/rapid_helpers.cpp
@@ -9,8 +9,20 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// find_attribute_value (depricated)
+//
+// This function does a linear search over an xml node to try and find an
+// attribute with the specified name. It the attribute is not found then an
+// empty string is returned.
+//
+// This function is depricated and should not be used by any new code.
+////////////////////////////////////////////////////////////////////////////////
 string find_attribute_value(rapidxml::xml_node<>* node, string attribute_name) {
-    auto attribute = node->first_attribute(attribute_name.data(), attribute_name.size(), false);
+    rapidxml::xml_attribute<char>* attribute = node->first_attribute(attribute_name.data(), attribute_name.size(), false);
+    if (attribute == nullptr) {
+        return "";
+    }
 
     return string(attribute->value(), attribute->value_size());
 }


### PR DESCRIPTION
If a MarkerCategory is missing the `name` attribute xml_converter would segfault on that field. Now an error is logged to the error list instead and does not crash.