### PR TITLE
Installing libzip in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install gtest
         run: sudo apt-get install libgtest-dev
 
+      - name: Install libzip
+        run: sudo apt-get install libzip-dev
+
       - name: Install cpplint
         run: |
           pip3 install cpplint==1.6.1


### PR DESCRIPTION
This adds the ability to compile with the libzip dependency in the github's CI. This is being added ahead of the code that will need to use it.