### PR TITLE
Reading paths after input or output is called. 

### DIFF
--- a/xml_converter/src/argument_parser.cpp
+++ b/xml_converter/src/argument_parser.cpp
@@ -57,10 +57,6 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
                 }
                 current_paths.clear();
             }
-            else if (type != BehaviorType::NONE) {
-                cerr << "Error: Expected a path to a directory after " << current_argument << endl;
-                return {};
-            }
             current_argument = argv[i];
             type = it->second.type;
             format = it->second.format;
@@ -95,10 +91,6 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
         for (const auto& path : current_paths) {
             marker_pack_configs.emplace_back(type, format, path, split_by_map_id);
         }
-    }
-    else if (type != BehaviorType::NONE) {
-        cerr << "Error: Expected a path to a directory after " << current_argument << endl;
-        return {};
     }
 
     parsed_arguments.marker_pack_configs = marker_pack_configs;

--- a/xml_converter/src/argument_parser.cpp
+++ b/xml_converter/src/argument_parser.cpp
@@ -66,6 +66,14 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
             format = it->second.format;
             // All flags must be set to default value
             split_by_map_id = false;
+
+            while (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
+                current_paths.push_back(argv[++i]);
+            }
+            if (current_paths.empty()) {
+                cerr << "Error: Expected a path to a directory after " << current_argument << endl;
+                return {};
+            }
         }
         else if (string(argv[i]) == "--allow-duplicates") {
             parsed_arguments.allow_duplicates = true;
@@ -78,7 +86,8 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
             split_by_map_id = true;
         }
         else {
-            current_paths.push_back(argv[i]);
+            cerr << "Error: Unknown argument " << argv[i] << endl;
+            return {};
         }
     }
 

--- a/xml_converter/tests/test_argument_parser.cpp
+++ b/xml_converter/tests/test_argument_parser.cpp
@@ -151,3 +151,42 @@ TEST_F(ParseArgumentsTest, InvalidNoPathAfterOutput){
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
     EXPECT_NE(std_err.find("Error: Expected a path to a directory after --output-taco-path"), std::string::npos);
 }
+
+TEST_F(ParseArgumentsTest, InvalidFileAfterWrongArgument){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-taco-path",
+        (char*)"input1",
+        (char*)"--output-taco-path",
+        (char*)"output1",        
+        (char*)"--split-by-map-id",
+        (char*)"output2"
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    testing::internal::CaptureStderr();
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    std::string std_err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
+    EXPECT_NE(std_err.find("Error: Unknown argument output2"), std::string::npos);
+}
+
+TEST_F(ParseArgumentsTest, InvalidArgument){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-taco-path",
+        (char*)"input1",
+        (char*)"--output-taco-path",
+        (char*)"output1",
+        (char*)"--ERROR"
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    testing::internal::CaptureStderr();
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    std::string std_err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
+    EXPECT_NE(std_err.find("Error: Unknown argument --ERROR"), std::string::npos);
+}


### PR DESCRIPTION
Changed how paths are found in the parser to make sure they can only follow input and output arguments.

The old code assumed any unknown string was a file path. 