### PR TITLE
Single File for saving imported packs

### DIFF
--- a/Spatial.gd
+++ b/Spatial.gd
@@ -1110,8 +1110,8 @@ func _on_ImportPackDialog_dir_selected(dir):
 	var user_data_dir = str(OS.get_user_data_dir())
 	var args: PoolStringArray = [
 		"--input-taco-path", dir,
-		"--input-waypoint-path", self.saved_markers_dir,
-		"--output-waypoint-path", self.saved_markers_dir,
+		"--input-waypoint-path", ProjectSettings.globalize_path(self.saved_markers_dir),
+		"--output-waypoint-path", ProjectSettings.globalize_path(self.saved_markers_dir),
 		"--output-split-waypoint-path", ProjectSettings.globalize_path(self.unsaved_markers_dir)
 	]
 	FileHandler.call_xml_converter(args)
@@ -1123,6 +1123,6 @@ func _on_SaveData_pressed():
 	var user_data_dir = str(OS.get_user_data_dir())
 	var args: PoolStringArray = [
 		"--input-waypoint-path", ProjectSettings.globalize_path(self.unsaved_markers_dir),
-		"--output-waypoint-path", self.saved_markers_dir,
+		"--output-waypoint-path", ProjectSettings.globalize_path(self.saved_markers_dir),
 	]
 	FileHandler.call_xml_converter(args)

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -405,6 +405,7 @@ var waypoint_data = Waypoint.Waypoint.new()
 # by Map ID. All changes made by the editor are automatically saved in these
 # files prior to export.
 var unsaved_markers_dir = "user://protobin_by_map_id/"
+var saved_markers_dir = "user://protobin/"
 var marker_file_path = ""
 
 func load_waypoint_markers(map_id_to_load: int):
@@ -1109,11 +1110,19 @@ func _on_ImportPackDialog_dir_selected(dir):
 	var user_data_dir = str(OS.get_user_data_dir())
 	var args: PoolStringArray = [
 		"--input-taco-path", dir,
-		# TODO: This line is not working as intended and needs to be investigated
-		# "--input-waypoint-path", user_data_dir.plus_file("protobin"),
-		"--output-waypoint-path", user_data_dir.plus_file("protobin"),
+		"--input-waypoint-path", self.saved_markers_dir,
+		"--output-waypoint-path", self.saved_markers_dir,
 		"--output-split-waypoint-path", ProjectSettings.globalize_path(self.unsaved_markers_dir)
 	]
 	FileHandler.call_xml_converter(args)
 	save_hashes()
 	load_waypoint_markers(self.map_id)
+
+
+func _on_SaveData_pressed():
+	var user_data_dir = str(OS.get_user_data_dir())
+	var args: PoolStringArray = [
+		"--input-waypoint-path", ProjectSettings.globalize_path(self.unsaved_markers_dir),
+		"--output-waypoint-path", self.saved_markers_dir,
+	]
+	FileHandler.call_xml_converter(args)

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -241,7 +241,7 @@ margin_bottom = 92.0
 rect_min_size = Vector2( 0, 40 )
 text = "Import Marker Pack"
 
-[node name="SaveTrail" type="Button" parent="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer"]
+[node name="SaveData" type="Button" parent="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer"]
 margin_top = 96.0
 margin_right = 220.0
 margin_bottom = 136.0
@@ -889,7 +889,7 @@ material/0 = SubResource( 4 )
 [connection signal="hide" from="Control/Dialogs/MainMenu" to="." method="_on_Dialog_hide"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/LoadTrail" to="." method="_on_LoadTrail_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/ImportPath" to="." method="_on_ImportPath_pressed"]
-[connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/SaveTrail" to="." method="_on_SaveTrail_pressed"]
+[connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/SaveData" to="." method="_on_SaveData_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/OpenEditorQuickPanel" to="." method="_on_OpenEditorQuickPanel_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/Ranges" to="." method="_on_RangesButton_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/Settings" to="." method="_on_Settings_pressed"]

--- a/xml_converter/src/attribute/image.cpp
+++ b/xml_converter/src/attribute/image.cpp
@@ -39,7 +39,7 @@ string image_to_xml_attribute(
     const Image* value) {
     if (filesystem::exists(filesystem::path(value->original_filepath))) {
         filesystem::path output_path = filesystem::path(state->marker_pack_root_directory) / value->filename;
-        if (value->original_filepath != output_path){
+        if (value->original_filepath != output_path) {
             filesystem::create_directories(output_path.parent_path());
             filesystem::copy_file(filesystem::path(value->original_filepath), output_path, filesystem::copy_options::overwrite_existing);
         }
@@ -89,7 +89,7 @@ void image_to_proto(
         state->textures.push_back(&value);
         if (filesystem::exists(filesystem::path(value.original_filepath))) {
             filesystem::path output_path = filesystem::path(state->marker_pack_root_directory) / value.filename;
-            if (value.original_filepath != output_path){
+            if (value.original_filepath != output_path) {
                 filesystem::create_directories(output_path.parent_path());
                 filesystem::copy_file(filesystem::path(value.original_filepath), output_path, filesystem::copy_options::overwrite_existing);
             }

--- a/xml_converter/src/attribute/image.cpp
+++ b/xml_converter/src/attribute/image.cpp
@@ -39,8 +39,10 @@ string image_to_xml_attribute(
     const Image* value) {
     if (filesystem::exists(filesystem::path(value->original_filepath))) {
         filesystem::path output_path = filesystem::path(state->marker_pack_root_directory) / value->filename;
-        filesystem::create_directories(output_path.parent_path());
-        filesystem::copy_file(filesystem::path(value->original_filepath), output_path, filesystem::copy_options::overwrite_existing);
+        if (value->original_filepath != output_path){
+            filesystem::create_directories(output_path.parent_path());
+            filesystem::copy_file(filesystem::path(value->original_filepath), output_path, filesystem::copy_options::overwrite_existing);
+        }
     }
     else {
         cout << "Warning: File path " << value->original_filepath << " not found." << endl;
@@ -87,8 +89,10 @@ void image_to_proto(
         state->textures.push_back(&value);
         if (filesystem::exists(filesystem::path(value.original_filepath))) {
             filesystem::path output_path = filesystem::path(state->marker_pack_root_directory) / value.filename;
-            filesystem::create_directories(output_path.parent_path());
-            filesystem::copy_file(filesystem::path(value.original_filepath), output_path, filesystem::copy_options::overwrite_existing);
+            if (value.original_filepath != output_path){
+                filesystem::create_directories(output_path.parent_path());
+                filesystem::copy_file(filesystem::path(value.original_filepath), output_path, filesystem::copy_options::overwrite_existing);
+            }
         }
         else {
             cout << "Warning: File path " << value.original_filepath << " not found." << endl;


### PR DESCRIPTION
This changes the saved files to contain one single protobin file. This file is the definitive file and any changes to the internal data can be saved to it. 

Changed import function to add new pack into existing packs instead of overwriting.

A bug emerged where filesystem was faulting when both paths were identical. I thought this would have been covered by the copy_options.