### PR TITLE
Adding examples for compound fields based on their components

### DIFF
--- a/xml_converter/doc/rotation/euler_rotation.md
+++ b/xml_converter/doc/rotation/euler_rotation.md
@@ -11,19 +11,23 @@ components:
   type: Float32
   xml_fields: [RotateX]
   protobuf_field: "x"
+  examples: ["180", "90", "0", "85", "-90", "0.01"]
 
 - name: Y Rotation
   type: Float32
   xml_fields: [RotateY]
   protobuf_field: "y"
+  examples: ["10", "-18", "0", "-1.5", "20", "359"]
 
 - name: Z Rotation
   type: Float32
   xml_fields: [RotateZ]
   protobuf_field: "z"
+  examples: ["-38", "-10.55", "-0.65", "123", "53.5", "-75"]
 
 ---
-Euler X Y Z rotation.
+Euler X Y Z rotation in degrees.
+Can be any floating point value but will be modulo 360 when applied
 
 Notes
 =====

--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -207,14 +207,27 @@ class Generator:
                 valid_values += "</table>"
 
             elif fieldval.variable_type == "CompoundValue":
-                print("  Unknown examples for {} {}".format(fieldval.variable_type, fieldkey))
+                subcomponent_examples = [
+                    self.get_examples(
+                        field_type=x.subcomponent_type.value,
+                        field_key=fieldkey + "[" + x.name + "]",
+                        examples=x.examples
+                    ) for x in fieldval.components
+                ]
+
+                compound_examples = build_combinations(
+                    subcomponent_examples
+                )
+
+                # TODO: the get_examples function above is not great because it puts quotes around everything and we need to remove them before joining
+                examples = ["\"" + ",".join([y.strip("\"") for y in x]) + "\"" for x in compound_examples]
+
                 example = self.build_example(
                     type=fieldval.variable_type,
                     applies_to=fieldval.applies_to_as_str(),
                     xml_field=fieldval.xml_fields[0],
-                    examples=["???TODO???"]
+                    examples=examples
                 )
-                # ",".join( [ self.get_examples(x['type'], fieldval['applies_to'], fieldval['xml_fields'][0]) for x in fieldval['components'] ])
             else:
                 example = self.build_example(
                     type=fieldval.variable_type,
@@ -225,7 +238,6 @@ class Generator:
                         field_key=fieldkey,
                     )
                 )
-                # self.get_examples(fieldval['type'], fieldval['applies_to'], fieldval['xml_fieldsval'][0])
 
             proto_field_type: str = ""
             for marker_type in fieldval.applies_to_as_str():
@@ -288,6 +300,21 @@ class Generator:
                     ))
 
         return template.render(field_rows=field_rows), field_rows
+
+
+def build_combinations(inputs: List[List[str]]) -> List[List[str]]:
+    output_list: List[List[str]] = []
+
+    longest_input_list = max([len(x) for x in inputs])
+
+    for i in range(longest_input_list):
+        inner_list: List[str] = []
+        for input_list in inputs:
+            inner_list.append(input_list[i % len(input_list)])
+
+        output_list.append(inner_list)
+
+    return output_list
 
 
 ################################################################################


### PR DESCRIPTION
This adds a method of dynamically generating examples for compound types based on the types of the components.

![Screenshot from 2024-05-26 12-50-57](https://github.com/AsherGlick/Burrito/assets/603989/827127ba-4e22-4007-ac9f-cfcaa99906ca)
![Screenshot from 2024-05-26 12-52-09](https://github.com/AsherGlick/Burrito/assets/603989/12d5d872-7c1c-459c-b3d4-f0b69f60a47c)
![Screenshot from 2024-05-26 12-52-18](https://github.com/AsherGlick/Burrito/assets/603989/4418b5db-1349-462b-84c0-afabee1336a0)
![Screenshot from 2024-05-26 12-52-30](https://github.com/AsherGlick/Burrito/assets/603989/0cc686a1-e40e-4e39-a9e8-67ff65063691)
