### PR TITLE
Migrating the cpp generator to use dataclasses

### DIFF
--- a/xml_converter/generators/metadata.py
+++ b/xml_converter/generators/metadata.py
@@ -200,7 +200,7 @@ class CompoundCustomClassMetadata(OptionalBaseMetadata, _CompoundCustomClassMeta
 class _CustomMetadata:
     variable_type: Literal["Custom"] = field(metadata={"json": "type"})
     cpp_class: str = field(metadata={"json": "class"})
-    uses_file_path: Optional[bool] = None
+    uses_file_path: bool = False
 
 
 @dataclass


### PR DESCRIPTION
This migrates the rest of the code that uses the markdown frontmatter metadata to use dataclasses.