### PR TITLE
Remove gizmo node linking

### DIFF
--- a/Gizmo/PointEdit.gd
+++ b/Gizmo/PointEdit.gd
@@ -3,6 +3,7 @@ extends Spatial
 var camera: Camera
 signal selected(selected_object)
 signal deselected(selected_object)
+signal updated(point_position)
 var last_translation
 var selected: bool = false
 
@@ -27,32 +28,6 @@ func select(camera, event):
 	$Pillar/CollisionShape.disabled = false
 	emit_signal("selected", self)
 
-var object_link = null
-var object_2d_link = null
-var object_index:int = 0
-var point_type: String
-
-
-func link_point(point_type: String, object_link, object_2d_link = null, object_index = 0):
-	self.point_type = point_type
-	self.object_link = object_link
-	if point_type == "path" || point_type == "area":
-		self.object_2d_link = object_2d_link
-		self.object_index = object_index
-	if point_type == "icon":
-		pass
-
-
-func update_point():
-	if self.translation != self.last_translation:
-		if point_type == "path" || point_type == "area":
-			self.object_link.set_point_position(self.object_index, self.translation)
-			self.object_2d_link.points[self.object_index] = Vector2(self.translation.x, self.translation.z)
-		if point_type == "icon":
-			self.object_link.translation = self.translation
-		print("update")
-		self.last_translation  = self.translation
-
 
 ################################################################################
 # Handle resizing the control nodes so that no matter how far away from the
@@ -70,4 +45,7 @@ func _process(delta):
 		$Plane.scale = new_scale
 		$Pillar.scale = new_scale
 
-		update_point()
+		if self.translation != self.last_translation:
+			#print("update")
+			emit_signal("updated", self.translation)
+			self.last_translation  = self.translation

--- a/Icon.gd
+++ b/Icon.gd
@@ -22,3 +22,6 @@ func set_icon_image(texture_path: String):
 	
 	self.texture = texture
 	self.material_override.set_shader_param("texture_albedo", texture)
+
+func set_point_position(position: Vector3):
+	self.translation = position

--- a/Icon.gd
+++ b/Icon.gd
@@ -23,5 +23,8 @@ func set_icon_image(texture_path: String):
 	self.texture = texture
 	self.material_override.set_shader_param("texture_albedo", texture)
 
-func set_point_position(position: Vector3):
+func update_point_poistion(position: Vector3):
 	self.translation = position
+
+func remove_point(index):
+	queue_free()

--- a/Route.gd
+++ b/Route.gd
@@ -93,10 +93,10 @@ func remove_point(index: int):
 	self.point_list.remove(index)
 	refresh_mesh()
 
-func new_point_after(midpoint, index):
-	var start = self.get_point_position(index)
+func new_point_after(midpoint: Vector3, index):
+	var start: Vector3 = self.get_point_position(index)
 	if self.get_point_count() > index+1:
-		var end = self.get_point_position(index+1)
+		var end: Vector3 = self.get_point_position(index+1)
 		midpoint = ((start-end)/2) + end
 	add_point(midpoint, index+1)
 

--- a/Route.gd
+++ b/Route.gd
@@ -78,7 +78,7 @@ func get_point_count():
 func get_point_position(index: int):
 	return self.point_list[index]
 
-func set_point_position(index: int, position: Vector3):
+func set_point_position(position: Vector3, index: int):
 	self.point_list[index] = position
 	refresh_mesh()
 

--- a/Route.gd
+++ b/Route.gd
@@ -78,7 +78,7 @@ func get_point_count():
 func get_point_position(index: int):
 	return self.point_list[index]
 
-func set_point_position(position: Vector3, index: int):
+func update_point_poistion(position: Vector3, index: int):
 	self.point_list[index] = position
 	refresh_mesh()
 
@@ -93,6 +93,12 @@ func remove_point(index: int):
 	self.point_list.remove(index)
 	refresh_mesh()
 
+func new_point_after(midpoint, index):
+	var start = self.get_point_position(index)
+	if self.get_point_count() > index+1:
+		var end = self.get_point_position(index+1)
+		midpoint = ((start-end)/2) + end
+	add_point(midpoint, index+1)
 
 func set_texture(texture):
 	$MeshInstance.material_override.set_shader_param("texture_albedo", texture)

--- a/Route2D.gd
+++ b/Route2D.gd
@@ -6,10 +6,11 @@ func add_new_point(position: Vector3, index: int = -1):
 func update_point_poistion(position: Vector3, index: int):
 	self.set_point_position(index, Vector2(position.x, position.z))
 	
-func new_point_after(midpoint, index):
-	var start = self.get_point_position(index)
+func new_point_after(midpoint: Vector3, index: int):
+	var midpoint2d: Vector2 = Vector2(midpoint.x, midpoint.z)
+	var start: Vector2 = self.get_point_position(index)
 		
 	if self.get_point_count() > index+1:
-		var end = self.get_point_position(index+1)
-		midpoint = ((start-end)/2) + end
-	add_point(midpoint, index+1)
+		var end: Vector2 = self.get_point_position(index+1)
+		midpoint2d = ((start-end)/2) + end
+	add_point(midpoint2d, index+1)

--- a/Route2D.gd
+++ b/Route2D.gd
@@ -1,0 +1,15 @@
+extends Line2D
+
+func add_new_point(position: Vector3, index: int = -1):
+	self.add_point(Vector2(position.x, position.z), index)
+	
+func update_point_poistion(position: Vector3, index: int):
+	self.set_point_position(index, Vector2(position.x, position.z))
+	
+func new_point_after(midpoint, index):
+	var start = self.get_point_position(index)
+		
+	if self.get_point_count() > index+1:
+		var end = self.get_point_position(index+1)
+		midpoint = ((start-end)/2) + end
+	add_point(midpoint, index+1)

--- a/Route2D.tscn
+++ b/Route2D.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Route2D.gd" type="Script" id=1]
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -27,3 +29,4 @@ material = SubResource( 2 )
 points = PoolVector2Array( 0, 0, 0, 0, 0, 0 )
 default_color = Color( 1, 1, 1, 1 )
 texture_mode = 1
+script = ExtResource( 1 )


### PR DESCRIPTION
This PR is trying to solve the following design goals.

- Allow the Gizmo's to exist without knowing node specific information
- Removing the tight coupling of 3d and 2d routes in gizmo
- Avoid branching logic for icons versus paths
- Convert the 3d position coordinates into 2d for updating 2d paths