### PR TITLE
Proto differ checker

### DIFF
--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -100,7 +100,7 @@ jobs:
             const timestamp_regex = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ \+\d{4}/g;
 
             // Check if a similar comment already exists
-            if (most_recent_comment && most_recent_comment.replace(timestamp_regex, '') === comment_body.replace(timestamp_regex, '')) {
+            if (most_recent_comment && most_recent_comment.body.replace(timestamp_regex, '') === comment_body.replace(timestamp_regex, '')) {
               console.log(`Skipping file ${file}, identical comment already exists.`);
               continue;
             }

--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -62,12 +62,29 @@ jobs:
           const issue_number = context.issue.number;
           const githubToken = process.env.GITHUB_TOKEN;
 
+          // Get the existing comments.
+          const {data: comments} = await github.rest.pulls.listReviewComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: issue_number,
+          })
+
           const files = fs.readFileSync('file_list.txt', 'utf8').split("\n");
 
           for (let file of files) {
             if (file == "") {
               continue;
             }
+
+            // Filter comments related to the current file
+            const file_comments = comments.filter(comment => comment.path === file);
+
+            // Sort comments by creation date in descending order
+            file_comments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            // Get the most recent comment
+            const most_recent_comment = file_comments.length > 0 ? file_comments[0] : null;
+
             const diff_contents = fs.readFileSync(file + "._diff", 'utf8')
             let comment_body = [
               "<details>",
@@ -79,6 +96,15 @@ jobs:
               "</details>",
             ].join("\n");
             
+            // Regular expression to remove timestamps from the diff contents
+            const timestamp_regex = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ \+\d{4}/g;
+
+            // Check if a similar comment already exists
+            if (most_recent_comment && most_recent_comment.replace(timestamp_regex, '') === comment_body.replace(timestamp_regex, '')) {
+              console.log(`Skipping file ${file}, identical comment already exists.`);
+              continue;
+            }
+
             console.log(file)
 
             await github.rest.pulls.createReviewComment({

--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -40,7 +40,7 @@ jobs:
             touch $file.textproto._new
           fi
 
-          diff -u $file.textproto._old $file.textproto._new > $file._diff || true
+          diff -u $file.textproto._old --label old $file.textproto._new --label new > $file._diff || true
           echo $file >> file_list.txt
         done
 
@@ -67,7 +67,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: issue_number,
-          })
+          });
 
           const files = fs.readFileSync('file_list.txt', 'utf8').split("\n");
 
@@ -96,11 +96,8 @@ jobs:
               "</details>",
             ].join("\n");
             
-            // Regular expression to remove timestamps from the diff contents
-            const timestamp_regex = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ \+\d{4}/g;
-
             // Check if a similar comment already exists
-            if (most_recent_comment && most_recent_comment.body.replace(timestamp_regex, '') === comment_body.replace(timestamp_regex, '')) {
+            if (most_recent_comment && most_recent_comment.body === comment_body) {
               console.log(`Skipping file ${file}, identical comment already exists.`);
               continue;
             }


### PR DESCRIPTION
This PR fixes an annoyance where the diff checker for protobuf files was posting a comment for every commit even when an identical comment already existed. 

This checks the most recent review comment on a file and if it matches the current diff, skips making a new comment.

This should reduce the noise in longer PRs.

See https://github.com/klingbolt/Burrito/pull/19 for tests to show that the code works in expected ways. 