### PR TITLE
Adding integration tests to github ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,11 @@ jobs:
           cp build/compile_commands.json ./compile_commands.json
           ./presubmit.sh
 
+      - name: Run Integration Tests
+        run: |
+          cd xml_converter/integration_tests
+          ./run_tests.py --no-build
+
       - name: Upload created file
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This adds the integration tests to the automatic CI scripts so that any errors with them can be caught automatically.