### PR TITLE
Add checks to trail data incase the trail file is missing

### DIFF
--- a/Trail2D.gd
+++ b/Trail2D.gd
@@ -6,6 +6,8 @@ var guildpoint: Guildpoint.Trail
 func refresh_points():
 	var trail_points := PoolVector2Array()
 	var trail_data = self.guildpoint.get_trail_data()
+	if trail_data == null:
+		return
 	for index in range(0, trail_data.get_points_z().size()):
 		trail_points.append(Vector2(trail_data.get_points_x()[index], -trail_data.get_points_z()[index]))
 	self.points = trail_points

--- a/Trail3D.gd
+++ b/Trail3D.gd
@@ -12,6 +12,8 @@ func refresh_mesh():
 	var i = 0
 	var last_uv: float = 0.0
 	var trail_data = self.guildpoint.get_trail_data()
+	if trail_data == null:
+		return
 	for point_index in range(trail_data.get_points_x().size()-1):
 		var point:Vector3 = Vector3(trail_data.get_points_x()[point_index], trail_data.get_points_y()[point_index], -trail_data.get_points_z()[point_index])
 		var next_point:Vector3 = Vector3(trail_data.get_points_x()[point_index+1], trail_data.get_points_y()[point_index+1], -trail_data.get_points_z()[point_index+1])


### PR DESCRIPTION
Burrito is crashing when a marker pack is loaded that has missing `*.trl` files. Therefore the `trail_data` field is `null` and the refresh functions where trying to access a function of `null`. Any other place `trail_data` is called is after a gizmo is selected or after a new trail is created. In the 2nd case, a point is instantly added so it can't be null after that. 