### PR TITLE
Adding an ability to parse the xml_converter duplicate category output

### DIFF
--- a/FileHandler.gd
+++ b/FileHandler.gd
@@ -2,7 +2,7 @@ const identify_duplicate_categories = preload("res://identify_duplicate_categori
 
 const converter_executable_path = "./xml_converter/build/xml_converter"
 
-static func call_xml_converter(args: PoolStringArray):
+static func call_xml_converter(args: PoolStringArray) -> Dictionary:
 	var output: Array = []
 	print(args)
 	var result: int = OS.execute(converter_executable_path, args, true, output, true)

--- a/FileHandler.gd
+++ b/FileHandler.gd
@@ -1,3 +1,5 @@
+const identify_duplicate_categories = preload("res://identify_duplicate_categories.gd")
+
 const converter_executable_path = "./xml_converter/build/xml_converter"
 
 static func call_xml_converter(args: PoolStringArray):
@@ -9,6 +11,7 @@ static func call_xml_converter(args: PoolStringArray):
 		print("Failed to execute the converter. Error code:", result)
 	else:
 		print("Command executed successfully.")
+	return identify_duplicate_categories.get_duplicate_categories(output[0])
 
 static func create_directory_if_missing(path: String):
 	var dir = Directory.new()

--- a/identify_duplicate_categories.gd
+++ b/identify_duplicate_categories.gd
@@ -1,24 +1,35 @@
 ################################################################################
-# starts_with
-#
-# A helper function to see if a string starts with a paticular value or not.
-################################################################################
-static func starts_with(value: String, prefix: String):
-	if value.length() < prefix.length():
-		return false
-	return value.substr(0, prefix.length()) == prefix
-
-
-################################################################################
 # get_duplicate_categories
 #
-# Parses the stdout of the xml_converter and extracts any category colisions if
-# there are any that exist.
+# Parses the stdout of the xml_converter and extracts any category collisions
+# if there are any that exist.
+#
+# Example Input
+# =============
+#   Did not write due to duplicates in categories.
+#   This commonly occurs when attempting to read the same pack multiple times or when separate packs coincidentally have the same name.
+#   Please remove one of the packs or edit the name of the packs' top level category before running the program again.
+#   If you want to bypass this stop, use '--allow-duplicates'.
+#   The following top level categories were found in more than one pack:
+#       "mycategory" in files:
+#           pack/xml_file.xml
+#           pack2/markers.guildpoint
+#           pack3/xml_file.xml
+#
+# Example Output
+# ==============
+#   {
+#     "mycategory": [
+#       "pack/xml_file.xml",
+#       "pack2/markers.guildpoint",
+#       "pack3/xml_file.xml",
+#     ]
+#   }
 ################################################################################
 static func get_duplicate_categories(stdin: String) -> Dictionary:
 	var lines: PoolStringArray = stdin.split("\n")
 	var capturing: bool = false
-	var colisions: Dictionary = {}
+	var collisions: Dictionary = {}
 	var category = null
 	for line in lines:
 		if line == null:
@@ -27,14 +38,16 @@ static func get_duplicate_categories(stdin: String) -> Dictionary:
 			if line == "The following top level categories were found in more than one pack:":
 				capturing = true
 		elif capturing:
-			if starts_with(line, "        "):
+			if line.begins_with("        "):
+				# Remove the first 8 spaces
 				var file_name = line.substr(8)
-				colisions[category].append(file_name)
-			elif starts_with(line, "    "):
+				collisions[category].append(file_name)
+			elif line.begins_with("    "):
+				# Remove the first 4 spaces and the open quote
 				var line_without_prefix = line.substr(5)
 				var endquote_index = line_without_prefix.find("\"")
 				category = line_without_prefix.substr(0, endquote_index)
-				colisions[category] = []
+				collisions[category] = []
 			else:
 				break
-	return colisions
+	return collisions

--- a/identify_duplicate_categories.gd
+++ b/identify_duplicate_categories.gd
@@ -1,0 +1,40 @@
+################################################################################
+# starts_with
+#
+# A helper function to see if a string starts with a paticular value or not.
+################################################################################
+static func starts_with(value: String, prefix: String):
+	if value.length() < prefix.length():
+		return false
+	return value.substr(0, prefix.length()) == prefix
+
+
+################################################################################
+# get_duplicate_categories
+#
+# Parses the stdout of the xml_converter and extracts any category colisions if
+# there are any that exist.
+################################################################################
+static func get_duplicate_categories(stdin: String):
+	var lines: PoolStringArray = stdin.split("\n")
+	var capturing: bool = false
+	var colisions = {}
+	var category = null
+	for line in lines:
+		if line == null:
+			continue
+		elif !capturing:
+			if line == "The following top level categories were found in more than one pack:":
+				capturing = true
+		elif capturing:
+			if starts_with(line, "        "):
+				var file_name = line.substr(8)
+				colisions[category].append(file_name)
+			elif starts_with(line, "    "):
+				var line_without_prefix = line.substr(5)
+				var endquote_index = line_without_prefix.find("\"")
+				category = line_without_prefix.substr(0, endquote_index)
+				colisions[category] = []
+			else:
+				break
+	return colisions

--- a/identify_duplicate_categories.gd
+++ b/identify_duplicate_categories.gd
@@ -15,7 +15,7 @@ static func starts_with(value: String, prefix: String):
 # Parses the stdout of the xml_converter and extracts any category colisions if
 # there are any that exist.
 ################################################################################
-static func get_duplicate_categories(stdin: String):
+static func get_duplicate_categories(stdin: String) -> Dictionary:
 	var lines: PoolStringArray = stdin.split("\n")
 	var capturing: bool = false
 	var colisions = {}

--- a/identify_duplicate_categories.gd
+++ b/identify_duplicate_categories.gd
@@ -18,7 +18,7 @@ static func starts_with(value: String, prefix: String):
 static func get_duplicate_categories(stdin: String) -> Dictionary:
 	var lines: PoolStringArray = stdin.split("\n")
 	var capturing: bool = false
-	var colisions = {}
+	var colisions: Dictionary = {}
 	var category = null
 	for line in lines:
 		if line == null:


### PR DESCRIPTION
This adds the ability to parse the xml_converter output to detect when it reports that a duplicate category has been detected.