### PR TITLE
Adding abstraction to read zip files

### DIFF
--- a/xml_converter/CMakeLists.txt
+++ b/xml_converter/CMakeLists.txt
@@ -27,6 +27,12 @@ add_library(${CORE_LIB} STATIC ${SOURCES} ${PROTO_SRC})
 # Include protobuf libraies.
 target_link_libraries(${CORE_LIB} PUBLIC ${Protobuf_LIBRARIES})
 
+# Include LibZip libraries.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBZIP REQUIRED libzip)
+target_include_directories(${CORE_LIB} PRIVATE ${LIBZIP_INCLUDE_DIRS})
+target_link_libraries(${CORE_LIB} PRIVATE ${LIBZIP_LIBRARIES})
+
 if(MSVC)
   target_compile_options(${CORE_LIB} PUBLIC /W4 /WX)
 else()

--- a/xml_converter/src/file_helper.hpp
+++ b/xml_converter/src/file_helper.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,3 +16,5 @@ class MarkerPackFile {
 void copy_file(std::string path, std::string new_path);
 
 std::vector<MarkerPackFile> get_files_by_suffix(const std::string& base, const std::string& suffix);
+
+std::unique_ptr<std::basic_istream<char>> open_file_for_read(const MarkerPackFile& file);

--- a/xml_converter/src/packaging_protobin.cpp
+++ b/xml_converter/src/packaging_protobin.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -69,11 +70,10 @@ set<string> read_protobuf_file(
     const MarkerPackFile& proto_filepath,
     map<string, Category>* marker_categories,
     vector<Parseable*>* parsed_pois) {
-    ifstream infile;
-    infile.open(proto_filepath.tmp_get_path(), ios::in | ios::binary);
+    unique_ptr<basic_istream<char>> infile = open_file_for_read(proto_filepath);
 
     guildpoint::Guildpoint proto_message;
-    proto_message.ParseFromIstream(&infile);
+    proto_message.ParseFromIstream(&*infile);
 
     ProtoReaderState state;
     state.marker_pack_root_directory = proto_filepath.base;

--- a/xml_converter/src/packaging_xml.cpp
+++ b/xml_converter/src/packaging_xml.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <set>
 #include <utility>
 
@@ -217,10 +218,9 @@ set<string> parse_xml_file(
     vector<Parseable*>* parsed_pois) {
     vector<XMLError*> errors;
 
-    ifstream input_filestream;
-    input_filestream.open(xml_filepath.tmp_get_path(), ios::in | ios::binary);
+    unique_ptr<basic_istream<char>> infile = open_file_for_read(xml_filepath);
 
-    rapidxml::file<> xml_file(input_filestream);
+    rapidxml::file<> xml_file(*infile);
 
     string tmp_get_path = xml_filepath.tmp_get_path();
 


### PR DESCRIPTION
Theoretically should be able to read contents from zip files. There are other locations in-code that directly access the filesystem that need to be updated to use this new feature, such as `src/attribute/image.cpp`, which we will need to migrate as well before we can add automated integration tests.