### PR TITLE
Beginning to flesh out the html docs

### DIFF
--- a/xml_converter/doc/map_id/map_id.md
+++ b/xml_converter/doc/map_id/map_id.md
@@ -5,8 +5,33 @@ applies_to: [Icon, Trail]
 xml_fields: [MapID]
 protobuf_field: map_id
 ---
-The ID of the map that this object should be displayed on.
+The Map which this marker should be displayed on.
 
-Notes
-=====
-https://blishhud.com/docs/markers/attributes/mapid
+Finding the Map ID
+==================
+Method 1: GameInfo Plugin
+---
+The GameInfo plugin displays some useful game information on your screen about the character. One of those is the map the character is currently on
+
+Method 2: [Guild Wars 2 Wiki][2] infobox
+---
+the InfoBox on the right hand side of map wiki pages has a field titled API followed by a number.
+
+For example, the [Gendarran Fields][1] wiki page has the API value of `24`. Gendarran Fields' Map ID is `24`.
+
+![Gendarran Fields InfoBox](./gendarran_fields_infobox.png)
+
+
+Quirks
+======
+* Map ID is also stored within the `.trl` files and may overwrite any other Map IDs set earlier in the node.
+
+
+References
+=========
+* [BlishHUD MapID Marker Docs](https://blishhud.com/docs/markers/attributes/mapid)
+* [TacO Marker Pack Guide](https://www.gw2taco.com/2016/01/how-to-create-your-own-marker-pack.html)
+
+
+[1]: https://wiki.guildwars2.com/wiki/Gendarran_Fields
+[2]: https://wiki.guildwars2.com

--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -123,6 +123,9 @@ class Generator:
 
     def load_input_doc(self, dir_path: str) -> None:
         for filepath in os.listdir(dir_path):
+            if not filepath.endswith(".md"):
+                continue
+
             filepath = os.path.join(dir_path, filepath)
             try:
                 document = frontmatter.load(filepath)

--- a/xml_converter/generators/web_templates/documentation.html
+++ b/xml_converter/generators/web_templates/documentation.html
@@ -30,6 +30,18 @@
 				border-radius: 3px;
 				margin: 10px 30px;
 			}
+			code {
+				display: inline-block;
+				background: #DDD;
+				padding: 1px 3px 0px 3px;
+				border: 1px solid #888;
+				border-radius: 3px;
+			}
+
+			.codehilite code {
+				width: 100%;
+				box-sizing: border-box;
+			}
 
 			table.flagbox {
 				margin-top: -1em;
@@ -87,7 +99,12 @@
 				text-align: center;
 				margin: 10px;
 			}
+
+			.field_wrapper h1 {
+				border-bottom: 1px solid #777;
+			}
 		</style>
+		<link rel="stylesheet" type="text/css" href="./styles.css">
 	</head>
 	<body>
 		<div class="header">Hello world</div>

--- a/xml_converter/generators/web_templates/infotable.html
+++ b/xml_converter/generators/web_templates/infotable.html
@@ -43,7 +43,7 @@
         <!-- </div><div class="halfbox"> -->
         <h3>Valid XML Values</h3>{{field_row.valid_values_html}}<br>
         <!-- </div><div style="clear: both"></div> -->
-        <h3>Description</h3>{{field_row.description}}<br>
+        <h1>Description</h1>{{field_row.description}}<br>
         <!-- <div style="clear: both"></div><div class="halfbox"> -->
     </div>
 {% endfor %}

--- a/xml_converter/requirements.txt
+++ b/xml_converter/requirements.txt
@@ -9,6 +9,7 @@ mypy==1.5.1
 pyaml==21.10.1
 pycodestyle==2.8.0
 pyflakes==2.4.0
+Pygments==2.17.2
 pyrsistent==0.18.1
 python-frontmatter==1.0.0
 PyYAML==5.1


### PR DESCRIPTION
This could have been a few PRs but because the HTML docs are in a far from desirable state I figured I would just save my own time and combine them as they are still pretty easy to read.
* First change is some updates to Map ID to fit in with a new general format I think is better then the previous format
* Second change is some style updates, adjusting the 'description' header to be an h1 instead of an h3 to better line up with markdown h1s and h2s
* The third change is syntax highlighting, adding it for code blocks in our documentation. The code block I was using for testing was the block inside of trail data with the sample trail data 