### PR TITLE
Breaking out xml info like proto info for consistency

### DIFF
--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -50,9 +50,9 @@ bool {{cpp_class}}::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vec
     string attributename;
     attributename = normalize(get_attribute_name(attribute));
     {% for n, attribute_variable in enumerate(attribute_variables) %}
-        {% for i, value in enumerate(attribute_variable.xml_fields) %}
+        {% for i, value in enumerate(attribute_variable.xml_info.xml_fields) %}
             {{ "if" if i == n == 0 else "else if" }} (attributename == "{{value}}") {
-                {{attribute_variable.deserialize_xml_function}}(attribute, errors, state, &(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.deserialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %});
+                {{attribute_variable.xml_info.deserialize_xml_function}}(attribute, errors, state, &(this->{{attribute_variable.attribute_name}}), &(this->{{attribute_variable.attribute_flag_name}}){% for side_effect in attribute_variable.xml_info.deserialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %});
             }
         {% endfor %}
     {% endfor %}
@@ -75,9 +75,9 @@ vector<string> {{cpp_class}}::as_xml(XMLWriterState* state) const {
     vector<string> xml_node_contents;
     xml_node_contents.push_back("<{{xml_class_name}} ");
     {% for attribute_variable in attribute_variables %}
-        {% if attribute_variable.write_to_xml == true %}
+        {% if attribute_variable.xml_info.write_to_xml == true %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
-                xml_node_contents.push_back({{attribute_variable.serialize_xml_function}}("{{attribute_variable.default_xml_field}}", state, &this->{{attribute_variable.attribute_name}}{% for side_effect in attribute_variable.serialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %}));
+                xml_node_contents.push_back({{attribute_variable.xml_info.serialize_xml_function}}("{{attribute_variable.xml_info.default_xml_field}}", state, &this->{{attribute_variable.attribute_name}}{% for side_effect in attribute_variable.xml_info.serialize_xml_side_effects %}, &(this->{{side_effect}}){% endfor %}));
             }
         {% endif %}
     {% endfor %}

--- a/xml_converter/generators/generate_cpp.py
+++ b/xml_converter/generators/generate_cpp.py
@@ -74,11 +74,7 @@ class AttributeVariableProtoInfo:
 
 
 @dataclass
-class AttributeVariable:
-    attribute_name: str
-    attribute_type: str
-    cpp_type: str
-    class_name: str
+class AttributeVariableXMLInfo:
     xml_fields: List[str]
 
     # The function name and additional side effect pointers for xml serialization.
@@ -89,13 +85,23 @@ class AttributeVariable:
     deserialize_xml_function: str
     deserialize_xml_side_effects: List[str]
 
-    proto_info: AttributeVariableProtoInfo
-
     default_xml_field: str = ""
-    side_effects: List[str] = field(default_factory=list)
     xml_bundled_components: List[str] = field(default_factory=list)
-    attribute_flag_name: Optional[str] = ""
     write_to_xml: bool = True
+
+
+@dataclass
+class AttributeVariable:
+    attribute_name: str
+    attribute_type: str
+    cpp_type: str
+    class_name: str
+
+    proto_info: AttributeVariableProtoInfo
+    xml_info: AttributeVariableXMLInfo
+
+    side_effects: List[str] = field(default_factory=list)
+    attribute_flag_name: Optional[str] = ""
 
     uses_file_path: bool = False
     is_component: bool = False
@@ -337,16 +343,8 @@ def generate_cpp_variable_data(
                         attribute_type="CompoundValue",
                         cpp_type=documentation_type_data[component.subcomponent_type.value]["cpp_type"],
                         class_name=component_class_name,
-                        xml_fields=component_xml_fields,
-                        default_xml_field=component_default_xml_field,
                         attribute_flag_name=attribute_name + "_is_set",
-                        write_to_xml=write_to_xml,
                         is_component=True,
-
-                        serialize_xml_function=component_class_name + "_to_xml_attribute",
-                        serialize_xml_side_effects=[],
-                        deserialize_xml_function="xml_attribute_to_" + component_class_name,
-                        deserialize_xml_side_effects=[],
 
                         proto_info=AttributeVariableProtoInfo(
                             protobuf_field=component.protobuf_field,
@@ -358,6 +356,15 @@ def generate_cpp_variable_data(
                             deserialize_proto_side_effects=[],
                         ),
 
+                        xml_info=AttributeVariableXMLInfo(
+                            xml_fields=component_xml_fields,
+                            default_xml_field=component_default_xml_field,
+                            write_to_xml=write_to_xml,
+                            serialize_xml_function=component_class_name + "_to_xml_attribute",
+                            serialize_xml_side_effects=[],
+                            deserialize_xml_function="xml_attribute_to_" + component_class_name,
+                            deserialize_xml_side_effects=[],
+                        )
                     )
                     attribute_variables.append(component_attribute_variable)
                 # If there aren't any components to bundle, we don't want to render the attribute
@@ -417,17 +424,9 @@ def generate_cpp_variable_data(
                 attribute_type=fieldval.variable_type,
                 cpp_type=cpp_type,
                 class_name=class_name,
-                xml_fields=xml_fields,
-                default_xml_field=default_xml_field,
 
-                write_to_xml=write_to_xml,
                 attribute_flag_name=attribute_name + "_is_set",
                 side_effects=side_effects,
-
-                serialize_xml_function=serialize_xml_function.function,
-                serialize_xml_side_effects=convert_side_effects_to_variable_names(serialize_xml_function.side_effects),
-                deserialize_xml_function=deserialize_xml_function.function,
-                deserialize_xml_side_effects=convert_side_effects_to_variable_names(deserialize_xml_function.side_effects),
 
                 uses_file_path=fieldval.uses_file_path if fieldval.variable_type == "Custom" else False,
 
@@ -441,8 +440,17 @@ def generate_cpp_variable_data(
                     serialize_proto_side_effects=convert_side_effects_to_variable_names(serialize_proto_function.side_effects),
                     deserialize_proto_function=deserialize_proto_function.function,
                     deserialize_proto_side_effects=convert_side_effects_to_variable_names(deserialize_proto_function.side_effects),
-                )
+                ),
 
+                xml_info=AttributeVariableXMLInfo(
+                    xml_fields=xml_fields,
+                    default_xml_field=default_xml_field,
+                    write_to_xml=write_to_xml,
+                    serialize_xml_function=serialize_xml_function.function,
+                    serialize_xml_side_effects=convert_side_effects_to_variable_names(serialize_xml_function.side_effects),
+                    deserialize_xml_function=deserialize_xml_function.function,
+                    deserialize_xml_side_effects=convert_side_effects_to_variable_names(deserialize_xml_function.side_effects),
+                ),
             )
             attribute_variables.append(attribute_variable)
 


### PR DESCRIPTION
Doing the same thing we just did with the proto data to the xml data for consistency.