### PR TITLE
Removing the requirement for protofields on each attribute

### DIFF
--- a/xml_converter/doc/category/category.md
+++ b/xml_converter/doc/category/category.md
@@ -4,18 +4,11 @@ type: Custom
 class: MarkerCategory
 applies_to: [Icon, Trail]
 xml_fields: [Type, Category]
-protobuf_field: category
+protobuf_field: null
 examples:
   - "mycategory"
   - "mycategory.subcategory"
   - "mycategory.subcategory.subsubcategory"
-custom_functions:
-  read.proto:
-    function: do_nothing
-    side_effects: []
-  write.proto:
-    function: do_nothing
-    side_effects: []
 ---
 The category this object belongs to.
 

--- a/xml_converter/doc/menu/name.md
+++ b/xml_converter/doc/menu/name.md
@@ -3,17 +3,10 @@ name: Name
 type: String
 applies_to: [Category]
 xml_fields: [Name]
-protobuf_field: name
+protobuf_field: null
 examples:
   - "mycategory"
   - "tribulationmode203"
-custom_functions:
-  read.proto:
-    function: do_nothing
-    side_effects: []
-  write.proto:
-    function: do_nothing
-    side_effects: []
 ---
 
 Notes

--- a/xml_converter/generators/cpp_templates/class_template.cpp
+++ b/xml_converter/generators/cpp_templates/class_template.cpp
@@ -103,7 +103,7 @@ vector<string> {{cpp_class}}::as_xml(XMLWriterState* state) const {
 waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf(ProtoWriterState* state) const {
     waypoint::{{cpp_class}} proto_{{cpp_class_header}};
     {% for attribute_variable in attribute_variables %}
-        {% if attribute_variable.is_component == false %}
+        {% if attribute_variable.is_component == false and attribute_variable.proto_info != None %}
             if (this->{{attribute_variable.attribute_flag_name}}) {
                 {% if not attribute_variable.proto_info.is_proto_field_scalar %}
                     std::function<void({{attribute_variable.proto_info.protobuf_cpp_type}}*)> setter = [&proto_{{cpp_class_header}}]({{attribute_variable.proto_info.protobuf_cpp_type}}* val) { proto_{{cpp_class_header}}.{{attribute_variable.proto_info.mutable_proto_drilldown_calls}}set_allocated_{{attribute_variable.proto_info.protobuf_field}}(val); };
@@ -119,7 +119,7 @@ waypoint::{{cpp_class}} {{cpp_class}}::as_protobuf(ProtoWriterState* state) cons
 
 void {{cpp_class}}::parse_protobuf(waypoint::{{cpp_class}} proto_{{cpp_class_header}}, ProtoReaderState* state) {
     {% for attribute_variable in attribute_variables %}
-        {% if attribute_variable.is_component == false %}
+        {% if attribute_variable.is_component == false and attribute_variable.proto_info != None %}
             {% if not attribute_variable.proto_info.is_proto_field_scalar %}
                 if (proto_{{cpp_class_header}}{{attribute_variable.proto_info.proto_drilldown_calls}}.has_{{attribute_variable.proto_info.protobuf_field}}()) {
             {% elif attribute_variable.proto_info.protobuf_cpp_type == "std::string" %}

--- a/xml_converter/generators/main.py
+++ b/xml_converter/generators/main.py
@@ -239,18 +239,27 @@ class Generator:
                     )
                 )
 
-            proto_field_type: str = ""
-            for marker_type in fieldval.applies_to_as_str():
-                proto_field_type = get_proto_field_type(marker_type, fieldval.protobuf_field)
-                # TODO: catch discrepencies if the proto field types across
-                # different messages have differing types. This will be caught
-                # in the cpp code regardless.
+            proto_field_type: str
+            proto_field_name: str
+            if fieldval.protobuf_field is not None:
+                proto_field_name = fieldval.protobuf_field
+                proto_field_type = ""
+                for marker_type in fieldval.applies_to_as_str():
+                    proto_field_type = get_proto_field_type(marker_type, fieldval.protobuf_field)
+                    # TODO: catch discrepencies if the proto field types across
+                    # different messages have differing types. This will be caught
+                    # in the cpp code regardless.
+                if proto_field_type == "":
+                    print("Could not find proto field type from proto schema")
+            else:
+                proto_field_name = ""
+                proto_field_type = "None"
 
             field_rows.append(FieldRow(
                 name=fieldval.name,
                 xml_attribute=fieldval.xml_fields[0],
                 alternate_xml_attributes=fieldval.xml_fields[1:],
-                binary_field=fieldval.protobuf_field,
+                binary_field=proto_field_name,
                 binary_field_type=proto_field_type,
                 data_type=fieldval.variable_type,
                 usable_on_html="<br>".join(fieldval.applies_to_as_str()),
@@ -265,7 +274,10 @@ class Generator:
             if fieldval.variable_type == "CompoundValue" or fieldval.variable_type == "CompoundCustomClass":
                 for component_field in fieldval.components:
 
-                    binary_field_name = fieldval.protobuf_field + "." + component_field.protobuf_field
+                    if fieldval.protobuf_field is not None:
+                        binary_field_name = fieldval.protobuf_field + "." + component_field.protobuf_field
+                    else:
+                        binary_field_name = ""
 
                     component_field_type: str = ""
                     for marker_type in fieldval.applies_to_as_str():

--- a/xml_converter/generators/metadata.py
+++ b/xml_converter/generators/metadata.py
@@ -51,7 +51,7 @@ class BaseMetadata:
     name: str  # TODO Match this to the regex ATTRIBUTE_NAME_REGEX
     applies_to: List[NodeType]
     xml_fields: List[str]  # TODO: Matche these to XML_ATTRIBUTE_REGEX
-    protobuf_field: str  # TODO: Match this to PROTO_FIELD_REGEX
+    protobuf_field: Optional[str]  # TODO: Match this to PROTO_FIELD_REGEX
 
     def applies_to_as_str(self) -> List[str]:
         return [x.value for x in self.applies_to]

--- a/xml_converter/proto/waypoint.proto
+++ b/xml_converter/proto/waypoint.proto
@@ -62,9 +62,6 @@ message Icon {
     bool tentative__render_on_minimap = 2051;
     string bhdraft__schedule = 2052;
     float bhdraft__schedule_duration = 2053;
-
-    // TODO: Delete this when we can parse data per marker instead of per field
-    bool category = 2054;
 }
 
 message Trail {
@@ -97,9 +94,6 @@ message Trail {
     bool tentative__render_on_minimap = 2051;
     string bhdraft__schedule = 2052;
     float bhdraft__schedule_duration = 2053;
-
-    // TODO: Delete this when we can parse data per marker instead of per field
-    bool category = 2054;
 }
 
 message RGBAColor {

--- a/xml_converter/src/attribute/string.hpp
+++ b/xml_converter/src/attribute/string.hpp
@@ -52,5 +52,3 @@ void display_name_and_name_to_proto_display_name(
     std::function<void(std::string)> setter,
     const std::string* name,
     const bool* is_name_set);
-
-#define do_nothing(...)

--- a/xml_converter/src/category_gen.cpp
+++ b/xml_converter/src/category_gen.cpp
@@ -129,10 +129,6 @@ waypoint::Category Category::as_protobuf(ProtoWriterState* state) const {
         std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_id(val); };
         unique_id_to_proto(this->menu_id, state, setter);
     }
-    if (this->name_is_set) {
-        std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_name(val); };
-        do_nothing(this->name, state, setter);
-    }
     if (this->tooltip_description_is_set) {
         std::function<void(std::string)> setter = [&proto_category](std::string val) { proto_category.set_tip_description(val); };
         string_to_proto(this->tooltip_description, state, setter);
@@ -152,9 +148,6 @@ void Category::parse_protobuf(waypoint::Category proto_category, ProtoReaderStat
     }
     if (proto_category.id() != "") {
         proto_to_unique_id(proto_category.id(), state, &(this->menu_id), &(this->menu_id_is_set));
-    }
-    if (proto_category.name() != "") {
-        do_nothing(proto_category.name(), state, &(this->name), &(this->name_is_set));
     }
     if (proto_category.tip_description() != "") {
         proto_to_string(proto_category.tip_description(), state, &(this->tooltip_description), &(this->tooltip_description_is_set));

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -435,10 +435,6 @@ waypoint::Icon Icon::as_protobuf(ProtoWriterState* state) const {
         std::function<void(float)> setter = [&proto_icon](float val) { proto_icon.mutable_trigger()->set_bounce_height(val); };
         float_to_proto(this->bounce_height, state, setter);
     }
-    if (this->category_is_set) {
-        std::function<void(bool)> setter = [&proto_icon](bool val) { proto_icon.set_category(val); };
-        do_nothing(this->category, state, setter);
-    }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_icon](waypoint::RGBAColor* val) { proto_icon.set_allocated_rgba_color(val); };
         color_to_proto(this->color, state, setter);
@@ -620,9 +616,6 @@ void Icon::parse_protobuf(waypoint::Icon proto_icon, ProtoReaderState* state) {
     }
     if (proto_icon.trigger().bounce_height() != 0) {
         proto_to_float(proto_icon.trigger().bounce_height(), state, &(this->bounce_height), &(this->bounce_height_is_set));
-    }
-    if (proto_icon.category() != 0) {
-        do_nothing(proto_icon.category(), state, &(this->category), &(this->category_is_set));
     }
     if (proto_icon.has_rgba_color()) {
         proto_to_color(proto_icon.rgba_color(), state, &(this->color), &(this->color_is_set));

--- a/xml_converter/src/trail_gen.cpp
+++ b/xml_converter/src/trail_gen.cpp
@@ -261,10 +261,6 @@ waypoint::Trail Trail::as_protobuf(ProtoWriterState* state) const {
         std::function<void(float)> setter = [&proto_trail](float val) { proto_trail.set_animation_speed(val); };
         float_to_proto(this->animation_speed, state, setter);
     }
-    if (this->category_is_set) {
-        std::function<void(bool)> setter = [&proto_trail](bool val) { proto_trail.set_category(val); };
-        do_nothing(this->category, state, setter);
-    }
     if (this->color_is_set) {
         std::function<void(waypoint::RGBAColor*)> setter = [&proto_trail](waypoint::RGBAColor* val) { proto_trail.set_allocated_rgba_color(val); };
         color_to_proto(this->color, state, setter);
@@ -369,9 +365,6 @@ void Trail::parse_protobuf(waypoint::Trail proto_trail, ProtoReaderState* state)
     }
     if (proto_trail.animation_speed() != 0) {
         proto_to_float(proto_trail.animation_speed(), state, &(this->animation_speed), &(this->animation_speed_is_set));
-    }
-    if (proto_trail.category() != 0) {
-        do_nothing(proto_trail.category(), state, &(this->category), &(this->category_is_set));
     }
     if (proto_trail.has_rgba_color()) {
         proto_to_color(proto_trail.rgba_color(), state, &(this->color), &(this->color_is_set));


### PR DESCRIPTION
Finally, removing the requirement for a proto field attached to each attribute.

Also cleaning up the `do_nothing` hack that was present while we were unable to handle this case.

Overall this is pretty simple, we are allowing the markdown proto field to be set to null, if it is set to null then we dont include any of the proto_info into the attribute variable. If there is no proto_info in the attribute variable then the jinja template does not write anything for that attribute in the reader or the writer.

Fixes #215 