### PR TITLE
Updating all workflows to run on ubuntu 22.04 before 20.04 is depricated by github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           if-no-files-found: error 
 
   Build-BurritoLink-Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
 
 
   Build-BurritoFG-Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
           if-no-files-found: error 
 
   Build-TacoParser-Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
           if-no-files-found: error 
 
   Build-BurritoUI-Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -231,7 +231,7 @@ jobs:
           if-no-files-found: error
 
   Package-Burrito-Linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - Build-XMLConverter-Linux
       - Build-BurritoLink-Linux


### PR DESCRIPTION
This does reduce some comparability with older machines but things should still work fine.