### PR TITLE
Fixing the stdout mismatch with the guildpoint file renames in the integration tests

### DIFF
--- a/xml_converter/integration_tests/test_cases/proto_and_xml_input_no_duplicates/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/proto_and_xml_input_no_duplicates/testcase.yaml
@@ -10,7 +10,7 @@ expected_stdout: |
     The following top level categories were found in more than one pack:
         "mycategory" in files:
             pack/xml_file.xml
-            pack2/markers.bin
+            pack2/markers.guildpoint
             pack3/xml_file.xml
 expected_stderr: |
 expected_returncode: 0


### PR DESCRIPTION
Fixing a leftover issue from the bin -> guildpoint rename migration.