### PR TITLE
Breaking out proto info inside AttributeVariable

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -105,12 +105,12 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf(ProtoWriterState* state) cons
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
-                {% if not attribute_variable.is_proto_field_scalar %}
-                    std::function<void({{attribute_variable.protobuf_cpp_type}}*)> setter = [&proto_{{cpp_class_header}}]({{attribute_variable.protobuf_cpp_type}}* val) { proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.protobuf_field}}(val); };
+                {% if not attribute_variable.proto_info.is_proto_field_scalar %}
+                    std::function<void({{attribute_variable.proto_info.protobuf_cpp_type}}*)> setter = [&proto_{{cpp_class_header}}]({{attribute_variable.proto_info.protobuf_cpp_type}}* val) { proto_{{cpp_class_header}}.{{attribute_variable.proto_info.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.proto_info.protobuf_field}}(val); };
                 {% else %}
-                    std::function<void({{attribute_variable.protobuf_cpp_type}})> setter = [&proto_{{cpp_class_header}}]({{attribute_variable.protobuf_cpp_type}} val) { proto_{{cpp_class_header}}.{{attribute_variable.mutable_proto_drilldown_calls}}set_{{attribute_variable.protobuf_field}}(val); };
+                    std::function<void({{attribute_variable.proto_info.protobuf_cpp_type}})> setter = [&proto_{{cpp_class_header}}]({{attribute_variable.proto_info.protobuf_cpp_type}} val) { proto_{{cpp_class_header}}.{{attribute_variable.proto_info.mutable_proto_drilldown_calls}}set_{{attribute_variable.proto_info.protobuf_field}}(val); };
                 {% endif %}
-                {{attribute_variable.serialize_proto_function}}(this->{{attribute_variable.attribute_name}}, state, setter{% for side_effect in attribute_variable.serialize_proto_side_effects %}, &(this->{{side_effect}}){% endfor %});
+                {{attribute_variable.proto_info.serialize_proto_function}}(this->{{attribute_variable.attribute_name}}, state, setter{% for side_effect in attribute_variable.proto_info.serialize_proto_side_effects %}, &(this->{{side_effect}}){% endfor %});
             }
         {% endif %}
     {% endfor %}
@@ -120,14 +120,14 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf(ProtoWriterState* state) cons
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}, ProtoReaderState* state) {
     {% for attribute_variable in attribute_variables %}
         {% if attribute_variable.is_component == false %}
-            {% if not attribute_variable.is_proto_field_scalar %}
-                if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.has_{{attribute_variable.protobuf_field}}()) {
-            {% elif attribute_variable.protobuf_cpp_type == "std::string" %}
-                if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != "") {
+            {% if not attribute_variable.proto_info.is_proto_field_scalar %}
+                if (proto_{{cpp_class_header}}{{attribute_variable.proto_info.proto_drilldown_calls}}.has_{{attribute_variable.proto_info.protobuf_field}}()) {
+            {% elif attribute_variable.proto_info.protobuf_cpp_type == "std::string" %}
+                if (proto_{{cpp_class_header}}{{attribute_variable.proto_info.proto_drilldown_calls}}.{{attribute_variable.proto_info.protobuf_field}}() != "") {
             {% else %}
-                if (proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}() != 0) {
+                if (proto_{{cpp_class_header}}{{attribute_variable.proto_info.proto_drilldown_calls}}.{{attribute_variable.proto_info.protobuf_field}}() != 0) {
             {% endif %}
-                {{attribute_variable.deserialize_proto_function}}(proto_{{cpp_class_header}}{{attribute_variable.proto_drilldown_calls}}.{{attribute_variable.protobuf_field}}(), state, &(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.deserialize_proto_side_effects %}, &(this->{{side_effect}}){% endfor %});
+                {{attribute_variable.proto_info.deserialize_proto_function}}(proto_{{cpp_class_header}}{{attribute_variable.proto_info.proto_drilldown_calls}}.{{attribute_variable.proto_info.protobuf_field}}(), state, &(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.proto_info.deserialize_proto_side_effects %}, &(this->{{side_effect}}){% endfor %});
             }
         {% endif %}
     {% endfor %}

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -44,6 +44,7 @@ documentation_type_data: Dict[str, DocumentationTypeData] = {
     }
 }
 
+
 @dataclass
 class AttributeVariableProtoInfo:
     # The function name and additional side effect pointers for proto serialization.
@@ -72,7 +73,6 @@ class AttributeVariableProtoInfo:
     mutable_proto_drilldown_calls: str = ""
 
 
-
 @dataclass
 class AttributeVariable:
     attribute_name: str
@@ -99,7 +99,6 @@ class AttributeVariable:
 
     uses_file_path: bool = False
     is_component: bool = False
-
 
 
 @dataclass
@@ -437,7 +436,7 @@ def generate_cpp_variable_data(
                     protobuf_cpp_type=get_proto_field_cpp_type(doc_type, fieldval.protobuf_field),
                     is_proto_field_scalar=is_proto_field_scalar(doc_type, fieldval.protobuf_field),
                     proto_drilldown_calls=proto_drilldown_calls,
-                    mutable_proto_drilldown_calls=mutable_proto_drilldown_calls, # Is this used?
+                    mutable_proto_drilldown_calls=mutable_proto_drilldown_calls,
                     serialize_proto_function=serialize_proto_function.function,
                     serialize_proto_side_effects=convert_side_effects_to_variable_names(serialize_proto_function.side_effects),
                     deserialize_proto_function=deserialize_proto_function.function,


### PR DESCRIPTION
Breaking out all the proto specific AttributeVariable fields into a new subfield called proto_info

Also making use of strict undefineds in jinja which make it easier to tell when a template is using a variable that does not exist.

This results in a zero-diff in the generated code