### PR TITLE
Allow bad unicode when reading the integration test output instead of crashing the test harness

### DIFF
--- a/xml_converter/integration_tests/run_tests.py
+++ b/xml_converter/integration_tests/run_tests.py
@@ -40,9 +40,13 @@ def run_xml_converter(
         cmd += ["--allow-duplicates"]
 
     # Run the C++ program and capture its output
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    return (result.stdout, result.stderr, result.returncode)
+    return (
+        result.stdout.decode(encoding="utf-8", errors="backslashreplace"),
+        result.stderr.decode(encoding="utf-8", errors="backslashreplace"),
+        result.returncode,
+    )
 
 
 def compare_text_files(file_path1: str, file_path2: str) -> List[str]:

--- a/xml_converter/integration_tests/src/proto_utils.py
+++ b/xml_converter/integration_tests/src/proto_utils.py
@@ -67,4 +67,4 @@ def get_guildpoint_textproto(protobin_path: str) -> str:
 
         # TODO: sanity check return code, stdout, and stderr
 
-        return result.stdout.decode("utf-8")
+        return result.stdout.decode("utf-8", errors="backslashreplace")


### PR DESCRIPTION
If for any reason the stdout from the xml_converter process is invalid utf-8 we should still parse it for the stdout diff instead of crashing the whole integration test parser process. This way it becomes possible to debug the error.