### PR TITLE
Removing Individual File Conversion

### DIFF
--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -82,13 +82,6 @@ map<string, vector<string>> read_taco_directory(
             }
         }
     }
-    else if (filesystem::is_regular_file(input_path)) {
-        set<string> top_level_category_names = parse_xml_file(input_path, get_base_dir(input_path), marker_categories, parsed_pois);
-        string filename = filesystem::path(input_path).filename();
-        for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
-            top_level_category_file_locations[*it].push_back(filename);
-        }
-    }
     return top_level_category_file_locations;
 }
 
@@ -109,13 +102,6 @@ map<string, vector<string>> read_burrito_directory(
             for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
                 top_level_category_file_locations[*it].push_back(relative_path);
             }
-        }
-    }
-    else if (filesystem::is_regular_file(input_path)) {
-        set<string> top_level_category_names = read_protobuf_file(input_path, get_base_dir(input_path), marker_categories, parsed_pois);
-        string filename = filesystem::path(input_path).filename();
-        for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
-            top_level_category_file_locations[*it].push_back(filename);
         }
     }
     return top_level_category_file_locations;


### PR DESCRIPTION
While this functionality was useful in early stages of prototyping, we dont want to support the ability to convert a single xml file. There are no marker packs that are a single xml file and there cannot be unless that marker pack also had no images. In all cases a marker pack is a directory, or a zip file.

Removing this functionality now makes the way for the eventual inclusion of zip file support. If the target input path is a directory then the code will perform as it currently does. But in the future if the target input path is a file then we will be able to assume it is a zip file.