### PR TITLE
Speeding up the file copying when writing taco xml packs

### DIFF
--- a/xml_converter/src/attribute/image.cpp
+++ b/xml_converter/src/attribute/image.cpp
@@ -46,7 +46,11 @@ void Attribute::Image::to_xml_attribute(
     std::function<void(std::string)> setter
 ) {
     MarkerPackFile output_path = MarkerPackFile(state->marker_pack_root_directory, value->filepath.relative_filepath);
-    copy_file(value->filepath, output_path);
+    auto file_lookup = state->written_textures.find(output_path.tmp_get_path());
+    if (file_lookup == state->written_textures.end()) {
+        copy_file(value->filepath, output_path);
+        state->written_textures.insert(output_path.tmp_get_path());
+    }
     setter(value->filepath.relative_filepath);
 }
 

--- a/xml_converter/src/state_structs/xml_writer_state.hpp
+++ b/xml_converter/src/state_structs/xml_writer_state.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <string>
 
 #include "../rapidxml-1.13/rapidxml.hpp"
@@ -7,4 +8,5 @@
 struct XMLWriterState {
     std::string marker_pack_root_directory;
     rapidxml::xml_document<char> *doc;
+    std::set<std::string> written_textures;
 };


### PR DESCRIPTION
We had previously made an assumption about the file copy operation being cached in memory, and therefore it was inexpensive to perform the same file copy multiple times. Since we started allowing zip files as inputs this assumption is no longer true and the extraction process occurs multiple times. This change prevents us from copying a file more than once when writing to xml. Writing to guildpoint protobufs already has similar functionality due to how its texture index functions.

An example using a large marker pack:
Before `The xml write function took 102667 milliseconds to run`
After `The xml write function took 4781 milliseconds to run`
