### PR TITLE
Added types to workflow to add trigger when PR is no longer draft

### DIFF
--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '**/*.bin'
       - '**/*.guildpoint'
+    types: [opened, synchronize, ready_for_review]
 jobs:
   custom-diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -1,11 +1,16 @@
 name: Diff Protobin
 
 on:
+  # This event occurs when there is activity on a pull request
   pull_request_target:
+    # This filter looks for files that have been changed with the suffix bin or guildpoint
     paths:
       - '**/*.bin'
       - '**/*.guildpoint'
-    types: [opened, synchronize, ready_for_review]
+    # To reduce noise, this filter restricts to the default activity plus when a draft is changed to open
+    # Default activity types as listed in the documentation are "opened, synchronize, and reopened"
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
+    types: [opened, ready_for_review, reopened, synchronize]
 jobs:
   custom-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change adds checks to the custom diff job to trigger when the PR is opened, the head is updated (new commit), or the status switches from draft to "ready for review". 

Testing to prove this workflow works can be seen here, https://github.com/klingbolt/Burrito/pull/20