### PR TITLE
setting up a parallel method of accessing metadata contents

### DIFF
--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -11,7 +11,7 @@ from protobuf_types import get_proto_field_type
 from util import capitalize, SchemaType, Document
 from generate_cpp import write_cpp_classes, write_attribute
 import argparse
-
+import metadata
 
 XML_ATTRIBUTE_REGEX: Final[str] = "^[A-Za-z]+$"
 PROTO_FIELD_REGEX: Final[str] = "^[a-z_.]+$"
@@ -136,6 +136,8 @@ class Generator:
                 print(filepath)
                 raise e
 
+            metadata_dataclass = metadata.parse_data(document.metadata)
+
             error = validate_front_matter_schema(document.metadata)
             if error != "":
                 print(filepath)
@@ -143,6 +145,7 @@ class Generator:
 
             self.data[filepath] = Document(
                 metadata=document.metadata,
+                metadata_dataclass=metadata_dataclass,
                 content=document.content
             )
 

--- a/xml_converter/generators/metadata.py
+++ b/xml_converter/generators/metadata.py
@@ -41,54 +41,106 @@ class CustomFunctions:
     write_proto_trail: Optional[CustomFunction] = field(default=None, metadata={"json": "write.proto.trail"})
 
 
-@dataclass(kw_only=True)
+@dataclass
 class BaseMetadata:
     name: str  # TODO Match this to the regex ATTRIBUTE_NAME_REGEX
     applies_to: List[NodeType]
     xml_fields: List[str]  # TODO: Matche these to XML_ATTRIBUTE_REGEX
     protobuf_field: str  # TODO: Match this to PROTO_FIELD_REGEX
 
+@dataclass
+class OptionalBaseMetadata:
     custom_functions: CustomFunctions = CustomFunctions()
     examples: List[str] = field(default_factory=list)
 
 
-@dataclass(kw_only=True)
-class Int32Metadata(BaseMetadata):
+
+################################################################################
+# Int32Metadata
+################################################################################
+@dataclass
+class _Int32Metadata:
     variable_type: Literal["Int32"] = field(metadata={"json": "type"})
 
 
-@dataclass(kw_only=True)
-class Fixed32Metadata(BaseMetadata):
+@dataclass
+class Int32Metadata(OptionalBaseMetadata, _Int32Metadata, BaseMetadata):
+    pass
+
+
+################################################################################
+# Fixed32Metadata
+################################################################################
+@dataclass
+class _Fixed32Metadata:
     variable_type: Literal["Fixed32"] = field(metadata={"json": "type"})
 
 
-@dataclass(kw_only=True)
-class Float32Metadata(BaseMetadata):
+@dataclass
+class Fixed32Metadata(OptionalBaseMetadata, _Fixed32Metadata, BaseMetadata):
+    pass
+
+
+################################################################################
+# Float32Metadata
+################################################################################
+@dataclass
+class _Float32Metadata:
     variable_type: Literal["Float32"] = field(metadata={"json": "type"})
+@dataclass
+class Float32Metadata(OptionalBaseMetadata, _Float32Metadata, BaseMetadata):
+    pass
 
 
-@dataclass(kw_only=True)
-class StringMetadata(BaseMetadata):
+################################################################################
+# StringMetadata
+################################################################################
+@dataclass
+class _StringMetadata:
     variable_type: Literal["String"] = field(metadata={"json": "type"})
+@dataclass
+class StringMetadata(OptionalBaseMetadata, _StringMetadata, BaseMetadata):
+    pass
 
 
-@dataclass(kw_only=True)
-class BooleanMetadata(BaseMetadata):
+################################################################################
+# BooleanMetadata
+################################################################################
+@dataclass
+class _BooleanMetadata:
     variable_type: Literal["Boolean"] = field(metadata={"json": "type"})
+@dataclass
+class BooleanMetadata(OptionalBaseMetadata, _BooleanMetadata, BaseMetadata):
+    pass
 
 
-@dataclass(kw_only=True)
-class MultiFlagValueMetadata(BaseMetadata):
+################################################################################
+# MultiFlagValueMetadata
+################################################################################
+@dataclass
+class _MultiFlagValueMetadata:
     variable_type: Literal["MultiflagValue"] = field(metadata={"json": "type"})
     flags: Dict[str, List[str]]  # Validate keys against INTERNAL_VARIBLE_REGEX
+@dataclass
+class MultiFlagValueMetadata(OptionalBaseMetadata, _MultiFlagValueMetadata, BaseMetadata):
+    pass
 
 
-@dataclass(kw_only=True)
-class EnumMetadata(BaseMetadata):
+################################################################################
+# EnumMetadata
+################################################################################
+@dataclass
+class _EnumMetadata:
     variable_type: Literal["Enum"] = field(metadata={"json": "type"})
     values: Dict[str, List[str]]  # Validate keys against INTERNAL_VARIBLE_REGEX
 
+@dataclass
+class EnumMetadata(OptionalBaseMetadata, _EnumMetadata, BaseMetadata):
+    pass
 
+################################################################################
+# CompoundValueMetadata
+################################################################################
 @dataclass
 class CompoundSubComponent:
     name: str
@@ -97,8 +149,8 @@ class CompoundSubComponent:
     protobuf_field: str
 
 
-@dataclass(kw_only=True)
-class CompoundValueMetadata(BaseMetadata):
+@dataclass
+class _CompoundValueMetadata:
     variable_type: Literal["CompoundValue"] = field(metadata={"json": "type"})
     xml_bundled_components: List[str]
     xml_separate_components: List[str]
@@ -106,8 +158,16 @@ class CompoundValueMetadata(BaseMetadata):
     components: List[CompoundSubComponent]
 
 
