### PR TITLE
Changing how the dll thread is terminated

### DIFF
--- a/burrito_link/burrito_link.c
+++ b/burrito_link/burrito_link.c
@@ -89,6 +89,12 @@ int64_t program_timeout = 0;
 // program_timeout to determine if the program should time out or continue.
 int64_t program_startime = 0;
 
+volatile int _end_process = 0;
+
+void end_process() {
+    _end_process = 1;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // initMumble
 //
@@ -254,6 +260,10 @@ int connect_and_or_send() {
             break;
         }
 
+        if (_end_process) {
+            printf("Exiting because the end_process flag was set.");
+            break;
+        }
         // If uiTick is the same value as it was the previous loop then Guild
         // Wars 2 has not updated any data. Sleep for 1ms and check again.
         if (lm->uiTick == last_ui_tick) {

--- a/burrito_link/dllmain.c
+++ b/burrito_link/dllmain.c
@@ -6,6 +6,7 @@
 
 // Forward declare the run_link() function defined in burrito_link.c
 void run_link();
+void end_process();
 
 #ifndef true
 #define true TRUE
@@ -275,7 +276,7 @@ void start_burrito_link_thread() {
 ////////////////////////////////////////////////////////////////////////////////
 void stop_burrito_link_thread() {
     if (burrito_link_thread_handle != nullptr) {
-        TerminateThread(burrito_link_thread_handle, 0);
+        end_process();
     }
 }
 


### PR DESCRIPTION
The previous method of thread termination caused some locks to not be released and prevented some processes from exiting properly in certain non deterministic situations.