### PR TITLE
Preventing xml node classes from forcing rebuilds when nothing changes

### DIFF
--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -146,8 +146,11 @@ class CPPInclude:
 def write_cpp_classes(
     output_directory: str,
     data: Dict[str, Document],
-) -> None:
+) -> List[str]:
     print("Writing XML Node Cpp Classes")
+
+    written_files: List[str] = []
+
     file_loader = FileSystemLoader('cpp_templates')
     env = Environment(
         loader=file_loader,
@@ -175,17 +178,23 @@ def write_cpp_classes(
             if attribute_variable.class_name == "marker_category":
                 attributes_of_type_marker_category.append(attribute_variable.attribute_name)
 
-        with open(os.path.join(output_directory, lowercase(cpp_class) + "_gen.hpp"), 'w') as f:
-            f.write(header_template.render(
+        hpp_filepath = os.path.join(output_directory, lowercase(cpp_class) + "_gen.hpp")
+        write_if_different(
+            path=hpp_filepath,
+            contents=header_template.render(
                 cpp_class=cpp_class,
                 attribute_variables=sorted(attribute_variables, key=get_attribute_variable_key),
                 cpp_includes=cpp_includes,
                 cpp_class_header=lowercase(cpp_class),
                 attributes_of_type_marker_category=attributes_of_type_marker_category,
-            ))
+            ),
+        )
+        written_files.append(hpp_filepath)
 
-        with open(os.path.join(output_directory, lowercase(cpp_class) + "_gen.cpp"), 'w') as f:
-            f.write(code_template.render(
+        cpp_filepath = os.path.join(output_directory, lowercase(cpp_class) + "_gen.cpp")
+        write_if_different(
+            path=cpp_filepath,
+            contents=code_template.render(
                 cpp_class=cpp_class,
                 cpp_includes=cpp_includes,
                 cpp_class_header=lowercase(cpp_class),
@@ -193,8 +202,11 @@ def write_cpp_classes(
                 attribute_variables=sorted(attribute_variables, key=get_attribute_variable_key),
                 enumerate=enumerate,
                 attributes_of_type_marker_category=attributes_of_type_marker_category,
-            ))
+            ),
+        )
+        written_files.append(cpp_filepath)
 
+    return written_files
 
 def build_custom_function_data(config: Dict[str, Any]) -> Tuple[str, List[str]]:
     function = config["function"]

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -208,6 +208,7 @@ def write_cpp_classes(
 
     return written_files
 
+
 def build_custom_function_data(config: Dict[str, Any]) -> Tuple[str, List[str]]:
     function = config["function"]
     side_effects = []

--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -373,9 +373,10 @@ def main() -> None:
             generator.load_input_doc(full_markdown_doc_directory)
 
     generator.delete_generated_docs("../web_docs")
-    generator.delete_generated_docs("../src/")
     generator.write_webdocs("../web_docs/")
-    write_cpp_classes("../src/", generator.data)
+
+    written_classes = write_cpp_classes("../src/", generator.data)
+    generator.delete_generated_docs("../src/", skip=written_classes)
 
     written_attributes = write_attribute("../src/attribute", generator.data)
     generator.delete_generated_docs("../src/attribute", skip=written_attributes)


### PR DESCRIPTION
Applying the same change that was made for xml attributes to the xml node classes to prevent cmake/make from thinking that the classes need to be rebuilt even when nothing has changed.