-@dataclass(kw_only=True)
-class CompoundCustomClassMetadata(BaseMetadata):
+@dataclass
+class CompoundValueMetadata(OptionalBaseMetadata, _CompoundValueMetadata, BaseMetadata):
+    pass
+
+
+################################################################################
+# CompoundCustomClassMetadata
+################################################################################
+@dataclass
+class _CompoundCustomClassMetadata:
     variable_type: Literal["CompoundCustomClass"] = field(metadata={"json": "type"})
     cpp_class: str = field(metadata={"json": "class"})
     xml_bundled_components: List[str]
@@ -115,12 +175,24 @@ class CompoundCustomClassMetadata(BaseMetadata):
     components: List[CompoundSubComponent]
 
 
-@dataclass(kw_only=True)
-class CustomMetadata(BaseMetadata):
+@dataclass
+class CompoundCustomClassMetadata(OptionalBaseMetadata, _CompoundCustomClassMetadata, BaseMetadata):
+    pass
+
+
+################################################################################
+# CustomMetadata
+################################################################################
+@dataclass
+class _CustomMetadata:
     variable_type: Literal["Custom"] = field(metadata={"json": "type"})
     cpp_class: str = field(metadata={"json": "class"})
     uses_file_path: Optional[bool] = None
 
+
+@dataclass
+class CustomMetadata(OptionalBaseMetadata, _CustomMetadata, BaseMetadata):
+    pass
 
 MetadataType = Union[
     Int32Metadata,

--- a/xml_converter/generators/metadata.py
+++ b/xml_converter/generators/metadata.py
@@ -48,11 +48,11 @@ class BaseMetadata:
     xml_fields: List[str]  # TODO: Matche these to XML_ATTRIBUTE_REGEX
     protobuf_field: str  # TODO: Match this to PROTO_FIELD_REGEX
 
+
 @dataclass
 class OptionalBaseMetadata:
     custom_functions: CustomFunctions = CustomFunctions()
     examples: List[str] = field(default_factory=list)
-
 
 
 ################################################################################
@@ -87,6 +87,8 @@ class Fixed32Metadata(OptionalBaseMetadata, _Fixed32Metadata, BaseMetadata):
 @dataclass
 class _Float32Metadata:
     variable_type: Literal["Float32"] = field(metadata={"json": "type"})
+
+
 @dataclass
 class Float32Metadata(OptionalBaseMetadata, _Float32Metadata, BaseMetadata):
     pass
@@ -98,6 +100,8 @@ class Float32Metadata(OptionalBaseMetadata, _Float32Metadata, BaseMetadata):
 @dataclass
 class _StringMetadata:
     variable_type: Literal["String"] = field(metadata={"json": "type"})
+
+
 @dataclass
 class StringMetadata(OptionalBaseMetadata, _StringMetadata, BaseMetadata):
     pass
@@ -109,6 +113,8 @@ class StringMetadata(OptionalBaseMetadata, _StringMetadata, BaseMetadata):
 @dataclass
 class _BooleanMetadata:
     variable_type: Literal["Boolean"] = field(metadata={"json": "type"})
+
+
 @dataclass
 class BooleanMetadata(OptionalBaseMetadata, _BooleanMetadata, BaseMetadata):
     pass
@@ -121,6 +127,8 @@ class BooleanMetadata(OptionalBaseMetadata, _BooleanMetadata, BaseMetadata):
 class _MultiFlagValueMetadata:
     variable_type: Literal["MultiflagValue"] = field(metadata={"json": "type"})
     flags: Dict[str, List[str]]  # Validate keys against INTERNAL_VARIBLE_REGEX
+
+
 @dataclass
 class MultiFlagValueMetadata(OptionalBaseMetadata, _MultiFlagValueMetadata, BaseMetadata):
     pass
@@ -134,9 +142,11 @@ class _EnumMetadata:
     variable_type: Literal["Enum"] = field(metadata={"json": "type"})
     values: Dict[str, List[str]]  # Validate keys against INTERNAL_VARIBLE_REGEX
 
+
 @dataclass
 class EnumMetadata(OptionalBaseMetadata, _EnumMetadata, BaseMetadata):
     pass
+
 
 ################################################################################
 # CompoundValueMetadata
@@ -193,6 +203,7 @@ class _CustomMetadata:
 @dataclass
 class CustomMetadata(OptionalBaseMetadata, _CustomMetadata, BaseMetadata):
     pass
+
 
 MetadataType = Union[
     Int32Metadata,

--- a/xml_converter/generators/util.py
+++ b/xml_converter/generators/util.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, Any
+from metadata import MetadataType
 
 
 ################################################################################
@@ -62,4 +63,5 @@ SchemaType = Dict[str, Any]
 @dataclass
 class Document:
     metadata: SchemaType
+    metadata_dataclass: MetadataType
     content: str

--- a/xml_converter/requirements.txt
+++ b/xml_converter/requirements.txt
@@ -1,3 +1,4 @@
+classnotation==1.2.1
 attrs==21.4.0
 flake8==4.0.1
 Jinja2==3.1.2
@@ -5,7 +6,7 @@ jsonschema==4.7.2
 Markdown==3.4.1
 MarkupSafe==2.1.1
 mccabe==0.6.1
-mypy==1.5.1
+mypy==1.10.0
 pyaml==21.10.1
 pycodestyle==2.8.0
 pyflakes==2.4.0


### PR DESCRIPTION
The goal will be to eventually completely replace the existing methods for accessing the metadata with this fully typed way to make the code faster to write and easier to read. This will ultimately remove JSONSchema from our list of dependencies once complete.