### PR TITLE
Underlaying parent defaults after parsing instead of pre-parsing `type`

### DIFF
--- a/xml_converter/src/state_structs/xml_reader_state.hpp
+++ b/xml_converter/src/state_structs/xml_reader_state.hpp
@@ -7,5 +7,5 @@ class Category;
 
 struct XMLReaderState {
     std::string marker_pack_root_directory;
-    std::map<std::string, Category>* marker_categories;
+    const std::map<std::string, Category>* marker_categories;
 };


### PR DESCRIPTION
This probably should not merge. It is here for reference.

This is the final step in optimizing "type" loading by not having to search for it in the xml attribute list.

Unfortunately it runs into two issues:
1) It is slower
2) It is less accurate

These are mortal issues to this feature, and as such I am probably going to end up ripping out this feature, and ripping out all of the support functions that are already in the code. However the latter will wait until after the rest of the code is implemented to see if there really is a use for overlays/underlays.

It is slower
---
New:
```
The taco parse function took 919 milliseconds to run
The taco parse function took 921 milliseconds to run
The taco parse function took 940 milliseconds to run
```

Current:
```
The taco parse function took 747 milliseconds to run
The taco parse function took 722 milliseconds to run
The taco parse function took 762 milliseconds to run
```

The old code copied the entire default Icon/Trail object in one swoop. This is, seemingly, a faster operation then iterating over all of the elements of the node and reading a bool to see if that node has been set yet or not. I would not have thought this was true at first but that may have just been me conflating memory allocation costs with memory copying costs. Empirically this new system is slower by a significant margin ~160ms.

It is less accurate
---
The current system copies data and then modifies it, as if all of the default data attributes were just attributes in the current node that were parsed earlier in the loop. This makes sense and all the code is already designed to handle this because it works the same way as it would without the default inheritance.

The new method requires understanding the `is_set` fields, and making sure they are set properly. This is more complex and not always accurate it seems. There are times when combo fields are used where `is_set` might be used to represent the entire group, causing them to not be properly underlayed/overlayed on the other node.