### PR TITLE
Fixing unused argument warnings

### DIFF
--- a/xml_converter/src/attribute/string.cpp
+++ b/xml_converter/src/attribute/string.cpp
@@ -85,8 +85,8 @@ void Attribute::NameAndDisplayname::to_proto_field(
     std::string value,
     ProtoWriterState*,
     std::function<void(std::string)> setter,
-    const std::string* name,
-    const bool* is_name_set
+    const std::string*,  // name
+    const bool*  // is_name_set
 ) {
     setter(value);
 }

--- a/xml_converter/src/attribute/trail_data.cpp
+++ b/xml_converter/src/attribute/trail_data.cpp
@@ -106,7 +106,7 @@ void Attribute::TrailData::to_xml_attribute(
     XMLWriterState* state,
     const TrailData* value,
     const int* map_id_value,
-    const bool* is_map_id_set,
+    const bool*,  // is_map_id_set
     std::function<void(std::string)> setter
 ) {
     size_t byte_array_size = sizeof(int) + sizeof(uint32_t) + value->points.size() * 3 * sizeof(float);


### PR DESCRIPTION
This fixes the warnings we get for having unused arguments when building the xml converter.