### PR TITLE
Added apt-get update to package installation

### DIFF
--- a/.github/workflows/diff_protobin.yml
+++ b/.github/workflows/diff_protobin.yml
@@ -21,7 +21,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install ProtoC
-      run: sudo apt-get install -y protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
 
     - name: Fetch PR commits
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,14 +41,19 @@ jobs:
       # # complain about missing files and error out.
       # - name: Install include-what-you-use
       #   run: |
+      #     sudo apt-get update
       #     sudo apt-get install iwyu
       #     sudo apt-get install clang-9
 
       - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
 
       - name: Install gtest
-        run: sudo apt-get install libgtest-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtest-dev
 
       - name: Install cpplint
         run: |
@@ -98,7 +103,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install mingw
-        run: sudo apt-get install gcc-mingw-w64
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-mingw-w64
 
       - name: Build Burrito Link
         run: |


### PR DESCRIPTION
Our builds are failing on package install. [This documentation](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners) recommends always running `sudo apt-get update` before installing a package. 