### PR TITLE
correcting argument names in help menu

### DIFF
--- a/xml_converter/src/argument_parser.cpp
+++ b/xml_converter/src/argument_parser.cpp
@@ -101,10 +101,10 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
         }
         else if (string(argv[i]) == "--help") {
             cout << "usage: ./xml_converter [--help] [--allow-duplicates]" << endl;
-            cout << "                       [--import_taco_path <PATH> ...]" << endl;
-            cout << "                       [--import_guildpoint_path <PATH> ...]" << endl;
-            cout << "                       [--export_taco_path <PATH> ...]" << endl;
-            cout << "                       [--export_guildpoint_path <PATH> [--split-by-map-id] [--split-by-category [DEPTH]] ...]" << endl;
+            cout << "                       [--input-taco-path <PATH> ...]" << endl;
+            cout << "                       [--input-guildpoint=path <PATH> ...]" << endl;
+            cout << "                       [--output-taco-path <PATH> ...]" << endl;
+            cout << "                       [--output-guildpoint-path <PATH> [--split-by-map-id] [--split-by-category [DEPTH]] ...]" << endl;
             cout << "Each PATH value should be an absolute or relative path to a marker pack directory or file" << endl;
             cout << "Supported file types include .burrito, .taco, and .zip" << endl;
             return {};


### PR DESCRIPTION
The help menu contained the incorrect argument names compared to the arguments that are actually being parsed