### PR TITLE
Unifying output file format

### DIFF
--- a/xml_converter/integration_tests/test_cases/proto_and_xml_input_no_duplicates/testcase.yaml
+++ b/xml_converter/integration_tests/test_cases/proto_and_xml_input_no_duplicates/testcase.yaml
@@ -9,8 +9,8 @@ expected_stdout: |
     If you want to bypass this stop, use '--allow-duplicates'.
     The following top level categories were found in more than one pack:
         "mycategory" in files:
-            pack/xml_file.xml
-            pack2/markers.guildpoint
-            pack3/xml_file.xml
+            test_cases/proto_and_xml_input_no_duplicates/input/pack/xml_file.xml
+            test_cases/proto_and_xml_input_no_duplicates/input/pack2/markers.guildpoint
+            test_cases/proto_and_xml_input_no_duplicates/input/pack3/xml_file.xml
 expected_stderr: |
 expected_returncode: 0

--- a/xml_converter/src/xml_converter.cpp
+++ b/xml_converter/src/xml_converter.cpp
@@ -45,9 +45,9 @@ map<string, vector<string>> read_taco_directory(
     vector<MarkerPackFile> xml_files = get_files_by_suffix(input_path, ".xml");
     for (const MarkerPackFile& path : xml_files) {
         set<string> top_level_category_names = parse_xml_file(path, marker_categories, parsed_pois);
-        string relative_path = join_file_paths(directory_name, path.relative_filepath);
+        string file_path = join_file_paths(input_path, path.relative_filepath);
         for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
-            top_level_category_file_locations[*it].push_back(relative_path);
+            top_level_category_file_locations[*it].push_back(file_path);
         }
     }
 
@@ -67,9 +67,9 @@ map<string, vector<string>> read_burrito_directory(
     vector<MarkerPackFile> burrito_files = get_files_by_suffix(input_path, ".guildpoint");
     for (const MarkerPackFile& path : burrito_files) {
         set<string> top_level_category_names = read_protobuf_file(path, marker_categories, parsed_pois);
-        string relative_path = join_file_paths(directory_name, path.relative_filepath);
+        string file_path = join_file_paths(input_path, path.relative_filepath);
         for (set<string>::iterator it = top_level_category_names.begin(); it != top_level_category_names.end(); it++) {
-            top_level_category_file_locations[*it].push_back(relative_path);
+            top_level_category_file_locations[*it].push_back(file_path);
         }
     }
 


### PR DESCRIPTION
Changes the output for relative files with duplicate categories to be the full relative file path and not just the directory of the marker pack plus the path to the file within the directory.