### PR TITLE
Unifying attribute comments

### DIFF
--- a/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_compoundvalue.cpp
@@ -11,6 +11,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a {{class_name}} from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::{{namespace}}::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>*,
@@ -35,6 +40,12 @@ void Attribute::{{namespace}}::from_xml_attribute(
     *is_set = true;
 }
 {% if xml_bundled_components != [] %}
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // to_xml_attribute
+    //
+    // Writes a {{class_name}} to an xml attribute using the provided setter function.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::to_xml_attribute(
         XMLWriterState*,
         const {{class_name}}* value,
@@ -55,6 +66,11 @@ void Attribute::{{namespace}}::from_xml_attribute(
 {% endif %}
 {% if exclude_from_protobuf == false %}
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // from_proto_field
+    //
+    // Reads a {{class_name}} from a proto field.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::from_proto_field(
         {{proto_field_cpp_type}} input,
         ProtoReaderState*,
@@ -71,6 +87,11 @@ void Attribute::{{namespace}}::from_xml_attribute(
         *is_set = true;
     }
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // to_proto_field
+    //
+    // Writes a {{class_name}} to a proto using the provided setter function.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::to_proto_field(
         {{class_name}} value,
         ProtoWriterState*,

--- a/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_enum.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a {{class_name}} from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::{{namespace}}::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -42,6 +47,11 @@ void Attribute::{{namespace}}::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a {{class_name}} to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::{{namespace}}::to_xml_attribute(
     XMLWriterState*,
     const {{class_name}}* value,
@@ -65,6 +75,11 @@ void Attribute::{{namespace}}::to_xml_attribute(
 }
 {% if exclude_from_protobuf == false %}
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // from_proto_field
+    //
+    // Reads a {{class_name}} from a proto field.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::from_proto_field(
         {{proto_field_cpp_type}} input,
         ProtoReaderState*,
@@ -85,6 +100,11 @@ void Attribute::{{namespace}}::to_xml_attribute(
         }
     }
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // to_proto_field
+    //
+    // Writes a {{class_name}} to a proto using the provided setter function.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::to_proto_field(
         {{class_name}} value,
         ProtoWriterState*,

--- a/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
+++ b/xml_converter/generators/cpp_templates/attribute_template_multiflagvalue.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a {{class_name}} from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::{{namespace}}::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -50,6 +55,11 @@ void Attribute::{{namespace}}::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a {{class_name}} to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::{{namespace}}::to_xml_attribute(
     XMLWriterState*,
     const {{class_name}}* value,
@@ -66,6 +76,11 @@ void Attribute::{{namespace}}::to_xml_attribute(
 }
 {% if exclude_from_protobuf == false %}
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // from_proto_field
+    //
+    // Reads a {{class_name}} from a proto field.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::from_proto_field(
         {{proto_field_cpp_type}} input,
         ProtoReaderState*,
@@ -80,6 +95,11 @@ void Attribute::{{namespace}}::to_xml_attribute(
         *is_set = true;
     }
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // to_proto_field
+    //
+    // Writes a {{class_name}} to a proto using the provided setter function.
+    ////////////////////////////////////////////////////////////////////////////////
     void Attribute::{{namespace}}::to_proto_field(
         {{class_name}} value,
         ProtoWriterState*,

--- a/xml_converter/src/attribute/bounce_gen.cpp
+++ b/xml_converter/src/attribute/bounce_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a Bounce from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::Bounce::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -35,6 +40,11 @@ void Attribute::Bounce::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a Bounce to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::Bounce::to_xml_attribute(
     XMLWriterState*,
     const Bounce* value,

--- a/xml_converter/src/attribute/color.cpp
+++ b/xml_converter/src/attribute/color.cpp
@@ -16,12 +16,12 @@
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
-// int_to_float // float_to_int
+// convert_color_channel_int_to_float
 //
-// Helper functions to convert the value of colors from one type to another.
-// Also serves to make sure the values stay within the bounds.
+// Helper function to convert the value of a color from an 8bit integer to a
+// floating point number. Numbers outside of the valid range will be clamped.
 ////////////////////////////////////////////////////////////////////////////////
-float convert_color_channel_int_to_float(int input) {
+static float convert_color_channel_int_to_float(int input) {
     if (input > 255) {
         input = 255;
     }
@@ -32,7 +32,13 @@ float convert_color_channel_int_to_float(int input) {
     return output;
 }
 
-int convert_color_channel_float_to_int(float input) {
+////////////////////////////////////////////////////////////////////////////////
+// convert_color_channel_float_to_int
+//
+// Helper function to convert the value of a color from a floating point number
+// to an 8bit integer. Numbers outside of the valid range will be clamped.
+////////////////////////////////////////////////////////////////////////////////
+static int convert_color_channel_float_to_int(float input) {
     if (input > 1.0) {
         input = 1.0;
     }
@@ -46,7 +52,7 @@ int convert_color_channel_float_to_int(float input) {
 ////////////////////////////////////////////////////////////////////////////////
 // from_xml_attribute
 //
-// Parses a Color from the value of a rapidxml::xml_attribute.
+// Reads a Color from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Color::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -95,7 +101,7 @@ void Attribute::Color::from_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // to_xml_attribute
 //
-// Converts a color into a fully qualified xml attribute string.
+// Writes a Color to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Color::to_xml_attribute(
     XMLWriterState*,
@@ -122,7 +128,7 @@ void Attribute::Color::to_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // from_proto_field
 //
-// Parses a Color from a proto field.
+// Reads a Color from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Color::from_proto_field(
     uint32_t input,

--- a/xml_converter/src/attribute/cull_chirality_gen.cpp
+++ b/xml_converter/src/attribute/cull_chirality_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a CullChirality from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::CullChirality::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -38,6 +43,11 @@ void Attribute::CullChirality::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a CullChirality to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::CullChirality::to_xml_attribute(
     XMLWriterState*,
     const CullChirality* value,
@@ -60,6 +70,11 @@ void Attribute::CullChirality::to_xml_attribute(
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a CullChirality from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::CullChirality::from_proto_field(
     guildpoint::CullChirality input,
     ProtoReaderState*,
@@ -86,6 +101,11 @@ void Attribute::CullChirality::from_proto_field(
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a CullChirality to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::CullChirality::to_proto_field(
     CullChirality value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/euler_rotation_gen.cpp
+++ b/xml_converter/src/attribute/euler_rotation_gen.cpp
@@ -11,6 +11,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a EulerRotation from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::EulerRotation::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>*,
@@ -34,6 +39,12 @@ void Attribute::EulerRotation::from_xml_attribute(
     *value = euler_rotation;
     *is_set = true;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a EulerRotation to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::EulerRotation::to_xml_attribute(
     XMLWriterState*,
     const EulerRotation* value,
@@ -46,6 +57,11 @@ void Attribute::EulerRotation::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a EulerRotation from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::EulerRotation::from_proto_field(
     guildpoint::EulerRotation input,
     ProtoReaderState*,
@@ -60,6 +76,11 @@ void Attribute::EulerRotation::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a EulerRotation to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::EulerRotation::to_proto_field(
     EulerRotation value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/festival_filter_gen.cpp
+++ b/xml_converter/src/attribute/festival_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a FestivalFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::FestivalFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -65,6 +70,11 @@ void Attribute::FestivalFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a FestivalFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::FestivalFilter::to_xml_attribute(
     XMLWriterState*,
     const FestivalFilter* value,
@@ -96,6 +106,11 @@ void Attribute::FestivalFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a FestivalFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::FestivalFilter::from_proto_field(
     guildpoint::FestivalFilter input,
     ProtoReaderState*,
@@ -114,6 +129,11 @@ void Attribute::FestivalFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a FestivalFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::FestivalFilter::to_proto_field(
     FestivalFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/float.cpp
+++ b/xml_converter/src/attribute/float.cpp
@@ -7,10 +7,11 @@
 #include "../rapidxml-1.13/rapidxml.hpp"
 
 using namespace std;
+
 ////////////////////////////////////////////////////////////////////////////////
 // from_xml_attribute
 //
-// Parses a float from the value of a rapidxml::xml_attribute.
+// Reads a float from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Float::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -26,7 +27,7 @@ void Attribute::Float::from_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // to_xml_attribute
 //
-// Converts a float into a fully qualified xml attribute string.
+// Writes a float to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Float::to_xml_attribute(
     XMLWriterState*,
@@ -39,7 +40,7 @@ void Attribute::Float::to_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // from_proto_field
 //
-// Parses a float from a proto field.
+// Reads a float from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Float::from_proto_field(
     float input,

--- a/xml_converter/src/attribute/image.cpp
+++ b/xml_converter/src/attribute/image.cpp
@@ -21,7 +21,7 @@ Attribute::Image::Image::Image(std::string base, std::string relative_filepath)
 ////////////////////////////////////////////////////////////////////////////////
 // from_xml_attribute
 //
-// Parses the path to an image from the value of a rapidxml::xml_attribute.
+// Reads an Image from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Image::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -38,7 +38,7 @@ void Attribute::Image::from_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // to_xml_attribute
 //
-// Converts an image into a fully qualified xml attribute string.
+// Writes an Image to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Image::to_xml_attribute(
     XMLWriterState* state,
@@ -53,7 +53,7 @@ void Attribute::Image::to_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // from_proto_field
 //
-// Parses an Image from proto
+// Reads an Image from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Image::from_proto_field(
     unsigned int input,
@@ -69,8 +69,9 @@ void Attribute::Image::from_proto_field(
 ////////////////////////////////////////////////////////////////////////////////
 // to_proto_field
 //
-// Creates a new element of the proto writer state if the image has not been
-// used before. Then writes the new or existing index of the image to the proto.
+// Writes an Image to a proto using the provided setter function. If the image
+// has not been used before the image is added to the writer state before it is
+// written to the proto setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Image::to_proto_field(
     const Image& value,

--- a/xml_converter/src/attribute/int.cpp
+++ b/xml_converter/src/attribute/int.cpp
@@ -13,8 +13,7 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////
 // from_xml_attribute
 //
-// Parses an int from the value of a rapidxml::xml_attribute. Adds an error
-// if the value cannot be parsed properly.
+// Reads an int from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Int::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -54,7 +53,7 @@ void Attribute::Int::to_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // from_proto_field
 //
-// Parses an int from a proto field.
+// Reads an int from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Int::from_proto_field(
     int input,

--- a/xml_converter/src/attribute/map_type_filter_gen.cpp
+++ b/xml_converter/src/attribute/map_type_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a MapTypeFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MapTypeFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -130,6 +135,11 @@ void Attribute::MapTypeFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a MapTypeFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MapTypeFilter::to_xml_attribute(
     XMLWriterState*,
     const MapTypeFilter* value,
@@ -212,6 +222,11 @@ void Attribute::MapTypeFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a MapTypeFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MapTypeFilter::from_proto_field(
     guildpoint::MapTypeFilter input,
     ProtoReaderState*,
@@ -247,6 +262,11 @@ void Attribute::MapTypeFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a MapTypeFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MapTypeFilter::to_proto_field(
     MapTypeFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/marker_category.cpp
+++ b/xml_converter/src/attribute/marker_category.cpp
@@ -10,7 +10,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // from_xml_attribute
 //
-// Parses a MarkerCategory from the value of a rapidxml::xml_attribute.
+// Reads a MarkerCategory from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::MarkerCategory::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -26,7 +26,7 @@ void Attribute::MarkerCategory::from_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // to_xml_attribute
 //
-// Converts a marker category a fully qualified xml attribute string.
+// Writes a MarkerCategory to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::MarkerCategory::to_xml_attribute(
     XMLWriterState*,
@@ -39,7 +39,7 @@ void Attribute::MarkerCategory::to_xml_attribute(
 ////////////////////////////////////////////////////////////////////////////////
 // from_proto_field
 //
-// Parses a marker category from a proto field.
+// Reads a MarkerCategory from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::MarkerCategory::from_proto_field(
     guildpoint::Category input,
@@ -56,7 +56,7 @@ void Attribute::MarkerCategory::from_proto_field(
 ////////////////////////////////////////////////////////////////////////////////
 // to_proto_field
 //
-// Returns a guildpoint::Category so that it can be saved to proto.
+// Writes a MarkerCategory to a proto using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::MarkerCategory::to_proto_field(
     MarkerCategory value,

--- a/xml_converter/src/attribute/mount_filter_gen.cpp
+++ b/xml_converter/src/attribute/mount_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a MountFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MountFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -74,6 +79,11 @@ void Attribute::MountFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a MountFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MountFilter::to_xml_attribute(
     XMLWriterState*,
     const MountFilter* value,
@@ -114,6 +124,11 @@ void Attribute::MountFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a MountFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MountFilter::from_proto_field(
     guildpoint::MountFilter input,
     ProtoReaderState*,
@@ -135,6 +150,11 @@ void Attribute::MountFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a MountFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::MountFilter::to_proto_field(
     MountFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/position_gen.cpp
+++ b/xml_converter/src/attribute/position_gen.cpp
@@ -11,6 +11,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a Position from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::Position::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>*,
@@ -35,6 +40,11 @@ void Attribute::Position::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a Position from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::Position::from_proto_field(
     guildpoint::Position input,
     ProtoReaderState*,
@@ -49,6 +59,11 @@ void Attribute::Position::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a Position to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::Position::to_proto_field(
     Position value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/profession_filter_gen.cpp
+++ b/xml_converter/src/attribute/profession_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a ProfessionFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ProfessionFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -70,6 +75,11 @@ void Attribute::ProfessionFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a ProfessionFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ProfessionFilter::to_xml_attribute(
     XMLWriterState*,
     const ProfessionFilter* value,
@@ -107,6 +117,11 @@ void Attribute::ProfessionFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a ProfessionFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ProfessionFilter::from_proto_field(
     guildpoint::ProfessionFilter input,
     ProtoReaderState*,
@@ -127,6 +142,11 @@ void Attribute::ProfessionFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a ProfessionFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ProfessionFilter::to_proto_field(
     ProfessionFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/reset_behavior_gen.cpp
+++ b/xml_converter/src/attribute/reset_behavior_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a ResetBehavior from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ResetBehavior::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -83,6 +88,11 @@ void Attribute::ResetBehavior::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a ResetBehavior to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::ResetBehavior::to_xml_attribute(
     XMLWriterState*,
     const ResetBehavior* value,

--- a/xml_converter/src/attribute/specialization_filter_gen.cpp
+++ b/xml_converter/src/attribute/specialization_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a SpecializationFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpecializationFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -403,6 +408,11 @@ void Attribute::SpecializationFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a SpecializationFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpecializationFilter::to_xml_attribute(
     XMLWriterState*,
     const SpecializationFilter* value,
@@ -629,6 +639,11 @@ void Attribute::SpecializationFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a SpecializationFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpecializationFilter::from_proto_field(
     guildpoint::SpecializationFilter input,
     ProtoReaderState*,
@@ -712,6 +727,11 @@ void Attribute::SpecializationFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a SpecializationFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpecializationFilter::to_proto_field(
     SpecializationFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/species_filter_gen.cpp
+++ b/xml_converter/src/attribute/species_filter_gen.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a SpeciesFilter from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpeciesFilter::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>* errors,
@@ -54,6 +59,11 @@ void Attribute::SpeciesFilter::from_xml_attribute(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_xml_attribute
+//
+// Writes a SpeciesFilter to an xml attribute using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpeciesFilter::to_xml_attribute(
     XMLWriterState*,
     const SpeciesFilter* value,
@@ -79,6 +89,11 @@ void Attribute::SpeciesFilter::to_xml_attribute(
     setter(output);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// from_proto_field
+//
+// Reads a SpeciesFilter from a proto field.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpeciesFilter::from_proto_field(
     guildpoint::SpeciesFilter input,
     ProtoReaderState*,
@@ -95,6 +110,11 @@ void Attribute::SpeciesFilter::from_proto_field(
     *is_set = true;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// to_proto_field
+//
+// Writes a SpeciesFilter to a proto using the provided setter function.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::SpeciesFilter::to_proto_field(
     SpeciesFilter value,
     ProtoWriterState*,

--- a/xml_converter/src/attribute/string.cpp
+++ b/xml_converter/src/attribute/string.cpp
@@ -11,9 +11,9 @@
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
-// xml_attribute_to_string
+// from_xml_attribute
 //
-// Parses a string from the value of a rapidxml::xml_attribute.
+// Reads a string from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::String::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -27,9 +27,9 @@ void Attribute::String::from_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// string_to_xml_attribute
+// to_xml_attribute
 //
-// Converts a string into a fully qualified xml attribute string.
+// Writes a string to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::String::to_xml_attribute(
     XMLWriterState*,
@@ -40,9 +40,9 @@ void Attribute::String::to_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// proto_to_string
+// from_proto_field
 //
-// Parses a string from a proto field.
+// Reads a string from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::String::from_proto_field(
     string input,
@@ -55,7 +55,7 @@ void Attribute::String::from_proto_field(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// string_to_proto
+// to_proto_field
 //
 // Writes a string to a proto using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////

--- a/xml_converter/src/attribute/trail_data.cpp
+++ b/xml_converter/src/attribute/trail_data.cpp
@@ -17,9 +17,25 @@
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
-// parse_trail_data
+// djb2_hash
 //
-// Parses a TrailData from the value of a rapidxml::xml_attribute.
+// A simple non cryptographic hash that we use to deterministically generate the
+// filename of the trl files.
+// TODO: Remove this in favor of a better naming scheme or move this to
+//       `hash_helpers.cpp` instead of here.
+////////////////////////////////////////////////////////////////////////////////
+static uint64_t djb2_hash(const unsigned char* str, size_t length) {
+    uint64_t hash = 5381;
+    for (size_t i = 0; i < length; i++) {
+        hash = ((hash << 5) + hash) + str[i]; /* hash * 33 + c */
+    }
+    return hash;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a TrailData from an xml attribute.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::TrailData::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
@@ -80,23 +96,9 @@ void Attribute::TrailData::from_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// djb2_hash
+// to_xml_attribute
 //
-// A simple non cryptographic hash that we use to deterministically generate the
-// filename of the trl files.
-////////////////////////////////////////////////////////////////////////////////
-uint64_t djb2_hash(const unsigned char* str, size_t length) {
-    uint64_t hash = 5381;
-    for (size_t i = 0; i < length; i++) {
-        hash = ((hash << 5) + hash) + str[i]; /* hash * 33 + c */
-    }
-    return hash;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// trail_data_to_xml_attribute
-//
-// Converts a traildata into a fully qualified xml attribute string.
+// Writes a TrailData to an xml attribute using the provided setter function.
 // TOOD: Determine a better trail path name
 ////////////////////////////////////////////////////////////////////////////////
 uint32_t trail_version_number = 0;
@@ -148,9 +150,9 @@ void Attribute::TrailData::to_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// proto_to_trail_data
+// from_proto_field
 //
-// Parses a TrailData from a proto field.
+// Reads a TrailData from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::TrailData::from_proto_field(
     guildpoint::TrailData input,
@@ -177,9 +179,9 @@ void Attribute::TrailData::from_proto_field(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// trail_data_to_proto
+// to_proto_field
 //
-// Saves a TrailData object to a proto using the provided setter function.
+// Writes a TrailData to a proto using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::TrailData::to_proto_field(
     TrailData value,

--- a/xml_converter/src/attribute/unique_id.cpp
+++ b/xml_converter/src/attribute/unique_id.cpp
@@ -12,6 +12,11 @@
 
 using namespace std;
 
+////////////////////////////////////////////////////////////////////////////////
+// from_xml_attribute
+//
+// Reads a UniqueId from an xml attribute.
+////////////////////////////////////////////////////////////////////////////////
 void Attribute::UniqueId::from_xml_attribute(
     rapidxml::xml_attribute<>* input,
     std::vector<XMLError*>*,
@@ -27,9 +32,9 @@ void Attribute::UniqueId::from_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// unique_id_to_xml_attribute
+// to_xml_attribute
 //
-// Converts a unique id into a fully qualified xml attribute string.
+// Writes a UniqueId to an xml attribute using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::UniqueId::to_xml_attribute(
     XMLWriterState*,
@@ -40,9 +45,9 @@ void Attribute::UniqueId::to_xml_attribute(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// proto_to_unique_id
+// from_proto_field
 //
-// Parses a UniqueId from a proto field.
+// Reads a UniqueId from a proto field.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::UniqueId::from_proto_field(
     std::string input,
@@ -58,9 +63,9 @@ void Attribute::UniqueId::from_proto_field(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// unique_id_to_proto
+// to_proto_field
 //
-// Writes a bool to a proto using the provided setter function.
+// Writes a UniqueId to a proto using the provided setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::UniqueId::to_proto_field(
     UniqueId value,


### PR DESCRIPTION
This unifies all of the attribute comments so that they all use the same verbiage.