### PR TITLE
Fixing the category key when loading proto files

### DIFF
--- a/xml_converter/integration_tests/run_tests.py
+++ b/xml_converter/integration_tests/run_tests.py
@@ -118,6 +118,7 @@ def rebuild_xml_converter_binary() -> None:
 ################################################################################
 line_patterns_to_ignore = [
     r"^Loading taco pack .*$",
+    r"^Loading waypoint pack .*$",
     r"^The taco parse function took [0-9]+ milliseconds to run$",
     r"^The xml write function took [0-9]+ milliseconds to run$",
     r"^The protobuf read function took [0-9]+ milliseconds to run$",
@@ -170,6 +171,7 @@ def main() -> bool:
 
         rawstdout, rawstderr, returncode = run_xml_converter(
             input_xml=testcase.xml_input_paths,
+            input_proto=testcase.proto_input_paths,
             output_xml=[xml_output_dir_path],
             output_proto=[proto_output_dir_path],
         )

--- a/xml_converter/integration_tests/test_cases/display_name_valid/input/pack/xml_file.xml
+++ b/xml_converter/integration_tests/test_cases/display_name_valid/input/pack/xml_file.xml
@@ -1,0 +1,16 @@
+<OverlayData>
+    <MarkerCategory DisplayName="My Category" Name="mycategory"></MarkerCategory>
+
+    <MarkerCategory DisplayName="Nested Level One" Name="NestedLevel1">
+        <MarkerCategory DisplayName="Nested Level Two" Name="NestedLevel2">
+            <MarkerCategory DisplayName="Nested Level Three" Name="NestedLevel3"></MarkerCategory>
+        </MarkerCategory>
+    </MarkerCategory>
+
+    <POIs>
+        <POI Type="mycategory" XPos="169.81" YPos="210.65" ZPos="215.83" MapID="50" />
+        <POI Type="nestedlevel1" XPos="169.81" YPos="210.65" ZPos="215.83" MapID="50" />
+        <POI Type="nestedlevel1.nestedlevel2" XPos="169.81" YPos="210.65" ZPos="215.83" MapID="50" />
+        <POI Type="nestedlevel1.nestedlevel2.nestedlevel3" XPos="169.81" YPos="210.65" ZPos="215.83" MapID="50" />
+    </POIs>
+</OverlayData>

--- a/xml_converter/integration_tests/test_cases/display_name_valid/output_proto/markers.bin
+++ b/xml_converter/integration_tests/test_cases/display_name_valid/output_proto/markers.bin
@@ -1,0 +1,7 @@
+
+,
+My Category 2B\Ï)Cf¦RC{ÔWCB(èÌÂ“^–
+™
+Nested Level Onef
+Nested Level Two3
+Nested Level Three 2B\Ï)Cf¦RC{ÔWCBp,TÔ…ßˆ¤ 2B\Ï)Cf¦RC{ÔWCB¸šÜ¸·xjÏ 2B\Ï)Cf¦RC{ÔWCB,’§íj@:

--- a/xml_converter/integration_tests/test_cases/display_name_valid/output_xml/xml_file.xml
+++ b/xml_converter/integration_tests/test_cases/display_name_valid/output_xml/xml_file.xml
@@ -1,0 +1,18 @@
+<OverlayData>
+<MarkerCategory  DisplayName="My Category" ID="KOjMBsKTXpY=" Name="mycategory">
+</MarkerCategory>
+
+<MarkerCategory  DisplayName="Nested Level One" ID="LJKn7WpADjo=" Name="NestedLevel1">
+	<MarkerCategory  DisplayName="Nested Level Two" ID="uJrcuLd4as8=" Name="NestedLevel2">
+	<MarkerCategory  DisplayName="Nested Level Three" ID="cCxU1IXfiKQ=" Name="NestedLevel3">
+</MarkerCategory>
+</MarkerCategory>
+</MarkerCategory>
+
+<POIs>
+<POI  Type="mycategory" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevel1" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevel1.nestedlevel2" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevel1.nestedlevel2.nestedlevel3" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+</POIs>
+</OverlayData>

--- a/xml_converter/integration_tests/test_cases/display_name_valid/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/display_name_valid/testcase.yaml
@@ -1,0 +1,5 @@
+input_paths: 
+    "pack": "xml"
+expected_stdout: |
+expected_stderr: |
+expected_returncode: 0

--- a/xml_converter/integration_tests/test_cases/proto_type_valid/input/pack/markers.bin
+++ b/xml_converter/integration_tests/test_cases/proto_type_valid/input/pack/markers.bin
@@ -1,0 +1,7 @@
+
+,
+My Category 2B\Ï)Cf¦RC{ÔWCB(èÌÂ“^–
+™
+Nested Level Onef
+Nested Level Two3
+Nested Level Three 2B\Ï)Cf¦RC{ÔWCBp,TÔ…ßˆ¤ 2B\Ï)Cf¦RC{ÔWCB¸šÜ¸·xjÏ 2B\Ï)Cf¦RC{ÔWCB,’§íj@:

--- a/xml_converter/integration_tests/test_cases/proto_type_valid/output_proto/markers.bin
+++ b/xml_converter/integration_tests/test_cases/proto_type_valid/output_proto/markers.bin
@@ -1,0 +1,7 @@
+
+,
+My Category 2B\Ï)Cf¦RC{ÔWCB(èÌÂ“^–
+™
+Nested Level Onef
+Nested Level Two3
+Nested Level Three 2B\Ï)Cf¦RC{ÔWCBp,TÔ…ßˆ¤ 2B\Ï)Cf¦RC{ÔWCB¸šÜ¸·xjÏ 2B\Ï)Cf¦RC{ÔWCB,’§íj@:

--- a/xml_converter/integration_tests/test_cases/proto_type_valid/output_xml/xml_file.xml
+++ b/xml_converter/integration_tests/test_cases/proto_type_valid/output_xml/xml_file.xml
@@ -1,0 +1,18 @@
+<OverlayData>
+<MarkerCategory  DisplayName="My Category" ID="KOjMBsKTXpY=" Name="mycategory">
+</MarkerCategory>
+
+<MarkerCategory  DisplayName="Nested Level One" ID="LJKn7WpADjo=" Name="nestedlevelone">
+	<MarkerCategory  DisplayName="Nested Level Two" ID="uJrcuLd4as8=" Name="nestedleveltwo">
+	<MarkerCategory  DisplayName="Nested Level Three" ID="cCxU1IXfiKQ=" Name="nestedlevelthree">
+</MarkerCategory>
+</MarkerCategory>
+</MarkerCategory>
+
+<POIs>
+<POI  Type="mycategory" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevelone" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevelone.nestedleveltwo" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+<POI  Type="nestedlevelone.nestedleveltwo.nestedlevelthree" MapID="50" XPos="169.809998" YPos="210.649994" ZPos="215.830002"/>
+</POIs>
+</OverlayData>

--- a/xml_converter/integration_tests/test_cases/proto_type_valid/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/proto_type_valid/testcase.yaml
@@ -1,0 +1,5 @@
+input_paths: 
+    "pack": "proto"
+expected_stdout: |
+expected_stderr: |
+expected_returncode: 0

--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -29,8 +29,10 @@ void parse_waypoint_categories(
     map<string, Category>* marker_categories,
     vector<Parseable*>* parsed_pois,
     ProtoReaderState* state) {
-    full_category_name += proto_category.name();
-    Category* this_category = &(*marker_categories)[full_category_name];
+
+    string category_name = normalize(proto_category.name());
+    full_category_name += category_name;
+    Category* this_category = &(*marker_categories)[category_name];
 
     this_category->parse_protobuf(proto_category, state);
 
@@ -40,6 +42,7 @@ void parse_waypoint_categories(
         // TODO: The field category in Icon is being deprciated
         // This overwrites any icon.category with its position in the heirarchy
         icon->category.category = full_category_name;
+        icon->category_is_set = true;
         parsed_pois->push_back(icon);
     }
     for (int i = 0; i < proto_category.trail_size(); i++) {
@@ -48,6 +51,7 @@ void parse_waypoint_categories(
         // TODO: The field category in Trail is being deprciated
         // This overwrites any trail.category with its position in the heirarchy
         trail->category.category = full_category_name;
+        trail->category_is_set = true;
         parsed_pois->push_back(trail);
     }
 
@@ -216,10 +220,12 @@ void write_protobuf_file(
         Parseable* parsed_poi = (*parsed_pois)[i];
         if (parsed_poi->classname() == "POI") {
             Icon* icon = dynamic_cast<Icon*>(parsed_poi);
+            // TODO(331): This is the wrong place to lowercase() the category and is hiding some crimes elsewhere
             category_to_pois[lowercase(icon->category.category)].push_back(parsed_poi);
         }
         else if (parsed_poi->classname() == "Trail") {
             Trail* trail = dynamic_cast<Trail*>(parsed_poi);
+            // TODO(331): This is the wrong place to lowercase() the category and is hiding some crimes elsewhere
             category_to_pois[lowercase(trail->category.category)].push_back(parsed_poi);
         }
         else {

--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -29,7 +29,6 @@ void parse_waypoint_categories(
     map<string, Category>* marker_categories,
     vector<Parseable*>* parsed_pois,
     ProtoReaderState* state) {
-
     string category_name = normalize(proto_category.name());
     full_category_name += category_name;
     Category* this_category = &(*marker_categories)[category_name];


### PR DESCRIPTION
Changes the proto loading code to properly assign category names to the category children map. This was causing errors where no output was being written to proto files if the input was also proto files.

Also adding new tests
Also adding the ability to have proto file inputs to the test harness.