### PR TITLE
Add basic compatibility with RaidcoreGG-Nexus

### DIFF
--- a/burrito_link/deffile.def
+++ b/burrito_link/deffile.def
@@ -5,3 +5,4 @@ EXPORTS
 	D3D11CoreCreateDevice
 	get_init_addr
 	get_release_addr
+	GetAddonDef

--- a/burrito_link/dllmain.c
+++ b/burrito_link/dllmain.c
@@ -436,8 +436,8 @@ extern __declspec(dllexport) struct AddonDefinition* GetAddonDef()
 	AddonDef.Signature = -1032686481;
 	AddonDef.APIVersion = 6; // taken from Nexus.h
 	AddonDef.Name = "Burrito Link";
-	AddonDef.Version.Major = 1;
-	AddonDef.Version.Minor = 4;
+	AddonDef.Version.Major = 0;
+	AddonDef.Version.Minor = 0;
 	AddonDef.Version.Build = 0;
 	AddonDef.Version.Revision = 1;
 	AddonDef.Author = "AsherGlick";

--- a/burrito_link/dllmain.c
+++ b/burrito_link/dllmain.c
@@ -433,7 +433,7 @@ struct AddonDefinition {
 
 extern __declspec(dllexport) struct AddonDefinition* GetAddonDef()
 {
-	AddonDef.Signature = -217;
+	AddonDef.Signature = -1032686481;
 	AddonDef.APIVersion = 6; // taken from Nexus.h
 	AddonDef.Name = "Burrito Link";
 	AddonDef.Version.Major = 1;

--- a/burrito_link/dllmain.c
+++ b/burrito_link/dllmain.c
@@ -439,7 +439,7 @@ extern __declspec(dllexport) struct AddonDefinition* GetAddonDef()
 	AddonDef.Version.Major = 1;
 	AddonDef.Version.Minor = 4;
 	AddonDef.Version.Build = 0;
-	AddonDef.Version.Revision = 3;
+	AddonDef.Version.Revision = 1;
 	AddonDef.Author = "AsherGlick";
 	AddonDef.Description = "Automatically provides the link for Burrito.";
 	AddonDef.Load = start_burrito_link_thread;

--- a/burrito_link/dllmain.c
+++ b/burrito_link/dllmain.c
@@ -1,4 +1,4 @@
-﻿#define WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <d3d11.h>
 #include <stdio.h>
@@ -395,4 +395,56 @@ uintptr_t mod_release() {
 
 extern __declspec(dllexport) void* get_release_addr() {
     return mod_release;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Raidcore Nexus
+//
+// GetAddonDef()
+// 
+//
+//
+// These function is present to allow nexus to recognize this dll as a addon.
+// These function is the only function that is required all others are optional.
+////////////////////////////////////////////////////////////////////////////////
+struct AddonDefinition {
+	/* required */
+	signed int      Signature;      /* Raidcore Addon ID, set to random unqiue negative integer if not on Raidcore */
+	signed int      APIVersion;     /* Determines which AddonAPI struct revision the Loader will pass, use the NEXUS_API_VERSION define from Nexus.h */
+	const char*     Name;           /* Name of the addon as shown in the library */
+	struct AddonVersion {
+		signed short      Major;
+		signed short      Minor;
+		signed short      Build;
+		signed short      Revision;
+	} Version;
+	const char*     Author;         /* Author of the addon */
+	const char*     Description;    /* Short description */
+	void*           Load;           /* Pointer to Load Function of the addon */
+	void*           Unload;         /* Pointer to Unload Function of the addon. Not required if EAddonFlags::DisableHotloading is set. */
+	signed int      Flags;          /* Information about the addon */
+
+	/* update fallback */
+	signed int      Provider;       /* What platform is the the addon hosted on */
+	const char*     UpdateLink;     /* Link to the update resource */
+
+} AddonDef;
+
+extern __declspec(dllexport) struct AddonDefinition* GetAddonDef()
+{
+	AddonDef.Signature = -217;
+	AddonDef.APIVersion = 6; // taken from Nexus.h
+	AddonDef.Name = "Burrito Link";
+	AddonDef.Version.Major = 1;
+	AddonDef.Version.Minor = 4;
+	AddonDef.Version.Build = 0;
+	AddonDef.Version.Revision = 3;
+	AddonDef.Author = "AsherGlick";
+	AddonDef.Description = "Automatically provides the link for Burrito.";
+	AddonDef.Load = start_burrito_link_thread;
+	AddonDef.Unload = stop_burrito_link_thread;
+	AddonDef.Flags = 0;
+
+	return &AddonDef;
 }


### PR DESCRIPTION
This PR adds the necessary basics so nexus will recognize the link-dll as a valid addon.

It keeps the existing functions to load the addon intact.
I verified that every method is still working, but did no in depth testing, I don't see any conflicts or edge-cases to test.

Nexus expects the addon to know it's own version, I've set it accordingly.
While it is recommended, it is not really necessary to update it as long as the dll is installed by hand.

![1](https://github.com/user-attachments/assets/2dd436e5-7806-4ff4-9ce6-f77313994e0a)
Note: The GitHub-button will be hidden in this scenario.