### PR TITLE
Edit description of Icon Size to clarify what the value does

### DIFF
--- a/xml_converter/doc/scale/icon_size.md
+++ b/xml_converter/doc/scale/icon_size.md
@@ -5,7 +5,7 @@ applies_to: [Icon]
 xml_fields: [IconSize]
 protobuf_field: tentative__scale
 ---
-Unclear) Some value representation of how large an icon should be. Is this a scale multiplier or a fixed size value? How does this relate to MinSize and MaxSize.
+Multiplier on the size of an image (i.e. 1 is a 100%, 2 is 200%).
 
 Notes
 =====

--- a/xml_converter/doc/scale/icon_size.md
+++ b/xml_converter/doc/scale/icon_size.md
@@ -5,7 +5,7 @@ applies_to: [Icon]
 xml_fields: [IconSize]
 protobuf_field: tentative__scale
 ---
-Multiplier on the size of an image (i.e. 1 is a 100%, 2 is 200%).
+Multiplier on the size of an image (i.e. 1 is 100%, 2 is 200%).
 
 Notes
 =====


### PR DESCRIPTION
I confirmed with a path dev that IconSize is a multiplier on the size of an image. 