### PR TITLE
Migrate web docs to use dataclass metadata

### DIFF
--- a/xml_converter/generators/metadata.py
+++ b/xml_converter/generators/metadata.py
@@ -48,6 +48,9 @@ class BaseMetadata:
     xml_fields: List[str]  # TODO: Matche these to XML_ATTRIBUTE_REGEX
     protobuf_field: str  # TODO: Match this to PROTO_FIELD_REGEX
 
+    def applies_to_as_str(self) -> List[str]:
+        return [x.value for x in self.applies_to]
+
 
 @dataclass
 class OptionalBaseMetadata:


### PR DESCRIPTION
This migrates the entire web-doc generator away from the Any dict metadata object into using the fully typed and typecheckable dataclass objects