### PR TITLE
Pipe through MarkerPackFile into the packaging functions

### DIFF
--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -61,20 +61,25 @@ string parse_guildpoint_categories(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// read_protobuf_file
 //
+// Reads a protobuf file into memory.
 ////////////////////////////////////////////////////////////////////////////////
-set<string> read_protobuf_file(string proto_filepath, const string marker_pack_root_directory, map<string, Category>* marker_categories, vector<Parseable*>* parsed_pois) {
-    fstream infile;
-    guildpoint::Guildpoint proto_message;
-    ProtoReaderState state;
-    state.marker_pack_root_directory = marker_pack_root_directory;
-    set<string> category_names;
+set<string> read_protobuf_file(
+    const MarkerPackFile& proto_filepath,
+    map<string, Category>* marker_categories,
+    vector<Parseable*>* parsed_pois) {
+    ifstream infile;
+    infile.open(proto_filepath.tmp_get_path(), ios::in | ios::binary);
 
-    infile.open(proto_filepath, ios::in | ios::binary);
+    guildpoint::Guildpoint proto_message;
     proto_message.ParseFromIstream(&infile);
 
+    ProtoReaderState state;
+    state.marker_pack_root_directory = proto_filepath.base;
     state.textures = proto_message.textures();
 
+    set<string> category_names;
     for (int i = 0; i < proto_message.category_size(); i++) {
         category_names.insert(parse_guildpoint_categories("", proto_message.category(i), marker_categories, parsed_pois, &state));
     }

--- a/xml_converter/src/packaging_protobin.hpp
+++ b/xml_converter/src/packaging_protobin.hpp
@@ -7,13 +7,13 @@
 #include <vector>
 
 #include "category_gen.hpp"
+#include "file_helper.hpp"
 #include "guildpoint.pb.h"
 #include "parseable.hpp"
 #include "string_hierarchy.hpp"
 
 std::set<std::string> read_protobuf_file(
-    std::string proto_filepath,
-    const std::string marker_pack_root_directory,
+    const MarkerPackFile& proto_filepath,
     std::map<std::string, Category>* marker_categories,
     std::vector<Parseable*>* parsed_pois);
 

--- a/xml_converter/src/packaging_xml.cpp
+++ b/xml_converter/src/packaging_xml.cpp
@@ -1,5 +1,6 @@
 #include "packaging_xml.hpp"
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -210,26 +211,35 @@ vector<Parseable*> parse_pois(rapidxml::xml_node<>* root_node, map<string, Categ
 //
 // A function which parses a single XML file into their corrisponding classes.
 ////////////////////////////////////////////////////////////////////////////////
-set<string> parse_xml_file(string xml_filepath, const string marker_pack_root_directory, map<string, Category>* marker_categories, vector<Parseable*>* parsed_pois) {
+set<string> parse_xml_file(
+    const MarkerPackFile& xml_filepath,
+    map<string, Category>* marker_categories,
+    vector<Parseable*>* parsed_pois) {
     vector<XMLError*> errors;
+
+    ifstream input_filestream;
+    input_filestream.open(xml_filepath.tmp_get_path(), ios::in | ios::binary);
+
+    rapidxml::file<> xml_file(input_filestream);
+
+    string tmp_get_path = xml_filepath.tmp_get_path();
+
     rapidxml::xml_document<> doc;
-    rapidxml::xml_node<>* root_node;
-    XMLReaderState state;
-    state.marker_pack_root_directory = marker_pack_root_directory;
-    set<string> category_names;
+    doc.parse<rapidxml::parse_non_destructive | rapidxml::parse_no_data_nodes>(xml_file.data(), tmp_get_path.c_str());
 
-    rapidxml::file<> xml_file(xml_filepath.c_str());
-    doc.parse<rapidxml::parse_non_destructive | rapidxml::parse_no_data_nodes>(xml_file.data(), xml_filepath.c_str());
-
-    root_node = doc.first_node();
+    rapidxml::xml_node<>* root_node = doc.first_node();
     // Validate the Root Node
     if (get_node_name(root_node) != "OverlayData") {
         errors.push_back(new XMLNodeNameError("Root node should be of type OverlayData", root_node));
     }
     if (root_node->first_attribute() != nullptr) {
-        cout << "Root Node has attributes when it should have none in " << xml_filepath << endl;
+        cout << "Root Node has attributes when it should have none in " << xml_filepath.tmp_get_path() << endl;
     }
 
+    XMLReaderState state;
+    state.marker_pack_root_directory = xml_filepath.base;
+
+    set<string> category_names;
     for (rapidxml::xml_node<>* node = root_node->first_node(); node; node = node->next_sibling()) {
         if (get_node_name(node) == "MarkerCategory") {
             OptionalString name = parse_marker_categories(node, marker_categories, nullptr, &errors, &state);
@@ -246,7 +256,7 @@ set<string> parse_xml_file(string xml_filepath, const string marker_pack_root_di
         }
     }
 
-    for (auto error : errors) {
+    for (XMLError* error : errors) {
         error->print_error();
     }
     return category_names;

--- a/xml_converter/src/packaging_xml.hpp
+++ b/xml_converter/src/packaging_xml.hpp
@@ -6,14 +6,14 @@
 #include <vector>
 
 #include "category_gen.hpp"
+#include "file_helper.hpp"
 #include "parseable.hpp"
 #include "rapidxml-1.13/rapidxml.hpp"
 #include "rapidxml-1.13/rapidxml_utils.hpp"
 #include "state_structs/xml_reader_state.hpp"
 
 std::set<std::string> parse_xml_file(
-    std::string xml_filepath,
-    const std::string marker_pack_root_directory,
+    const MarkerPackFile& xml_filepath,
     std::map<std::string, Category>* marker_categories,
     std::vector<Parseable*>* parsed_pois);
 

--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -44,7 +44,7 @@ map<string, vector<string>> read_taco_directory(
         string directory_name = filesystem::path(input_path).filename();
         vector<MarkerPackFile> xml_files = get_files_by_suffix(input_path, ".xml");
         for (const MarkerPackFile& path : xml_files) {
-            set<string> top_level_category_names = parse_xml_file(path.tmp_get_path(), input_path, marker_categories, parsed_pois);
+            set<string> top_level_category_names = parse_xml_file(path, marker_categories, parsed_pois);
             string relative_path = join_file_paths(directory_name, path.relative_filepath);
             for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
                 top_level_category_file_locations[*it].push_back(relative_path);
@@ -66,7 +66,7 @@ map<string, vector<string>> read_burrito_directory(
         string directory_name = filesystem::path(input_path).filename();
         vector<MarkerPackFile> burrito_files = get_files_by_suffix(input_path, ".guildpoint");
         for (const MarkerPackFile& path : burrito_files) {
-            set<string> top_level_category_names = read_protobuf_file(path.tmp_get_path(), input_path, marker_categories, parsed_pois);
+            set<string> top_level_category_names = read_protobuf_file(path, marker_categories, parsed_pois);
             string relative_path = join_file_paths(directory_name, path.relative_filepath);
             for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
                 top_level_category_file_locations[*it].push_back(relative_path);


### PR DESCRIPTION
This makes the packaging function use the agnostic MarkerPackFile instead of a string path. Still a few uses of `tmp_get_path()` which indicate to me that we will need some sort of `display_path()` function that is able to return a human readable path value for zip_file contents.

For a markerpack directory the solution is trivial
`some_markerpack_dir/somefile.xml`

But for a markerpack zipfile there are tradeoffs
`some_markerpack_file.zip/somefile.xml`
`some_markerpack_file.zip#/somefile.xml`