### PR TITLE
Adding a method of diffing trails visually in the integration test

### DIFF
--- a/xml_converter/integration_tests/run_tests.py
+++ b/xml_converter/integration_tests/run_tests.py
@@ -10,6 +10,7 @@ from src.testcase_loader import load_testcases, Testcase
 import shutil
 from src.proto_utils import compare_protos, compare_binary_file
 import zipfile
+from src.trail_utils import compare_trails
 
 # Path to compiled C++ executable
 xml_converter_binary_path: str = "../build/xml_converter"
@@ -439,9 +440,7 @@ def diff_dirs(actual_output_dir: str, expected_output_dir: str) -> bool:
         elif file_to_diff.endswith(".guildpoint"):
             diff = compare_protos(actual_file, expected_file)
         elif file_to_diff.endswith(".trl"):
-            diff = []
-            if not compare_binary_file(actual_file, expected_file):
-                diff = ['{} and {} Files Differ'.format(actual_file, expected_file)]
+            diff = compare_trails(actual_file, expected_file)
         else:
             diff = []
             if not compare_binary_file(actual_file, expected_file):

--- a/xml_converter/integration_tests/src/trail_utils.py
+++ b/xml_converter/integration_tests/src/trail_utils.py
@@ -1,0 +1,46 @@
+from .proto_utils import compare_binary_file
+from typing import List
+import difflib
+import os
+import struct
+
+
+def compare_trails(
+    expected_trail_path: str,
+    actual_trail_path: str
+) -> List[str]:
+    files_are_equal = compare_binary_file(expected_trail_path, actual_trail_path)
+
+    if files_are_equal:
+        return []
+
+    expected_textproto = get_texttrail(expected_trail_path)
+    actual_textproto = get_texttrail(actual_trail_path)
+
+    diff = list(difflib.unified_diff(actual_textproto.split("\n"), expected_textproto.split("\n"), fromfile=actual_trail_path, tofile=expected_trail_path, lineterm=""))
+
+    if len(diff) == 0:
+        diff = ["Something went wrong diffing {} and {}.".format(expected_trail_path, actual_trail_path)]
+
+    return list(diff)
+
+
+def get_texttrail(trail_path: str) -> str:
+    if not os.path.exists(trail_path):
+        return ""
+
+    lines = []
+    with open(trail_path, 'rb') as f:
+        version: int = struct.unpack("<i", f.read(4))[0]
+        lines.append("Version: " + str(version))
+        map_id: int = struct.unpack("<i", f.read(4))[0]
+        lines.append("MapID: " + str(map_id))
+
+        point_index = 0
+        while point_bytes := f.read(12):
+            x, y, z = struct.unpack("<fff", point_bytes)
+            # points.append((x, y, z))
+            lines.append("Point {}: {} {} {}".format(point_index, x, y, z))
+            point_index += 1
+
+    return "\n".join(lines)


### PR DESCRIPTION
Binary protos are converted into text before being diffed. Now binary trails are too.

![Screenshot from 2025-03-11 19-40-54](https://github.com/user-attachments/assets/af8dd80f-817e-4ce9-a76f-4212bff4a022)
