### PR TITLE
Adding bounce mode parsing

### DIFF
--- a/xml_converter/doc/trigger/bounce.md
+++ b/xml_converter/doc/trigger/bounce.md
@@ -1,0 +1,17 @@
+---
+name: Bounce
+applies_to: [Icon]
+xml_fields: [Bounce]
+exclude_from_protobuf: True
+protobuf_field: trigger.bounce_mode
+type: Enum
+values:
+  bounce: ["bounce"]
+  rise: ["rise"]
+---
+The bounce behavior mode.
+
+Notes
+=====
+
+https://blishhud.com/docs/markers/attributes/bounce

--- a/xml_converter/src/attribute/bounce_gen.cpp
+++ b/xml_converter/src/attribute/bounce_gen.cpp
@@ -1,0 +1,54 @@
+#include "bounce_gen.hpp"
+
+#include <algorithm>
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#include "../rapid_helpers.hpp"
+#include "../rapidxml-1.13/rapidxml.hpp"
+#include "../string_helper.hpp"
+#include "guildpoint.pb.h"
+
+using namespace std;
+
+void Attribute::Bounce::from_xml_attribute(
+    rapidxml::xml_attribute<>* input,
+    std::vector<XMLError*>* errors,
+    XMLReaderState*,
+    Bounce* value,
+    bool* is_set
+) {
+    Bounce bounce;
+    string normalized_value = normalize(get_attribute_value(input));
+    if (normalized_value == "bounce") {
+        bounce = Bounce::bounce;
+    }
+    else if (normalized_value == "rise") {
+        bounce = Bounce::rise;
+    }
+    else {
+        errors->push_back(new XMLAttributeValueError("Found an invalid value that was not in the Enum Bounce", input));
+        bounce = Bounce::bounce;
+    }
+    *value = bounce;
+    *is_set = true;
+}
+
+void Attribute::Bounce::to_xml_attribute(
+    XMLWriterState*,
+    const Bounce* value,
+    std::function<void(std::string)> setter
+) {
+    if (*value == Bounce::bounce) {
+        setter("bounce");
+        return;
+    }
+    else if (*value == Bounce::rise) {
+        setter("rise");
+        return;
+    }
+    else {
+        setter("Bounce::bounce");
+    }
+}

--- a/xml_converter/src/attribute/bounce_gen.hpp
+++ b/xml_converter/src/attribute/bounce_gen.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "../rapidxml-1.13/rapidxml.hpp"
+#include "../state_structs/proto_reader_state.hpp"
+#include "../state_structs/proto_writer_state.hpp"
+#include "../state_structs/xml_reader_state.hpp"
+#include "../state_structs/xml_writer_state.hpp"
+#include "guildpoint.pb.h"
+
+class XMLError;
+
+namespace Attribute::Bounce {
+
+enum Bounce {
+    bounce,
+    rise,
+};
+void from_xml_attribute(
+    rapidxml::xml_attribute<>* input,
+    std::vector<XMLError*>* errors,
+    XMLReaderState* state,
+    Bounce* value,
+    bool* is_set
+);
+
+void to_xml_attribute(
+    XMLWriterState* state,
+    const Bounce* value,
+    std::function<void(std::string)> setter
+);
+
+}  // namespace Attribute::Bounce

--- a/xml_converter/src/icon_gen.cpp
+++ b/xml_converter/src/icon_gen.cpp
@@ -34,6 +34,9 @@ bool Icon::init_xml_attribute(rapidxml::xml_attribute<>* attribute, vector<XMLEr
     else if (attributename == "autotrigger") {
         Attribute::Bool::from_xml_attribute(attribute, errors, state, &(this->auto_trigger), &(this->auto_trigger_is_set));
     }
+    else if (attributename == "bounce") {
+        Attribute::Bounce::from_xml_attribute(attribute, errors, state, &(this->bounce), &(this->bounce_is_set));
+    }
     else if (attributename == "bouncedelay") {
         Attribute::Float::from_xml_attribute(attribute, errors, state, &(this->bounce_delay), &(this->bounce_delay_is_set));
     }
@@ -270,6 +273,10 @@ rapidxml::xml_node<char>* Icon::as_xml(XMLWriterState* state) const {
         std::function<void(std::string)> setter = [xml_node, state](std::string val) { xml_node->append_attribute(state->doc->allocate_attribute("AutoTrigger", state->doc->allocate_string(val.c_str()))); };
         Attribute::Bool::to_xml_attribute(state, &this->auto_trigger, setter);
     }
+    if (this->bounce_is_set) {
+        std::function<void(std::string)> setter = [xml_node, state](std::string val) { xml_node->append_attribute(state->doc->allocate_attribute("Bounce", state->doc->allocate_string(val.c_str()))); };
+        Attribute::Bounce::to_xml_attribute(state, &this->bounce, setter);
+    }
     if (this->bounce_delay_is_set) {
         std::function<void(std::string)> setter = [xml_node, state](std::string val) { xml_node->append_attribute(state->doc->allocate_attribute("BounceDelay", state->doc->allocate_string(val.c_str()))); };
         Attribute::Float::to_xml_attribute(state, &this->bounce_delay, setter);
@@ -462,6 +469,7 @@ rapidxml::xml_node<char>* Icon::as_xml(XMLWriterState* state) const {
 //  achievement_bit_index
 //  achievement_id
 //  auto_trigger
+//  bounce
 //  bounce_delay
 //  bounce_duration
 //  bounce_height

--- a/xml_converter/src/icon_gen.hpp
+++ b/xml_converter/src/icon_gen.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "attribute/bounce_gen.hpp"
 #include "attribute/color.hpp"
 #include "attribute/cull_chirality_gen.hpp"
 #include "attribute/euler_rotation_gen.hpp"
@@ -30,6 +31,7 @@ class Icon : public Parseable {
     int achievement_bit_index;
     int achievement_id;
     bool auto_trigger;
+    Attribute::Bounce::Bounce bounce;
     float bounce_delay;
     float bounce_duration;
     float bounce_height;
@@ -77,6 +79,7 @@ class Icon : public Parseable {
     bool achievement_bit_index_is_set = false;
     bool achievement_id_is_set = false;
     bool auto_trigger_is_set = false;
+    bool bounce_is_set = false;
     bool bounce_delay_is_set = false;
     bool bounce_duration_is_set = false;
     bool bounce_height_is_set = false;


### PR DESCRIPTION
https://gw2pathing.com/docs/marker-dev/attributes/bounce

We had correct parsing for the float modifiers but not the mode.