### PR TITLE
Adding codegen runscript

### DIFF
--- a/xml_converter/generators/run.sh
+++ b/xml_converter/generators/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+source ../venv/bin/activate
+python main.py


### PR DESCRIPTION
This is a helper script that can be used to generate code even when not in the directory that contains the generator.