### PR TITLE
Parseable Overlays

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -17,7 +17,7 @@ using namespace std;
 string {{cpp_class}}::classname() {
     return "{{xml_class_name}}";
 }
-{% if cpp_class == "Category": %}
+{% if cpp_class == "Category" %}
     void {{cpp_class}}::init_from_xml(rapidxml::xml_node<>* node, vector<XMLError*>* errors, XMLReaderState* state) {
         for (rapidxml::xml_attribute<>* attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute()) {
             bool is_icon_value = this->default_icon.init_xml_attribute(attribute, errors, state);
@@ -69,7 +69,7 @@ vector<string> {{cpp_class}}::as_xml(XMLWriterState* state) const {
             }
         {% endif %}
     {% endfor %}
-    {% if cpp_class == "Category": %}
+    {% if cpp_class == "Category" %}
         xml_node_contents.push_back(">\n");
 
         for (const auto& [key, val] : this->children) {
@@ -121,7 +121,6 @@ void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_hea
     {% endfor %}
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // apply_underlay
 //
@@ -137,8 +136,8 @@ void {{cpp_class}}::apply_underlay(const {{cpp_class}}& underlay) {
             }
         {% endif %}
     {% endfor %}
+    {% if cpp_class == "Category" %}
 
-    {% if cpp_class == "Category": %}
         this->default_icon.apply_underlay(underlay.default_icon);
         this->default_trail.apply_underlay(underlay.default_trail);
     {% endif %}
@@ -159,10 +158,9 @@ void {{cpp_class}}::apply_overlay(const {{cpp_class}}& overlay) {
             }
         {% endif %}
     {% endfor %}
+    {% if cpp_class == "Category" %}
 
-    {% if cpp_class == "Category": %}
         this->default_icon.apply_overlay(overlay.default_icon);
         this->default_trail.apply_overlay(overlay.default_trail);
     {% endif %}
 }
-

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -120,3 +120,49 @@ void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_hea
         {% endif %}
     {% endfor %}
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_underlay
+//
+// Transforms this {{cpp_class}} as if this class was overlayed on top of the
+// underlay argument.
+////////////////////////////////////////////////////////////////////////////////
+void {{cpp_class}}::apply_underlay(const {{cpp_class}}& underlay) {
+    {% for attribute_variable in attribute_variables %}
+        {% if attribute_variable.is_component == false %}
+            if (!this->{{attribute_variable.attribute_flag_name}} && underlay.{{attribute_variable.attribute_flag_name}}) {
+                this->{{attribute_variable.attribute_name}} = underlay.{{attribute_variable.attribute_name}};
+                this->{{attribute_variable.attribute_flag_name}} = true;
+            }
+        {% endif %}
+    {% endfor %}
+
+    {% if cpp_class == "Category": %}
+        this->default_icon.apply_underlay(underlay.default_icon);
+        this->default_trail.apply_underlay(underlay.default_trail);
+    {% endif %}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_overlay
+//
+// Transforms this {{cpp_class}} as if the overlay argument were overlayed on
+// top of this class.
+////////////////////////////////////////////////////////////////////////////////
+void {{cpp_class}}::apply_overlay(const {{cpp_class}}& overlay) {
+    {% for attribute_variable in attribute_variables %}
+        {% if attribute_variable.is_component == false %}
+            if (overlay.{{attribute_variable.attribute_flag_name}}) {
+                this->{{attribute_variable.attribute_name}} = overlay.{{attribute_variable.attribute_name}};
+                this->{{attribute_variable.attribute_flag_name}} = true;
+            }
+        {% endif %}
+    {% endfor %}
+
+    {% if cpp_class == "Category": %}
+        this->default_icon.apply_overlay(overlay.default_icon);
+        this->default_trail.apply_overlay(overlay.default_trail);
+    {% endif %}
+}
+

--- a/xml_converter/generators/cpp_templates/class_template.hpp
+++ b/xml_converter/generators/cpp_templates/class_template.hpp
@@ -39,4 +39,6 @@ class {{cpp_class}} : public Parseable {
     {% if attributes_of_type_marker_category %}
         bool validate_attributes_of_type_marker_category();
     {% endif %}
+    void apply_underlay(const {{cpp_class}}& underlay);
+    void apply_overlay(const {{cpp_class}}& overlay);
 };

--- a/xml_converter/integration_tests/test_cases/category_name_invalid/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/category_name_invalid/testcase.yaml
@@ -1,11 +1,11 @@
 input_paths: 
     "pack": "xml"
 expected_stdout: |
-    Error: Category attribute 'name' is missing or is an empty string when it should be a non-empty string
+    Error: Category attribute 'name' is missing so it cannot be properly referenced
     test_cases/category_name_invalid/input/pack/xml_file.xml
     2 |    <MarkerCategory DisplayName="My Missing Category" />
       |     ^^^^^^^^^^^^^^
-    Error: Category attribute 'name' is missing or is an empty string when it should be a non-empty string
+    Error: Category attribute 'name' is an empty string so it cannot be properly referenced
     test_cases/category_name_invalid/input/pack/xml_file.xml
     3 |    <MarkerCategory DisplayName="My Empty Category" Name="" />
       |     ^^^^^^^^^^^^^^

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -133,7 +133,6 @@ void Category::parse_protobuf(waypoint::Category proto_category, ProtoReaderStat
     }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // apply_underlay
 //
@@ -197,4 +196,3 @@ void Category::apply_overlay(const Category& overlay) {
     this->default_icon.apply_overlay(overlay.default_icon);
     this->default_trail.apply_overlay(overlay.default_trail);
 }
-

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -132,3 +132,69 @@ void Category::parse_protobuf(waypoint::Category proto_category, ProtoReaderStat
         proto_to_string(proto_category.tip_description(), state, &(this->tooltip_description), &(this->tooltip_description_is_set));
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_underlay
+//
+// Transforms this Category as if this class was overlayed on top of the
+// underlay argument.
+////////////////////////////////////////////////////////////////////////////////
+void Category::apply_underlay(const Category& underlay) {
+    if (!this->default_visibility_is_set && underlay.default_visibility_is_set) {
+        this->default_visibility = underlay.default_visibility;
+        this->default_visibility_is_set = true;
+    }
+    if (!this->display_name_is_set && underlay.display_name_is_set) {
+        this->display_name = underlay.display_name;
+        this->display_name_is_set = true;
+    }
+    if (!this->is_separator_is_set && underlay.is_separator_is_set) {
+        this->is_separator = underlay.is_separator;
+        this->is_separator_is_set = true;
+    }
+    if (!this->name_is_set && underlay.name_is_set) {
+        this->name = underlay.name;
+        this->name_is_set = true;
+    }
+    if (!this->tooltip_description_is_set && underlay.tooltip_description_is_set) {
+        this->tooltip_description = underlay.tooltip_description;
+        this->tooltip_description_is_set = true;
+    }
+
+    this->default_icon.apply_underlay(underlay.default_icon);
+    this->default_trail.apply_underlay(underlay.default_trail);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_overlay
+//
+// Transforms this Category as if the overlay argument were overlayed on
+// top of this class.
+////////////////////////////////////////////////////////////////////////////////
+void Category::apply_overlay(const Category& overlay) {
+    if (overlay.default_visibility_is_set) {
+        this->default_visibility = overlay.default_visibility;
+        this->default_visibility_is_set = true;
+    }
+    if (overlay.display_name_is_set) {
+        this->display_name = overlay.display_name;
+        this->display_name_is_set = true;
+    }
+    if (overlay.is_separator_is_set) {
+        this->is_separator = overlay.is_separator;
+        this->is_separator_is_set = true;
+    }
+    if (overlay.name_is_set) {
+        this->name = overlay.name;
+        this->name_is_set = true;
+    }
+    if (overlay.tooltip_description_is_set) {
+        this->tooltip_description = overlay.tooltip_description;
+        this->tooltip_description_is_set = true;
+    }
+
+    this->default_icon.apply_overlay(overlay.default_icon);
+    this->default_trail.apply_overlay(overlay.default_trail);
+}
+

--- a/xml_converter/src/category_gen.hpp
+++ b/xml_converter/src/category_gen.hpp
@@ -36,4 +36,6 @@ class Category : public Parseable {
     bool init_xml_attribute(rapidxml::xml_attribute<>* attribute, std::vector<XMLError*>* errors, XMLReaderState* state);
     waypoint::Category as_protobuf(ProtoWriterState* state) const;
     void parse_protobuf(waypoint::Category proto_category, ProtoReaderState* state);
+    void apply_underlay(const Category& underlay);
+    void apply_overlay(const Category& overlay);
 };

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -743,7 +743,6 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state) {
     }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // apply_underlay
 //
@@ -939,7 +938,6 @@ void Icon::apply_underlay(const Icon& underlay) {
         this->trigger_range = underlay.trigger_range;
         this->trigger_range_is_set = true;
     }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1137,6 +1135,4 @@ void Icon::apply_overlay(const Icon& overlay) {
         this->trigger_range = overlay.trigger_range;
         this->trigger_range_is_set = true;
     }
-
 }
-

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -742,3 +742,401 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state) {
         proto_to_float(proto_icon.trigger().range(), state, &(this->trigger_range), &(this->trigger_range_is_set));
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_underlay
+//
+// Transforms this Icon as if this class was overlayed on top of the
+// underlay argument.
+////////////////////////////////////////////////////////////////////////////////
+void Icon::apply_underlay(const Icon& underlay) {
+    if (!this->achievement_bitmask_is_set && underlay.achievement_bitmask_is_set) {
+        this->achievement_bitmask = underlay.achievement_bitmask;
+        this->achievement_bitmask_is_set = true;
+    }
+    if (!this->achievement_id_is_set && underlay.achievement_id_is_set) {
+        this->achievement_id = underlay.achievement_id;
+        this->achievement_id_is_set = true;
+    }
+    if (!this->auto_trigger_is_set && underlay.auto_trigger_is_set) {
+        this->auto_trigger = underlay.auto_trigger;
+        this->auto_trigger_is_set = true;
+    }
+    if (!this->bounce_delay_is_set && underlay.bounce_delay_is_set) {
+        this->bounce_delay = underlay.bounce_delay;
+        this->bounce_delay_is_set = true;
+    }
+    if (!this->bounce_duration_is_set && underlay.bounce_duration_is_set) {
+        this->bounce_duration = underlay.bounce_duration;
+        this->bounce_duration_is_set = true;
+    }
+    if (!this->bounce_height_is_set && underlay.bounce_height_is_set) {
+        this->bounce_height = underlay.bounce_height;
+        this->bounce_height_is_set = true;
+    }
+    if (!this->category_is_set && underlay.category_is_set) {
+        this->category = underlay.category;
+        this->category_is_set = true;
+    }
+    if (!this->color_is_set && underlay.color_is_set) {
+        this->color = underlay.color;
+        this->color_is_set = true;
+    }
+    if (!this->copy_clipboard_is_set && underlay.copy_clipboard_is_set) {
+        this->copy_clipboard = underlay.copy_clipboard;
+        this->copy_clipboard_is_set = true;
+    }
+    if (!this->copy_message_is_set && underlay.copy_message_is_set) {
+        this->copy_message = underlay.copy_message;
+        this->copy_message_is_set = true;
+    }
+    if (!this->cull_chirality_is_set && underlay.cull_chirality_is_set) {
+        this->cull_chirality = underlay.cull_chirality;
+        this->cull_chirality_is_set = true;
+    }
+    if (!this->disable_player_cutout_is_set && underlay.disable_player_cutout_is_set) {
+        this->disable_player_cutout = underlay.disable_player_cutout;
+        this->disable_player_cutout_is_set = true;
+    }
+    if (!this->distance_fade_end_is_set && underlay.distance_fade_end_is_set) {
+        this->distance_fade_end = underlay.distance_fade_end;
+        this->distance_fade_end_is_set = true;
+    }
+    if (!this->distance_fade_start_is_set && underlay.distance_fade_start_is_set) {
+        this->distance_fade_start = underlay.distance_fade_start;
+        this->distance_fade_start_is_set = true;
+    }
+    if (!this->euler_rotation_is_set && underlay.euler_rotation_is_set) {
+        this->euler_rotation = underlay.euler_rotation;
+        this->euler_rotation_is_set = true;
+    }
+    if (!this->festival_filter_is_set && underlay.festival_filter_is_set) {
+        this->festival_filter = underlay.festival_filter;
+        this->festival_filter_is_set = true;
+    }
+    if (!this->guid_is_set && underlay.guid_is_set) {
+        this->guid = underlay.guid;
+        this->guid_is_set = true;
+    }
+    if (!this->has_countdown_is_set && underlay.has_countdown_is_set) {
+        this->has_countdown = underlay.has_countdown;
+        this->has_countdown_is_set = true;
+    }
+    if (!this->height_offset_is_set && underlay.height_offset_is_set) {
+        this->height_offset = underlay.height_offset;
+        this->height_offset_is_set = true;
+    }
+    if (!this->hide_category_is_set && underlay.hide_category_is_set) {
+        this->hide_category = underlay.hide_category;
+        this->hide_category_is_set = true;
+    }
+    if (!this->icon_is_set && underlay.icon_is_set) {
+        this->icon = underlay.icon;
+        this->icon_is_set = true;
+    }
+    if (!this->icon_size_is_set && underlay.icon_size_is_set) {
+        this->icon_size = underlay.icon_size;
+        this->icon_size_is_set = true;
+    }
+    if (!this->info_message_is_set && underlay.info_message_is_set) {
+        this->info_message = underlay.info_message;
+        this->info_message_is_set = true;
+    }
+    if (!this->invert_visibility_is_set && underlay.invert_visibility_is_set) {
+        this->invert_visibility = underlay.invert_visibility;
+        this->invert_visibility_is_set = true;
+    }
+    if (!this->map_display_size_is_set && underlay.map_display_size_is_set) {
+        this->map_display_size = underlay.map_display_size;
+        this->map_display_size_is_set = true;
+    }
+    if (!this->map_id_is_set && underlay.map_id_is_set) {
+        this->map_id = underlay.map_id;
+        this->map_id_is_set = true;
+    }
+    if (!this->map_type_filter_is_set && underlay.map_type_filter_is_set) {
+        this->map_type_filter = underlay.map_type_filter;
+        this->map_type_filter_is_set = true;
+    }
+    if (!this->maximum_size_on_screen_is_set && underlay.maximum_size_on_screen_is_set) {
+        this->maximum_size_on_screen = underlay.maximum_size_on_screen;
+        this->maximum_size_on_screen_is_set = true;
+    }
+    if (!this->minimum_size_on_screen_is_set && underlay.minimum_size_on_screen_is_set) {
+        this->minimum_size_on_screen = underlay.minimum_size_on_screen;
+        this->minimum_size_on_screen_is_set = true;
+    }
+    if (!this->mount_filter_is_set && underlay.mount_filter_is_set) {
+        this->mount_filter = underlay.mount_filter;
+        this->mount_filter_is_set = true;
+    }
+    if (!this->position_is_set && underlay.position_is_set) {
+        this->position = underlay.position;
+        this->position_is_set = true;
+    }
+    if (!this->profession_filter_is_set && underlay.profession_filter_is_set) {
+        this->profession_filter = underlay.profession_filter;
+        this->profession_filter_is_set = true;
+    }
+    if (!this->render_ingame_is_set && underlay.render_ingame_is_set) {
+        this->render_ingame = underlay.render_ingame;
+        this->render_ingame_is_set = true;
+    }
+    if (!this->render_on_map_is_set && underlay.render_on_map_is_set) {
+        this->render_on_map = underlay.render_on_map;
+        this->render_on_map_is_set = true;
+    }
+    if (!this->render_on_minimap_is_set && underlay.render_on_minimap_is_set) {
+        this->render_on_minimap = underlay.render_on_minimap;
+        this->render_on_minimap_is_set = true;
+    }
+    if (!this->reset_behavior_is_set && underlay.reset_behavior_is_set) {
+        this->reset_behavior = underlay.reset_behavior;
+        this->reset_behavior_is_set = true;
+    }
+    if (!this->reset_length_is_set && underlay.reset_length_is_set) {
+        this->reset_length = underlay.reset_length;
+        this->reset_length_is_set = true;
+    }
+    if (!this->scale_on_map_with_zoom_is_set && underlay.scale_on_map_with_zoom_is_set) {
+        this->scale_on_map_with_zoom = underlay.scale_on_map_with_zoom;
+        this->scale_on_map_with_zoom_is_set = true;
+    }
+    if (!this->schedule_is_set && underlay.schedule_is_set) {
+        this->schedule = underlay.schedule;
+        this->schedule_is_set = true;
+    }
+    if (!this->schedule_duration_is_set && underlay.schedule_duration_is_set) {
+        this->schedule_duration = underlay.schedule_duration;
+        this->schedule_duration_is_set = true;
+    }
+    if (!this->show_category_is_set && underlay.show_category_is_set) {
+        this->show_category = underlay.show_category;
+        this->show_category_is_set = true;
+    }
+    if (!this->specialization_filter_is_set && underlay.specialization_filter_is_set) {
+        this->specialization_filter = underlay.specialization_filter;
+        this->specialization_filter_is_set = true;
+    }
+    if (!this->species_filter_is_set && underlay.species_filter_is_set) {
+        this->species_filter = underlay.species_filter;
+        this->species_filter_is_set = true;
+    }
+    if (!this->toggle_category_is_set && underlay.toggle_category_is_set) {
+        this->toggle_category = underlay.toggle_category;
+        this->toggle_category_is_set = true;
+    }
+    if (!this->tooltip_description_is_set && underlay.tooltip_description_is_set) {
+        this->tooltip_description = underlay.tooltip_description;
+        this->tooltip_description_is_set = true;
+    }
+    if (!this->tooltip_name_is_set && underlay.tooltip_name_is_set) {
+        this->tooltip_name = underlay.tooltip_name;
+        this->tooltip_name_is_set = true;
+    }
+    if (!this->trigger_range_is_set && underlay.trigger_range_is_set) {
+        this->trigger_range = underlay.trigger_range;
+        this->trigger_range_is_set = true;
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_overlay
+//
+// Transforms this Icon as if the overlay argument were overlayed on
+// top of this class.
+////////////////////////////////////////////////////////////////////////////////
+void Icon::apply_overlay(const Icon& overlay) {
+    if (overlay.achievement_bitmask_is_set) {
+        this->achievement_bitmask = overlay.achievement_bitmask;
+        this->achievement_bitmask_is_set = true;
+    }
+    if (overlay.achievement_id_is_set) {
+        this->achievement_id = overlay.achievement_id;
+        this->achievement_id_is_set = true;
+    }
+    if (overlay.auto_trigger_is_set) {
+        this->auto_trigger = overlay.auto_trigger;
+        this->auto_trigger_is_set = true;
+    }
+    if (overlay.bounce_delay_is_set) {
+        this->bounce_delay = overlay.bounce_delay;
+        this->bounce_delay_is_set = true;
+    }
+    if (overlay.bounce_duration_is_set) {
+        this->bounce_duration = overlay.bounce_duration;
+        this->bounce_duration_is_set = true;
+    }
+    if (overlay.bounce_height_is_set) {
+        this->bounce_height = overlay.bounce_height;
+        this->bounce_height_is_set = true;
+    }
+    if (overlay.category_is_set) {
+        this->category = overlay.category;
+        this->category_is_set = true;
+    }
+    if (overlay.color_is_set) {
+        this->color = overlay.color;
+        this->color_is_set = true;
+    }
+    if (overlay.copy_clipboard_is_set) {
+        this->copy_clipboard = overlay.copy_clipboard;
+        this->copy_clipboard_is_set = true;
+    }
+    if (overlay.copy_message_is_set) {
+        this->copy_message = overlay.copy_message;
+        this->copy_message_is_set = true;
+    }
+    if (overlay.cull_chirality_is_set) {
+        this->cull_chirality = overlay.cull_chirality;
+        this->cull_chirality_is_set = true;
+    }
+    if (overlay.disable_player_cutout_is_set) {
+        this->disable_player_cutout = overlay.disable_player_cutout;
+        this->disable_player_cutout_is_set = true;
+    }
+    if (overlay.distance_fade_end_is_set) {
+        this->distance_fade_end = overlay.distance_fade_end;
+        this->distance_fade_end_is_set = true;
+    }
+    if (overlay.distance_fade_start_is_set) {
+        this->distance_fade_start = overlay.distance_fade_start;
+        this->distance_fade_start_is_set = true;
+    }
+    if (overlay.euler_rotation_is_set) {
+        this->euler_rotation = overlay.euler_rotation;
+        this->euler_rotation_is_set = true;
+    }
+    if (overlay.festival_filter_is_set) {
+        this->festival_filter = overlay.festival_filter;
+        this->festival_filter_is_set = true;
+    }
+    if (overlay.guid_is_set) {
+        this->guid = overlay.guid;
+        this->guid_is_set = true;
+    }
+    if (overlay.has_countdown_is_set) {
+        this->has_countdown = overlay.has_countdown;
+        this->has_countdown_is_set = true;
+    }
+    if (overlay.height_offset_is_set) {
+        this->height_offset = overlay.height_offset;
+        this->height_offset_is_set = true;
+    }
+    if (overlay.hide_category_is_set) {
+        this->hide_category = overlay.hide_category;
+        this->hide_category_is_set = true;
+    }
+    if (overlay.icon_is_set) {
+        this->icon = overlay.icon;
+        this->icon_is_set = true;
+    }
+    if (overlay.icon_size_is_set) {
+        this->icon_size = overlay.icon_size;
+        this->icon_size_is_set = true;
+    }
+    if (overlay.info_message_is_set) {
+        this->info_message = overlay.info_message;
+        this->info_message_is_set = true;
+    }
+    if (overlay.invert_visibility_is_set) {
+        this->invert_visibility = overlay.invert_visibility;
+        this->invert_visibility_is_set = true;
+    }
+    if (overlay.map_display_size_is_set) {
+        this->map_display_size = overlay.map_display_size;
+        this->map_display_size_is_set = true;
+    }
+    if (overlay.map_id_is_set) {
+        this->map_id = overlay.map_id;
+        this->map_id_is_set = true;
+    }
+    if (overlay.map_type_filter_is_set) {
+        this->map_type_filter = overlay.map_type_filter;
+        this->map_type_filter_is_set = true;
+    }
+    if (overlay.maximum_size_on_screen_is_set) {
+        this->maximum_size_on_screen = overlay.maximum_size_on_screen;
+        this->maximum_size_on_screen_is_set = true;
+    }
+    if (overlay.minimum_size_on_screen_is_set) {
+        this->minimum_size_on_screen = overlay.minimum_size_on_screen;
+        this->minimum_size_on_screen_is_set = true;
+    }
+    if (overlay.mount_filter_is_set) {
+        this->mount_filter = overlay.mount_filter;
+        this->mount_filter_is_set = true;
+    }
+    if (overlay.position_is_set) {
+        this->position = overlay.position;
+        this->position_is_set = true;
+    }
+    if (overlay.profession_filter_is_set) {
+        this->profession_filter = overlay.profession_filter;
+        this->profession_filter_is_set = true;
+    }
+    if (overlay.render_ingame_is_set) {
+        this->render_ingame = overlay.render_ingame;
+        this->render_ingame_is_set = true;
+    }
+    if (overlay.render_on_map_is_set) {
+        this->render_on_map = overlay.render_on_map;
+        this->render_on_map_is_set = true;
+    }
+    if (overlay.render_on_minimap_is_set) {
+        this->render_on_minimap = overlay.render_on_minimap;
+        this->render_on_minimap_is_set = true;
+    }
+    if (overlay.reset_behavior_is_set) {
+        this->reset_behavior = overlay.reset_behavior;
+        this->reset_behavior_is_set = true;
+    }
+    if (overlay.reset_length_is_set) {
+        this->reset_length = overlay.reset_length;
+        this->reset_length_is_set = true;
+    }
+    if (overlay.scale_on_map_with_zoom_is_set) {
+        this->scale_on_map_with_zoom = overlay.scale_on_map_with_zoom;
+        this->scale_on_map_with_zoom_is_set = true;
+    }
+    if (overlay.schedule_is_set) {
+        this->schedule = overlay.schedule;
+        this->schedule_is_set = true;
+    }
+    if (overlay.schedule_duration_is_set) {
+        this->schedule_duration = overlay.schedule_duration;
+        this->schedule_duration_is_set = true;
+    }
+    if (overlay.show_category_is_set) {
+        this->show_category = overlay.show_category;
+        this->show_category_is_set = true;
+    }
+    if (overlay.specialization_filter_is_set) {
+        this->specialization_filter = overlay.specialization_filter;
+        this->specialization_filter_is_set = true;
+    }
+    if (overlay.species_filter_is_set) {
+        this->species_filter = overlay.species_filter;
+        this->species_filter_is_set = true;
+    }
+    if (overlay.toggle_category_is_set) {
+        this->toggle_category = overlay.toggle_category;
+        this->toggle_category_is_set = true;
+    }
+    if (overlay.tooltip_description_is_set) {
+        this->tooltip_description = overlay.tooltip_description;
+        this->tooltip_description_is_set = true;
+    }
+    if (overlay.tooltip_name_is_set) {
+        this->tooltip_name = overlay.tooltip_name;
+        this->tooltip_name_is_set = true;
+    }
+    if (overlay.trigger_range_is_set) {
+        this->trigger_range = overlay.trigger_range;
+        this->trigger_range_is_set = true;
+    }
+
+}
+

--- a/xml_converter/src/icon_gen.hpp
+++ b/xml_converter/src/icon_gen.hpp
@@ -127,4 +127,6 @@ class Icon : public Parseable {
     waypoint::Icon as_protobuf(ProtoWriterState* state) const;
     void parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state);
     bool validate_attributes_of_type_marker_category();
+    void apply_underlay(const Icon& underlay);
+    void apply_overlay(const Icon& overlay);
 };

--- a/xml_converter/src/rapid_helpers.cpp
+++ b/xml_converter/src/rapid_helpers.cpp
@@ -9,23 +9,6 @@
 
 using namespace std;
 
-////////////////////////////////////////////////////////////////////////////////
-// find_attribute_value (depricated)
-//
-// This function does a linear search over an xml node to try and find an
-// attribute with the specified name. It the attribute is not found then an
-// empty string is returned.
-//
-// This function is depricated and should not be used by any new code.
-////////////////////////////////////////////////////////////////////////////////
-string find_attribute_value(rapidxml::xml_node<>* node, string attribute_name) {
-    rapidxml::xml_attribute<char>* attribute = node->first_attribute(attribute_name.data(), attribute_name.size(), false);
-    if (attribute == nullptr) {
-        return "";
-    }
-
-    return string(attribute->value(), attribute->value_size());
-}
 
 rapidxml::xml_attribute<>* find_attribute(rapidxml::xml_node<>* node, string attribute_name) {
     return node->first_attribute(attribute_name.data(), attribute_name.size(), false);

--- a/xml_converter/src/rapid_helpers.cpp
+++ b/xml_converter/src/rapid_helpers.cpp
@@ -9,7 +9,6 @@
 
 using namespace std;
 
-
 rapidxml::xml_attribute<>* find_attribute(rapidxml::xml_node<>* node, string attribute_name) {
     return node->first_attribute(attribute_name.data(), attribute_name.size(), false);
 }

--- a/xml_converter/src/rapid_helpers.hpp
+++ b/xml_converter/src/rapid_helpers.hpp
@@ -4,7 +4,6 @@
 
 #include "rapidxml-1.13/rapidxml.hpp"
 
-std::string find_attribute_value(rapidxml::xml_node<>* node, std::string attribute_name);
 rapidxml::xml_attribute<>* find_attribute(rapidxml::xml_node<>* node, std::string attribute_name);
 
 std::string get_attribute_name(rapidxml::xml_attribute<>* attribute);

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -440,3 +440,241 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state)
         proto_to_float(proto_trail.scale(), state, &(this->trail_scale), &(this->trail_scale_is_set));
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_underlay
+//
+// Transforms this Trail as if this class was overlayed on top of the
+// underlay argument.
+////////////////////////////////////////////////////////////////////////////////
+void Trail::apply_underlay(const Trail& underlay) {
+    if (!this->achievement_bitmask_is_set && underlay.achievement_bitmask_is_set) {
+        this->achievement_bitmask = underlay.achievement_bitmask;
+        this->achievement_bitmask_is_set = true;
+    }
+    if (!this->achievement_id_is_set && underlay.achievement_id_is_set) {
+        this->achievement_id = underlay.achievement_id;
+        this->achievement_id_is_set = true;
+    }
+    if (!this->animation_speed_is_set && underlay.animation_speed_is_set) {
+        this->animation_speed = underlay.animation_speed;
+        this->animation_speed_is_set = true;
+    }
+    if (!this->category_is_set && underlay.category_is_set) {
+        this->category = underlay.category;
+        this->category_is_set = true;
+    }
+    if (!this->color_is_set && underlay.color_is_set) {
+        this->color = underlay.color;
+        this->color_is_set = true;
+    }
+    if (!this->cull_chirality_is_set && underlay.cull_chirality_is_set) {
+        this->cull_chirality = underlay.cull_chirality;
+        this->cull_chirality_is_set = true;
+    }
+    if (!this->disable_player_cutout_is_set && underlay.disable_player_cutout_is_set) {
+        this->disable_player_cutout = underlay.disable_player_cutout;
+        this->disable_player_cutout_is_set = true;
+    }
+    if (!this->distance_fade_end_is_set && underlay.distance_fade_end_is_set) {
+        this->distance_fade_end = underlay.distance_fade_end;
+        this->distance_fade_end_is_set = true;
+    }
+    if (!this->distance_fade_start_is_set && underlay.distance_fade_start_is_set) {
+        this->distance_fade_start = underlay.distance_fade_start;
+        this->distance_fade_start_is_set = true;
+    }
+    if (!this->festival_filter_is_set && underlay.festival_filter_is_set) {
+        this->festival_filter = underlay.festival_filter;
+        this->festival_filter_is_set = true;
+    }
+    if (!this->guid_is_set && underlay.guid_is_set) {
+        this->guid = underlay.guid;
+        this->guid_is_set = true;
+    }
+    if (!this->is_wall_is_set && underlay.is_wall_is_set) {
+        this->is_wall = underlay.is_wall;
+        this->is_wall_is_set = true;
+    }
+    if (!this->map_display_size_is_set && underlay.map_display_size_is_set) {
+        this->map_display_size = underlay.map_display_size;
+        this->map_display_size_is_set = true;
+    }
+    if (!this->map_id_is_set && underlay.map_id_is_set) {
+        this->map_id = underlay.map_id;
+        this->map_id_is_set = true;
+    }
+    if (!this->map_type_filter_is_set && underlay.map_type_filter_is_set) {
+        this->map_type_filter = underlay.map_type_filter;
+        this->map_type_filter_is_set = true;
+    }
+    if (!this->mount_filter_is_set && underlay.mount_filter_is_set) {
+        this->mount_filter = underlay.mount_filter;
+        this->mount_filter_is_set = true;
+    }
+    if (!this->profession_filter_is_set && underlay.profession_filter_is_set) {
+        this->profession_filter = underlay.profession_filter;
+        this->profession_filter_is_set = true;
+    }
+    if (!this->render_ingame_is_set && underlay.render_ingame_is_set) {
+        this->render_ingame = underlay.render_ingame;
+        this->render_ingame_is_set = true;
+    }
+    if (!this->render_on_map_is_set && underlay.render_on_map_is_set) {
+        this->render_on_map = underlay.render_on_map;
+        this->render_on_map_is_set = true;
+    }
+    if (!this->render_on_minimap_is_set && underlay.render_on_minimap_is_set) {
+        this->render_on_minimap = underlay.render_on_minimap;
+        this->render_on_minimap_is_set = true;
+    }
+    if (!this->schedule_is_set && underlay.schedule_is_set) {
+        this->schedule = underlay.schedule;
+        this->schedule_is_set = true;
+    }
+    if (!this->schedule_duration_is_set && underlay.schedule_duration_is_set) {
+        this->schedule_duration = underlay.schedule_duration;
+        this->schedule_duration_is_set = true;
+    }
+    if (!this->specialization_filter_is_set && underlay.specialization_filter_is_set) {
+        this->specialization_filter = underlay.specialization_filter;
+        this->specialization_filter_is_set = true;
+    }
+    if (!this->species_filter_is_set && underlay.species_filter_is_set) {
+        this->species_filter = underlay.species_filter;
+        this->species_filter_is_set = true;
+    }
+    if (!this->texture_is_set && underlay.texture_is_set) {
+        this->texture = underlay.texture;
+        this->texture_is_set = true;
+    }
+    if (!this->trail_data_is_set && underlay.trail_data_is_set) {
+        this->trail_data = underlay.trail_data;
+        this->trail_data_is_set = true;
+    }
+    if (!this->trail_scale_is_set && underlay.trail_scale_is_set) {
+        this->trail_scale = underlay.trail_scale;
+        this->trail_scale_is_set = true;
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// apply_overlay
+//
+// Transforms this Trail as if the overlay argument were overlayed on
+// top of this class.
+////////////////////////////////////////////////////////////////////////////////
+void Trail::apply_overlay(const Trail& overlay) {
+    if (overlay.achievement_bitmask_is_set) {
+        this->achievement_bitmask = overlay.achievement_bitmask;
+        this->achievement_bitmask_is_set = true;
+    }
+    if (overlay.achievement_id_is_set) {
+        this->achievement_id = overlay.achievement_id;
+        this->achievement_id_is_set = true;
+    }
+    if (overlay.animation_speed_is_set) {
+        this->animation_speed = overlay.animation_speed;
+        this->animation_speed_is_set = true;
+    }
+    if (overlay.category_is_set) {
+        this->category = overlay.category;
+        this->category_is_set = true;
+    }
+    if (overlay.color_is_set) {
+        this->color = overlay.color;
+        this->color_is_set = true;
+    }
+    if (overlay.cull_chirality_is_set) {
+        this->cull_chirality = overlay.cull_chirality;
+        this->cull_chirality_is_set = true;
+    }
+    if (overlay.disable_player_cutout_is_set) {
+        this->disable_player_cutout = overlay.disable_player_cutout;
+        this->disable_player_cutout_is_set = true;
+    }
+    if (overlay.distance_fade_end_is_set) {
+        this->distance_fade_end = overlay.distance_fade_end;
+        this->distance_fade_end_is_set = true;
+    }
+    if (overlay.distance_fade_start_is_set) {
+        this->distance_fade_start = overlay.distance_fade_start;
+        this->distance_fade_start_is_set = true;
+    }
+    if (overlay.festival_filter_is_set) {
+        this->festival_filter = overlay.festival_filter;
+        this->festival_filter_is_set = true;
+    }
+    if (overlay.guid_is_set) {
+        this->guid = overlay.guid;
+        this->guid_is_set = true;
+    }
+    if (overlay.is_wall_is_set) {
+        this->is_wall = overlay.is_wall;
+        this->is_wall_is_set = true;
+    }
+    if (overlay.map_display_size_is_set) {
+        this->map_display_size = overlay.map_display_size;
+        this->map_display_size_is_set = true;
+    }
+    if (overlay.map_id_is_set) {
+        this->map_id = overlay.map_id;
+        this->map_id_is_set = true;
+    }
+    if (overlay.map_type_filter_is_set) {
+        this->map_type_filter = overlay.map_type_filter;
+        this->map_type_filter_is_set = true;
+    }
+    if (overlay.mount_filter_is_set) {
+        this->mount_filter = overlay.mount_filter;
+        this->mount_filter_is_set = true;
+    }
+    if (overlay.profession_filter_is_set) {
+        this->profession_filter = overlay.profession_filter;
+        this->profession_filter_is_set = true;
+    }
+    if (overlay.render_ingame_is_set) {
+        this->render_ingame = overlay.render_ingame;
+        this->render_ingame_is_set = true;
+    }
+    if (overlay.render_on_map_is_set) {
+        this->render_on_map = overlay.render_on_map;
+        this->render_on_map_is_set = true;
+    }
+    if (overlay.render_on_minimap_is_set) {
+        this->render_on_minimap = overlay.render_on_minimap;
+        this->render_on_minimap_is_set = true;
+    }
+    if (overlay.schedule_is_set) {
+        this->schedule = overlay.schedule;
+        this->schedule_is_set = true;
+    }
+    if (overlay.schedule_duration_is_set) {
+        this->schedule_duration = overlay.schedule_duration;
+        this->schedule_duration_is_set = true;
+    }
+    if (overlay.specialization_filter_is_set) {
+        this->specialization_filter = overlay.specialization_filter;
+        this->specialization_filter_is_set = true;
+    }
+    if (overlay.species_filter_is_set) {
+        this->species_filter = overlay.species_filter;
+        this->species_filter_is_set = true;
+    }
+    if (overlay.texture_is_set) {
+        this->texture = overlay.texture;
+        this->texture_is_set = true;
+    }
+    if (overlay.trail_data_is_set) {
+        this->trail_data = overlay.trail_data;
+        this->trail_data_is_set = true;
+    }
+    if (overlay.trail_scale_is_set) {
+        this->trail_scale = overlay.trail_scale;
+        this->trail_scale_is_set = true;
+    }
+
+}
+

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -441,7 +441,6 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state)
     }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // apply_underlay
 //
@@ -557,7 +556,6 @@ void Trail::apply_underlay(const Trail& underlay) {
         this->trail_scale = underlay.trail_scale;
         this->trail_scale_is_set = true;
     }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -675,6 +673,4 @@ void Trail::apply_overlay(const Trail& overlay) {
         this->trail_scale = overlay.trail_scale;
         this->trail_scale_is_set = true;
     }
-
 }
-

--- a/xml_converter/src/trail_gen.hpp
+++ b/xml_converter/src/trail_gen.hpp
@@ -85,4 +85,6 @@ class Trail : public Parseable {
     waypoint::Trail as_protobuf(ProtoWriterState* state) const;
     void parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state);
     bool validate_attributes_of_type_marker_category();
+    void apply_underlay(const Trail& underlay);
+    void apply_overlay(const Trail& overlay);
 };


### PR DESCRIPTION
This changes how we handle defaults so that we can parse an entire XML node normally before needing to use any of its attributes to determine what default values that node should have.

This comes with a slight performance impact:

~668ms to run parsexml in the old system on a large marker pack
~680ms to run parsexml in the new system on the same large marker pack

The slowdown is likely do to a combination of:
- Creating a new `Category` object for each node
- Initializing all the boolean values in the new `Category` object
- Iterating over every attribute when doing an overlay

But the tradeoffs are worth it, especially because those performance hits can probably be optimized away in the future.

This overlay/underlay system will allow us to get simpler fine grain control over each field. We no longer need to do a search for a particular field, such as category's "name" field, we can just parse the whole category node using the normal attribute parsing tech and then access the value from a member variable. EG: We were previously looking for just the "name" attribute, but now we can look for any xml tag that we have associated with the 'name' field, such as 'bh-name'. All without adding custom logic to the parser.
