### PR TITLE
Renaming default burrito link dll build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,7 @@ jobs:
           cd burrito_link/build
           cmake ..
           make
+          mv burrito_link.dll d3d11.dll
 
       - name: Build ArcDPS Addon
         run: |

--- a/burrito_link/CMakeLists.txt
+++ b/burrito_link/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_options(${STANDALONE} PRIVATE -mconsole)
 # Create the D3D11.dll file
 set(CMAKE_SYSTEM_NAME Windows)
 
-SET(DX11LIB d3d11.dll)
+SET(DX11LIB burrito_link.dll)
 
 # Will this build a library
 add_library(${DX11LIB} SHARED dllmain.c burrito_link.c)


### PR DESCRIPTION
Renaming the default build file for burrito link. This is primarily a setup pr for two future branches of work, but will function as a bit of code cleanliness for now.