### PR TITLE
Improving integration test output readability with more colors

### DIFF
--- a/xml_converter/integration_tests/run_tests.py
+++ b/xml_converter/integration_tests/run_tests.py
@@ -414,8 +414,6 @@ def diff_dirs(actual_output_dir: str, expected_output_dir: str) -> bool:
     expected_only_dirs = set(expected_directories) - set(actual_directories)
     actual_only_dirs = set(actual_directories) - set(expected_directories)
 
-    filetree_diff: List[str] = []
-
     for file in expected_only_files:
         diff_found = True
         print("  |\033[31m-Expected `{}` but did not find the file in the actual output.\033[0m".format(os.path.join(expected_output_dir, file)))


### PR DESCRIPTION
* Adds colors to stdout diffs and comforms format with stdout diff format
* Conforms text file content diffs to stdout diff format
* Adds colors to file tree diffs for missing and unexpected files
* Adds highlight color to failed unit test rows to make them easily distinguishable
* Fixes protodiff identification by identifying the ".guildpoint" suffix properly.

Examples
----------
![Screenshot from 2025-03-11 19-07-54](https://github.com/user-attachments/assets/eb31e130-325f-410e-a974-abe757a11189)

![Screenshot from 2025-03-11 19-06-46](https://github.com/user-attachments/assets/da1cd352-0c7e-4d79-ab06-4ebec79084c1)

![Screenshot from 2025-03-11 19-09-02](https://github.com/user-attachments/assets/bb3ac041-42bc-40f9-9b41-e65ee7580ff6)

![Screenshot from 2025-03-11 19-08-49](https://github.com/user-attachments/assets/98d5efad-c4f4-4a7b-9af4-02712114281c)

![Screenshot from 2025-03-11 19-08-26](https://github.com/user-attachments/assets/91a7aafb-25cd-4ec9-83a3-9be3c8589bc5)

![Screenshot from 2025-03-11 19-08-07](https://github.com/user-attachments/assets/66d6d11a-cbdc-4721-a897-ef67a3335f7e)
