### PR TITLE
Added an argument to the parser for splitting by category

### DIFF
--- a/xml_converter/src/argument_parser.cpp
+++ b/xml_converter/src/argument_parser.cpp
@@ -62,7 +62,7 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
             type = it->second.type;
             format = it->second.format;
             // All flags must be set to default value
-            split_by_category_depth.reset();
+            split_by_category_depth.set_null();
             split_by_map_id = false;
 
             while (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
@@ -82,7 +82,7 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
                 return {};
             }
             split_by_category_depth.set_value(0);
-            while (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
+            if (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
                 if (is_string_valid_integer(argv[i + 1])) {
                     split_by_category_depth.set_value(std::stoi(argv[++i]));
                 }

--- a/xml_converter/src/argument_parser.hpp
+++ b/xml_converter/src/argument_parser.hpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "int_helper.hpp"
+
 // Defines what behavior is expected i.e. (Read/Import or Write/Export)
 enum class BehaviorType {
     IMPORT,
@@ -22,11 +24,12 @@ class MarkerPackConfig {
     BehaviorType type;
     MarkerFormat format;
     std::string path;
+    OptionalInt split_by_category;
     bool split_by_map_id = false;
 
     MarkerPackConfig();
 
-    MarkerPackConfig(BehaviorType type, MarkerFormat format, std::string path, bool split_by_map_id = false);
+    MarkerPackConfig(BehaviorType type, MarkerFormat format, std::string path, OptionalInt split_by_category, bool split_by_map_id = false);
 };
 
 class ParsedArguments {

--- a/xml_converter/src/int_helper.cpp
+++ b/xml_converter/src/int_helper.cpp
@@ -1,0 +1,10 @@
+#include "int_helper.hpp"
+
+#include <algorithm>
+
+using namespace std;
+
+bool is_string_valid_integer(const string test) {
+    if (test.empty()) return false;
+    return std::all_of(test.begin(), test.end(), ::isdigit);
+}

--- a/xml_converter/src/int_helper.hpp
+++ b/xml_converter/src/int_helper.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+class OptionalInt {
+ public:
+    OptionalInt()
+        : is_null(true), value(0) {
+    }
+
+    explicit OptionalInt(int val)
+        : is_null(false), value(val) {
+    }
+
+    void set_value(int val) {
+        is_null = false;
+        value = val;
+    }
+
+    int get_value() {
+        return value;
+    }
+
+    bool has_value() {
+        return !is_null;
+    }
+
+    void reset() {
+        is_null = true;
+        value = 0;
+    }
+
+ private:
+    bool is_null;
+    int value;
+};
+
+bool is_string_valid_integer(const std::string test);

--- a/xml_converter/src/int_helper.hpp
+++ b/xml_converter/src/int_helper.hpp
@@ -25,7 +25,7 @@ class OptionalInt {
         return !is_null;
     }
 
-    void reset() {
+    void set_null() {
         is_null = true;
         value = 0;
     }

--- a/xml_converter/tests/test_argument_parser.cpp
+++ b/xml_converter/tests/test_argument_parser.cpp
@@ -58,6 +58,67 @@ TEST_F(ParseArgumentsTest, ValidSplitMapID){
     EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
 }
 
+TEST_F(ParseArgumentsTest, ValidSplitCategory){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-guildpoint-path",
+        (char*)"input1",
+        (char*)"--output-guildpoint-path",
+        (char*)"output1",
+        (char*)"--split-by-category",
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    EXPECT_FALSE(parsed_arguments.allow_duplicates);
+
+    ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
+
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::GUILDPOINT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_category.has_value());
+
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::GUILDPOINT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_category.has_value());
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].split_by_category.get_value(), 0);
+}
+
+TEST_F(ParseArgumentsTest, ValidSplitCategoryWithDepth){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-guildpoint-path",
+        (char*)"input1",
+        (char*)"--output-guildpoint-path",
+        (char*)"output1",
+        (char*)"--split-by-category",
+        (char*)"2",
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    EXPECT_FALSE(parsed_arguments.allow_duplicates);
+
+    ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
+
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::GUILDPOINT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_category.has_value());
+
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::GUILDPOINT);
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
+    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_category.has_value());
+    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].split_by_category.get_value(), 2);
+}
+
 TEST_F(ParseArgumentsTest, ValidMultipleInputPaths){
     char* argv[] = {
         (char*)"./xml_converter",
@@ -189,4 +250,24 @@ TEST_F(ParseArgumentsTest, InvalidArgument){
 
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
     EXPECT_NE(std_err.find("Error: Unknown argument --ERROR"), std::string::npos);
+}
+
+TEST_F(ParseArgumentsTest, InvalidTypeAfterSplitCategory){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-taco-path",
+        (char*)"input1",
+        (char*)"--output-guildpoint-path",
+        (char*)"output1",
+        (char*)"--split-by-category",
+        (char*)"output2"
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    testing::internal::CaptureStderr();
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    std::string std_err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
+    EXPECT_NE(std_err.find("Error: expected an integer after --split-by-category but received output2"), std::string::npos);
 }

--- a/xml_converter/tests/test_argument_parser.cpp
+++ b/xml_converter/tests/test_argument_parser.cpp
@@ -271,3 +271,25 @@ TEST_F(ParseArgumentsTest, InvalidTypeAfterSplitCategory){
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
     EXPECT_NE(std_err.find("Error: expected an integer after --split-by-category but received output2"), std::string::npos);
 }
+
+TEST_F(ParseArgumentsTest, InvalidMultipleIntsAfterSplitCategory){
+    char* argv[] = {
+        (char*)"./xml_converter",
+        (char*)"--input-taco-path",
+        (char*)"input1",
+        (char*)"--output-guildpoint-path",
+        (char*)"output1",
+        (char*)"--split-by-category",
+        (char*)"1",
+        (char*)"2",
+        (char*)"3"
+    };
+    int argc = sizeof(argv) / sizeof(char*);
+
+    testing::internal::CaptureStderr();
+    ParsedArguments parsed_arguments = parse_arguments(argc, argv);
+    std::string std_err = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
+    EXPECT_NE(std_err.find("Error: Unknown argument 2"), std::string::npos);
+}


### PR DESCRIPTION
This argument will be used to determine the depth in the category tree that the outputs should be split by with a default value of 0.