### PR TITLE
Adding support for custom examples for fields

### DIFF
--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -194,7 +194,7 @@ class Generator:
 
     def get_examples(self, field_type: str, field_key: str) -> List[str]:
         if "examples" in self.data[field_key].metadata:
-            return  [f'"{x}"' for x in self.data[field_key].metadata["examples"]]
+            return [f'"{x}"' for x in self.data[field_key].metadata["examples"]]
         return ["???"]
 
     def get_fixed_option_examples(self, field_type: str, pairings: Any) -> List[str]:


### PR DESCRIPTION
* Renames `custom_serial_functions` to `shared_optional_fields` so we can add `examples` to the list
* Renames `shared_field_properties` to `shared_required_fields` to match the previous rename
* Checks if `examples` is set, and if it is set then uses those examples.