### PR TITLE
Burrito link integration test

### DIFF
--- a/burrito_link/.gitignore
+++ b/burrito_link/.gitignore
@@ -1,3 +1,4 @@
 .clangd/
+.cache/
 build/
 compile_commands.json

--- a/burrito_link/CMakeLists.txt
+++ b/burrito_link/CMakeLists.txt
@@ -39,3 +39,14 @@ set_target_properties(${DX11LIB} PROPERTIES
     SUFFIX ""
     LINK_FLAGS "../deffile.def -Wl,--allow-shlib-undefined,--no-insert-timestamp -Wl,-O1 -shared -static -static-libgcc -static-libstdc++ -Wl,--file-alignment=4096 -lm -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32"
 )
+
+################################################################################
+# Integration Tests ############################################################
+################################################################################
+set(INTEGRATION_TESTS integration_tests.exe)
+file(GLOB_RECURSE INTEGRATION_SOURCES "integration_tests/*.c")
+
+add_executable(${INTEGRATION_TESTS} ${INTEGRATION_SOURCES})
+target_link_libraries(${INTEGRATION_TESTS} PRIVATE "ws2_32")
+
+target_compile_options(${INTEGRATION_TESTS} PRIVATE -Wall -Os -g)

--- a/burrito_link/integration_tests/data.h
+++ b/burrito_link/integration_tests/data.h
@@ -1,0 +1,185 @@
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define VARTYPE_BYTE (size_t)0
+#define VARTYPE_FLOAT (size_t)1
+#define VARTYPE_UNSIGNED_INT32 (size_t)2
+#define VARTYPE_STRING (size_t)3
+#define VARTYPE_UNSIGNED_INT16 (size_t)4
+
+const size_t variable_lengths[] = {
+    sizeof(uint8_t),
+    sizeof(float),
+    sizeof(uint32_t),
+    0,
+    sizeof(uint16_t),
+};
+
+struct SizedBuffer {
+    uint8_t* buffer;
+    size_t size;
+};
+
+struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
+    size_t length = 0;
+    va_list args;
+    va_start(args, num_args);
+    for (size_t i = 0; i < num_args; i+=2) {
+        size_t vartype = va_arg(args, size_t);
+        if (vartype == VARTYPE_STRING) {
+            char* data = va_arg(args, char*);
+            length += strlen(data);
+            // We need to include the null byte because WideCharToMultiByte includes it when cchWideChar is -1
+            length += 1;
+        }
+        else {
+            length += variable_lengths[vartype];
+            va_arg(args, void*);
+        }
+    }
+    va_end(args);
+    // printf("Hello world starting processing %zu\n", length);
+    uint8_t* buffer = malloc(length * sizeof(uint8_t));
+    size_t buffer_position = 0;
+
+    va_start(args, num_args);
+    for (size_t i = 0; i < num_args; i+=2) {
+        uint32_t vartype = va_arg(args, size_t);
+        if (vartype == VARTYPE_BYTE) {
+            int data = va_arg(args, int);
+            memcpy(buffer + buffer_position, &data, 1);
+            buffer_position += 1;
+        }
+        else if (vartype == VARTYPE_FLOAT) {
+            float data = va_arg(args, double);
+            memcpy(buffer + buffer_position, &data, 4);
+            buffer_position += 4;
+        }
+        else if (vartype == VARTYPE_UNSIGNED_INT32) {
+            uint32_t data = va_arg(args, uint32_t);
+            memcpy(buffer + buffer_position, &data, 4);
+            buffer_position += 4;
+        }
+        else if (vartype == VARTYPE_STRING) {
+            char* data = va_arg(args, char*);
+            size_t length = strlen(data);
+
+            // We need to include the null byte because WideCharToMultiByte includes it when cchWideChar is -1
+            length += 1;
+            memcpy(buffer + buffer_position, data, length);
+            buffer_position += length;
+        }
+        else if (vartype == VARTYPE_UNSIGNED_INT16) {
+            uint16_t data = va_arg(args, uint32_t);
+            memcpy(buffer + buffer_position, &data, 2);
+            buffer_position += 2;
+        }
+        else {
+            printf("ERROR, unknown type");
+        }
+    }
+    va_end(args);
+    // printf("Hello World, done processing. %zu %zu\n", length, num_args);
+
+    // for (size_t i = 0; i < length; i++) {
+    //     printf("%02X", buffer[i]);
+    // }
+    struct SizedBuffer sized_buffer;
+    sized_buffer.buffer = buffer;
+    sized_buffer.size = length;
+    return sized_buffer;
+}
+
+void mask_bytes(size_t start_byte, uint32_t count, uint8_t* buffer) {
+    for (size_t i = 0; i < count; i++) {
+        buffer[i+start_byte] = 0xFF;
+    }
+}
+
+#define MAKETESTCASE_BYTES(...) my_sum_and_call(__VA_ARGS__)
+#define B(a) VARTYPE_BYTE, (uint8_t)a
+#define F(a) VARTYPE_FLOAT, (float)a
+#define U(a) VARTYPE_UNSIGNED_INT32, (uint32_t)a
+#define S(a) VARTYPE_STRING, (char*)a
+#define U16(a) VARTYPE_UNSIGNED_INT16, (uint16_t)a
+
+struct SizedBuffer* test_cases_1;
+struct SizedBuffer test_case_heavy;
+
+const size_t TESTCASE_COUNT = 1020;
+void build_testcases() {
+    // Build Testcases for the LightData
+    test_cases_1 = malloc(TESTCASE_COUNT * sizeof(struct SizedBuffer));
+    //                                             [ Camera Pos XYZ     ]  [ Camera Front XYZ      ]  [ Player XYZ            ]  [Mao offset XY  ]   [minimap Scale Rotation] UI State
+    test_cases_1[0] = MAKETESTCASE_BYTES(30, B(1), F(0.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(6.4),  F(6.4),  F(6.4),  F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+    test_cases_1[1] = MAKETESTCASE_BYTES(30, B(1), F(1.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(12.8), F(12.8), F(12.8), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+    test_cases_1[2] = MAKETESTCASE_BYTES(30, B(1), F(2.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(19.2), F(19.2), F(19.2), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+    test_cases_1[3] = MAKETESTCASE_BYTES(30, B(1), F(3.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(25.6), F(25.6), F(25.6), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+
+    for (size_t i = 4; i < TESTCASE_COUNT; i++) {
+        float floati = i;
+        test_cases_1[i] = MAKETESTCASE_BYTES(30, B(1), F(floati), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(32.0), F(32.0), F(32.0), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+    }
+
+    // Build Testcases for the HeavyData
+    test_case_heavy = MAKETESTCASE_BYTES(
+        14, B(2),
+        U16(12), // Compass Width
+        U16(300), // Compass Height
+        U(12345), // Map ID
+        U(4294967295), // x11 window ID
+        U(183), // String Buffer Length
+        S("{\n  \"name\": \"Irwene\",\n  \"profession\": 4,\n  \"spec\": 55,\n  \"race\": 4,\n  \"map_id\": 50,\n  \"world_id\": 268435505,\n  \"team_color_id\": 0,\n  \"commander\": false,\n  \"fov\": 0.873,\n  \"uisz\": 1\n}") // Identify JSON
+    );
+}
+
+
+// 02 00000000 00000000 00000000 01000000 00
+// 02 00004041 00009643 39300000 C47D9B1C 0C0000006173666173646661736466
+
+// d  w    h    map      x11      length   str
+// 02 0C00 2C01 00000000 00000000 01000000 00
+// 02 0C00 2C01 39300000 C47D9B1C 0C000000 6173666173646661736466
+
+
+struct SizedBuffer get_testcase(size_t n) {
+    if (n >= TESTCASE_COUNT) {
+        n = TESTCASE_COUNT - 1;
+    }
+    return test_cases_1[n];
+}
+
+int compare(uint8_t* buffer_1, size_t buffer_len_1, uint8_t* buffer_2, size_t buffer_len_2) {
+    if (buffer_len_1 != buffer_len_2) {
+        printf("Lengths Differ %lli %lli\n", buffer_len_1, buffer_len_2);
+        for (size_t j = 0; j < buffer_len_1; j++) {
+            printf("%02X", buffer_1[j]);
+        }
+        printf("\n");
+        for (size_t j = 0; j < buffer_len_2; j++) {
+            printf("%02X", buffer_2[j]);
+        }
+        printf("\n");
+        return 0;
+    }
+
+    for (size_t i = 0; i < buffer_len_1; i++) {
+        if (buffer_1[i] != buffer_2[i]) {
+
+            for (size_t j = 0; j < buffer_len_1; j++) {
+                printf("%02X", buffer_1[j]);
+            }
+            printf("\n");
+            for (size_t j = 0; j < buffer_len_2; j++) {
+                printf("%02X", buffer_2[j]);
+            }
+            printf("\n");
+
+            return 0;
+        }
+    }
+    return 1;
+}

--- a/burrito_link/integration_tests/data.h
+++ b/burrito_link/integration_tests/data.h
@@ -1,5 +1,5 @@
-#ifndef BURRITO_LINK_INTEGRATION_TEST_DATA_H_
-#define BURRITO_LINK_INTEGRATION_TEST_DATA_H_
+#ifndef BURRITO_LINK_INTEGRATION_TESTS_DATA_H_
+#define BURRITO_LINK_INTEGRATION_TESTS_DATA_H_
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -176,4 +176,4 @@ int compare(uint8_t* buffer_1, size_t buffer_len_1, uint8_t* buffer_2, size_t bu
     return 1;
 }
 
-#endif // BURRITO_LINK_INTEGRATION_TEST_DATA_H_
+#endif  // BURRITO_LINK_INTEGRATION_TESTS_DATA_H_

--- a/burrito_link/integration_tests/data.h
+++ b/burrito_link/integration_tests/data.h
@@ -44,7 +44,6 @@ struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
         }
     }
     va_end(args);
-    // printf("Hello world starting processing %zu\n", length);
     uint8_t* buffer = malloc(length * sizeof(uint8_t));
     size_t buffer_position = 0;
 
@@ -85,11 +84,7 @@ struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
         }
     }
     va_end(args);
-    // printf("Hello World, done processing. %zu %zu\n", length, num_args);
 
-    // for (size_t i = 0; i < length; i++) {
-    //     printf("%02X", buffer[i]);
-    // }
     struct SizedBuffer sized_buffer;
     sized_buffer.buffer = buffer;
     sized_buffer.size = length;

--- a/burrito_link/integration_tests/data.h
+++ b/burrito_link/integration_tests/data.h
@@ -1,8 +1,11 @@
-#include <stdint.h>
+#ifndef BURRITO_LINK_INTEGRATION_TEST_DATA_H_
+#define BURRITO_LINK_INTEGRATION_TEST_DATA_H_
+
 #include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 #define VARTYPE_BYTE (size_t)0
 #define VARTYPE_FLOAT (size_t)1
@@ -27,7 +30,7 @@ struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
     size_t length = 0;
     va_list args;
     va_start(args, num_args);
-    for (size_t i = 0; i < num_args; i+=2) {
+    for (size_t i = 0; i < num_args; i += 2) {
         size_t vartype = va_arg(args, size_t);
         if (vartype == VARTYPE_STRING) {
             char* data = va_arg(args, char*);
@@ -46,7 +49,7 @@ struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
     size_t buffer_position = 0;
 
     va_start(args, num_args);
-    for (size_t i = 0; i < num_args; i+=2) {
+    for (size_t i = 0; i < num_args; i += 2) {
         uint32_t vartype = va_arg(args, size_t);
         if (vartype == VARTYPE_BYTE) {
             int data = va_arg(args, int);
@@ -95,7 +98,7 @@ struct SizedBuffer my_sum_and_call(size_t num_args, ...) {
 
 void mask_bytes(size_t start_byte, uint32_t count, uint8_t* buffer) {
     for (size_t i = 0; i < count; i++) {
-        buffer[i+start_byte] = 0xFF;
+        buffer[i + start_byte] = 0xFF;
     }
 }
 
@@ -113,37 +116,27 @@ const size_t TESTCASE_COUNT = 1020;
 void build_testcases() {
     // Build Testcases for the LightData
     test_cases_1 = malloc(TESTCASE_COUNT * sizeof(struct SizedBuffer));
-    //                                             [ Camera Pos XYZ     ]  [ Camera Front XYZ      ]  [ Player XYZ            ]  [Mao offset XY  ]   [minimap Scale Rotation] UI State
-    test_cases_1[0] = MAKETESTCASE_BYTES(30, B(1), F(0.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(6.4),  F(6.4),  F(6.4),  F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
-    test_cases_1[1] = MAKETESTCASE_BYTES(30, B(1), F(1.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(12.8), F(12.8), F(12.8), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
-    test_cases_1[2] = MAKETESTCASE_BYTES(30, B(1), F(2.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(19.2), F(19.2), F(19.2), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
-    test_cases_1[3] = MAKETESTCASE_BYTES(30, B(1), F(3.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(25.6), F(25.6), F(25.6), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+    test_cases_1[0] = MAKETESTCASE_BYTES(30, B(1), F(0.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(6.4), F(6.4), F(6.4), F(-123.0), F(-124.0), F(2.5), F(130.0), U(0));
+    test_cases_1[1] = MAKETESTCASE_BYTES(30, B(1), F(1.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(12.8), F(12.8), F(12.8), F(-123.0), F(-124.0), F(2.5), F(130.0), U(0));
+    test_cases_1[2] = MAKETESTCASE_BYTES(30, B(1), F(2.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(19.2), F(19.2), F(19.2), F(-123.0), F(-124.0), F(2.5), F(130.0), U(0));
+    test_cases_1[3] = MAKETESTCASE_BYTES(30, B(1), F(3.0), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(25.6), F(25.6), F(25.6), F(-123.0), F(-124.0), F(2.5), F(130.0), U(0));
 
     for (size_t i = 4; i < TESTCASE_COUNT; i++) {
         float floati = i;
-        test_cases_1[i] = MAKETESTCASE_BYTES(30, B(1), F(floati), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(32.0), F(32.0), F(32.0), F(-123.0), F(-124.0), F(2.5), F(130.0),        U(0));
+        test_cases_1[i] = MAKETESTCASE_BYTES(30, B(1), F(floati), F(2.0), F(3.0), F(1.11), F(2.22), F(3.33), F(32.0), F(32.0), F(32.0), F(-123.0), F(-124.0), F(2.5), F(130.0), U(0));
     }
 
     // Build Testcases for the HeavyData
     test_case_heavy = MAKETESTCASE_BYTES(
         14, B(2),
-        U16(12), // Compass Width
-        U16(300), // Compass Height
-        U(12345), // Map ID
-        U(4294967295), // x11 window ID
-        U(183), // String Buffer Length
-        S("{\n  \"name\": \"Irwene\",\n  \"profession\": 4,\n  \"spec\": 55,\n  \"race\": 4,\n  \"map_id\": 50,\n  \"world_id\": 268435505,\n  \"team_color_id\": 0,\n  \"commander\": false,\n  \"fov\": 0.873,\n  \"uisz\": 1\n}") // Identify JSON
+        U16(12),  // Compass Width
+        U16(300),  // Compass Height
+        U(12345),  // Map ID
+        U(4294967295),  // x11 window ID
+        U(183),  // String Buffer Length
+        S("{\n  \"name\": \"Irwene\",\n  \"profession\": 4,\n  \"spec\": 55,\n  \"race\": 4,\n  \"map_id\": 50,\n  \"world_id\": 268435505,\n  \"team_color_id\": 0,\n  \"commander\": false,\n  \"fov\": 0.873,\n  \"uisz\": 1\n}")  // Identify JSON
     );
 }
-
-
-// 02 00000000 00000000 00000000 01000000 00
-// 02 00004041 00009643 39300000 C47D9B1C 0C0000006173666173646661736466
-
-// d  w    h    map      x11      length   str
-// 02 0C00 2C01 00000000 00000000 01000000 00
-// 02 0C00 2C01 39300000 C47D9B1C 0C000000 6173666173646661736466
-
 
 struct SizedBuffer get_testcase(size_t n) {
     if (n >= TESTCASE_COUNT) {
@@ -168,7 +161,6 @@ int compare(uint8_t* buffer_1, size_t buffer_len_1, uint8_t* buffer_2, size_t bu
 
     for (size_t i = 0; i < buffer_len_1; i++) {
         if (buffer_1[i] != buffer_2[i]) {
-
             for (size_t j = 0; j < buffer_len_1; j++) {
                 printf("%02X", buffer_1[j]);
             }
@@ -183,3 +175,5 @@ int compare(uint8_t* buffer_1, size_t buffer_len_1, uint8_t* buffer_2, size_t bu
     }
     return 1;
 }
+
+#endif // BURRITO_LINK_INTEGRATION_TEST_DATA_H_

--- a/burrito_link/integration_tests/main.c
+++ b/burrito_link/integration_tests/main.c
@@ -4,9 +4,9 @@
 #include <stdio.h>
 #include <stringapiset.h>
 #include <synchapi.h>
+#include <time.h>
 #include <winerror.h>
 #include <winsock2.h>
-#include <time.h>
 
 #include "../linked_memory.h"
 #include "../serializer.h"
@@ -14,7 +14,6 @@
 
 #define PORT 4242
 #define BUFFER_SIZE 1024
-
 
 #define bool int
 #define false 0
@@ -32,7 +31,7 @@ int get_message(
         buffer,
         BUFFER_SIZE,
         0,
-        (struct sockaddr *)&client_address,
+        (struct sockaddr*)&client_address,
         &client_address_length
     );
 
@@ -71,7 +70,6 @@ int clear_all_messages(
     return count;
 }
 
-
 int udp_listen(SOCKET* server_socket) {
     // Windows Socket API Data
     WSADATA win_sock_api_data;
@@ -91,9 +89,8 @@ int udp_listen(SOCKET* server_socket) {
         WSACleanup();
         return 1;
     }
-    unsigned long value = TRUE;
+    u_long value = TRUE;
     ioctlsocket(*server_socket, FIONBIO, &value);
-
 
     // Set up the server address
     server_address.sin_family = AF_INET;
@@ -101,7 +98,7 @@ int udp_listen(SOCKET* server_socket) {
     server_address.sin_addr.s_addr = INADDR_ANY;
 
     // Bind the socket
-    int bind_result = bind(*server_socket, (struct sockaddr *)&server_address, sizeof(server_address));
+    int bind_result = bind(*server_socket, (struct sockaddr*)&server_address, sizeof(server_address));
     if (bind_result == SOCKET_ERROR) {
         printf("Bind failed: %d\n", WSAGetLastError());
         closesocket(*server_socket);
@@ -113,14 +110,11 @@ int udp_listen(SOCKET* server_socket) {
     return 0;
 }
 
-
 int udp_close(SOCKET server_socket) {
     closesocket(server_socket);
     WSACleanup();
     return 0;
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // initMumble
@@ -132,8 +126,8 @@ int udp_close(SOCKET server_socket) {
 ////////////////////////////////////////////////////////////////////////////////
 HANDLE handle_lm;
 LPCTSTR mapped_lm;
-struct LinkedMem *lm = NULL;
-struct MumbleContext *lc = NULL;
+struct LinkedMem* lm = NULL;
+struct MumbleContext* lc = NULL;
 
 void initMumble() {
     size_t BUF_SIZE = sizeof(struct LinkedMem);
@@ -168,9 +162,9 @@ void initMumble() {
 
         return;
     }
-    lm = (struct LinkedMem *)mapped_lm;
+    lm = (struct LinkedMem*)mapped_lm;
 
-    lc = (struct MumbleContext *)lm->context;
+    lc = (struct MumbleContext*)lm->context;
     printf("successfully opened mumble link shared memory..\n");
 }
 
@@ -178,10 +172,8 @@ void closeMumble() {
     // unmap the shared memory from our process address space.
     UnmapViewOfFile(mapped_lm);
     // close LinkedMemory handle
-    CloseHandle(handle_lm);    
+    CloseHandle(handle_lm);
 }
-
-
 
 typedef int (*MyFunctionType)(int, int);  // Example function signature: int MyFunction(int, int)
 
@@ -226,22 +218,18 @@ int main() {
 
     lc->mapId = 12345;
 
-
     char* identity = "{\n  \"name\": \"Irwene\",\n  \"profession\": 4,\n  \"spec\": 55,\n  \"race\": 4,\n  \"map_id\": 50,\n  \"world_id\": 268435505,\n  \"team_color_id\": 0,\n  \"commander\": false,\n  \"fov\": 0.873,\n  \"uisz\": 1\n}";
     // char* identity = "randomidentity";
     MultiByteToWideChar(
-        CP_UTF8, // CodePage,
-        0, // dwFlags,
-        identity, // lpMultiByteStr,
-        -1, // cbMultiByte,
-        lm->identity, // lpWideCharStr,
-        256 // cchWideChar
+        CP_UTF8,  // CodePage,
+        0,  // dwFlags,
+        identity,  // lpMultiByteStr,
+        -1,  // cbMultiByte,
+        lm->identity,  // lpWideCharStr,
+        256  // cchWideChar
     );
 
-
     lc->mapId = 12345;
-
-
 
     // Load the burrito link dll
     HINSTANCE burrito_link_dll = LoadLibrary("burrito_link.dll");
@@ -256,8 +244,6 @@ int main() {
         FreeLibrary(burrito_link_dll);
         return 1;
     }
-
-
 
     // Launch the burrito_link using the thread function
     int buffer_length;
@@ -304,10 +290,9 @@ int main() {
 
         // Update shared memory
         QueryPerformanceFrequency(&frequency);
-        
+
         lm->fCameraPosition[0] = frame_message_count;
-    
-    
+
         lm->uiTick = frame_message_count;
         QueryPerformanceCounter(&start);
         // Wait for a response over the network (with a timeout?)
@@ -316,13 +301,12 @@ int main() {
         } while (buffer_length == -2);
         QueryPerformanceCounter(&end);
 
-
         while (buffer_length > 0) {
             // Sleep for a moment to allow network packets to fully send.
             Sleep(10);
             switch (buffer[0]) {
                 case 0x01: {
-                    struct BurritoFrameData* burrito_frame = (struct BurritoFrameData*)buffer; 
+                    struct BurritoFrameData* burrito_frame = (struct BurritoFrameData*)buffer;
                     // printf("!!FrameNumber: %f %i\n", burrito_frame->camera_position[0], frame_message_count);
 
                     if (!per_frame_message_expected) {

--- a/burrito_link/integration_tests/main.c
+++ b/burrito_link/integration_tests/main.c
@@ -1,0 +1,398 @@
+#include <errhandlingapi.h>
+#include <libloaderapi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stringapiset.h>
+#include <synchapi.h>
+#include <winerror.h>
+#include <winsock2.h>
+#include <time.h>
+
+#include "../linked_memory.h"
+#include "../serializer.h"
+#include "data.h"
+
+#define PORT 4242
+#define BUFFER_SIZE 1024
+
+
+#define bool int
+#define false 0
+#define true 1
+
+int get_message(
+    SOCKET server_socket,
+    struct sockaddr_in* client_address,
+    char* buffer
+) {
+    int client_address_length = sizeof(struct sockaddr_in);
+
+    int receive_length = recvfrom(
+        server_socket,
+        buffer,
+        BUFFER_SIZE,
+        0,
+        (struct sockaddr *)&client_address,
+        &client_address_length
+    );
+
+    if (receive_length == SOCKET_ERROR) {
+        int receive_error = WSAGetLastError();
+        if (receive_error == WSAEWOULDBLOCK) {
+            return -2;
+        }
+        printf("recvfrom failed: %d\n", receive_error);
+        return -1;
+    }
+
+    return receive_length;
+}
+
+int clear_all_messages(
+    SOCKET server_socket,
+    struct sockaddr_in* client_address,
+    char* buffer
+) {
+    int count = 0;
+    int size;
+    do {
+        size = get_message(
+            server_socket,
+            client_address,
+            buffer
+        );
+        if (size > 0) {
+            printf("---cleared a message %i\n", buffer[0]);
+            if (buffer[0] == 0x01) {
+                ++count;
+            }
+        }
+    } while (size > 0);
+    return count;
+}
+
+
+int udp_listen(SOCKET* server_socket) {
+    // Windows Socket API Data
+    WSADATA win_sock_api_data;
+
+    struct sockaddr_in server_address;
+
+    // Initialize Winsock
+    if (WSAStartup(MAKEWORD(2, 2), &win_sock_api_data) != 0) {
+        printf("WSAStartup failed: %d\n", WSAGetLastError());
+        return 1;
+    }
+
+    // Create a UDP socket
+    *server_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (*server_socket == INVALID_SOCKET) {
+        printf("Socket creation failed: %d\n", WSAGetLastError());
+        WSACleanup();
+        return 1;
+    }
+    unsigned long value = TRUE;
+    ioctlsocket(*server_socket, FIONBIO, &value);
+
+
+    // Set up the server address
+    server_address.sin_family = AF_INET;
+    server_address.sin_port = htons(PORT);
+    server_address.sin_addr.s_addr = INADDR_ANY;
+
+    // Bind the socket
+    int bind_result = bind(*server_socket, (struct sockaddr *)&server_address, sizeof(server_address));
+    if (bind_result == SOCKET_ERROR) {
+        printf("Bind failed: %d\n", WSAGetLastError());
+        closesocket(*server_socket);
+        WSACleanup();
+        return 1;
+    }
+
+    printf("UDP server listening on port %d...\n", PORT);
+    return 0;
+}
+
+
+int udp_close(SOCKET server_socket) {
+    closesocket(server_socket);
+    WSACleanup();
+    return 0;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// initMumble
+//
+// Duplicated from the burrito_link.c It should deduplicated when we split out
+// functions from burrito_link.c into other files.
+// We dont want to do that work first yet because this integration test harness
+// is also doing performance testing.
+////////////////////////////////////////////////////////////////////////////////
+HANDLE handle_lm;
+LPCTSTR mapped_lm;
+struct LinkedMem *lm = NULL;
+struct MumbleContext *lc = NULL;
+
+void initMumble() {
+    size_t BUF_SIZE = sizeof(struct LinkedMem);
+
+    handle_lm = CreateFileMapping(
+        INVALID_HANDLE_VALUE,  // use paging file
+        NULL,  // default security
+        PAGE_READWRITE,  // read/write access
+        0,  // maximum object size (high-order DWORD)
+        BUF_SIZE,  // maximum object size (low-order DWORD)
+        "MumbleLink"  // name of mapping object
+    );
+
+    // CreateFileMapping returns NULL when it fails, we print the error code for debugging purposes.
+    if (handle_lm == NULL) {
+        printf("Could not create file mapping object (%lu).\n", GetLastError());
+        return;
+    }
+
+    mapped_lm = (LPTSTR)MapViewOfFile(
+        handle_lm,  // handle to map object
+        FILE_MAP_ALL_ACCESS,  // read/write permission
+        0,
+        0,
+        BUF_SIZE
+    );
+
+    if (mapped_lm == NULL) {
+        printf("Could not map view of file (%lu).\n", GetLastError());
+
+        CloseHandle(handle_lm);
+
+        return;
+    }
+    lm = (struct LinkedMem *)mapped_lm;
+
+    lc = (struct MumbleContext *)lm->context;
+    printf("successfully opened mumble link shared memory..\n");
+}
+
+void closeMumble() {
+    // unmap the shared memory from our process address space.
+    UnmapViewOfFile(mapped_lm);
+    // close LinkedMemory handle
+    CloseHandle(handle_lm);    
+}
+
+
+
+typedef int (*MyFunctionType)(int, int);  // Example function signature: int MyFunction(int, int)
+
+int main() {
+    bool all_tests_passed = true;
+    build_testcases();
+
+    SOCKET server_socket;
+    char buffer[BUFFER_SIZE];
+    struct sockaddr_in client_address;
+
+    // Create a UDP Server
+    udp_listen(&server_socket);
+
+    // Create a shared memory buffer
+    initMumble();
+
+    lm->uiTick = 0;
+    lm->fCameraPosition[0] = 1;
+    lm->fCameraPosition[1] = 2;
+    lm->fCameraPosition[2] = 3;
+
+    lm->fCameraFront[0] = 1.11;
+    lm->fCameraFront[1] = 2.22;
+    lm->fCameraFront[2] = 3.33;
+
+    lm->fAvatarPosition[0] = 32.0;
+    lm->fAvatarPosition[1] = 32.0;
+    lm->fAvatarPosition[2] = 32.0;
+
+    lc->compassWidth = 12;
+    lc->compassHeight = 300;
+
+    lc->playerX = 5.0;
+    lc->playerY = 5.0;
+    lc->mapCenterX = 128.0;
+    lc->mapCenterY = 129.0;
+    lc->mapScale = 2.5;
+    lc->compassRotation = 130.0;
+
+    lc->uiState = 0x00000000;
+
+    lc->mapId = 12345;
+
+
+    char* identity = "{\n  \"name\": \"Irwene\",\n  \"profession\": 4,\n  \"spec\": 55,\n  \"race\": 4,\n  \"map_id\": 50,\n  \"world_id\": 268435505,\n  \"team_color_id\": 0,\n  \"commander\": false,\n  \"fov\": 0.873,\n  \"uisz\": 1\n}";
+    // char* identity = "randomidentity";
+    MultiByteToWideChar(
+        CP_UTF8, // CodePage,
+        0, // dwFlags,
+        identity, // lpMultiByteStr,
+        -1, // cbMultiByte,
+        lm->identity, // lpWideCharStr,
+        256 // cchWideChar
+    );
+
+
+    lc->mapId = 12345;
+
+
+
+    // Load the burrito link dll
+    HINSTANCE burrito_link_dll = LoadLibrary("burrito_link.dll");
+    if (burrito_link_dll == NULL) {
+        printf("Failed to load burrito link DLL. %lu\n", GetLastError());
+        return 1;
+    }
+
+    MyFunctionType MyFunction = (MyFunctionType)GetProcAddress(burrito_link_dll, "GetAddonDef");
+    if (MyFunction == NULL) {
+        printf("Could not find the function. Error code: %lu\n", GetLastError());
+        FreeLibrary(burrito_link_dll);
+        return 1;
+    }
+
+
+
+    // Launch the burrito_link using the thread function
+    int buffer_length;
+
+    for (int i = 1001; i < 2000; i++) {
+        lm->uiTick = i;
+        buffer_length = get_message(server_socket, &client_address, buffer);
+        if (buffer_length > 0) {
+            break;
+        }
+        Sleep(100);
+    }
+
+    printf("Got first message %i\n", buffer[0]);
+    Sleep(2000);
+    int frame_message_count = 1;
+
+    do {
+        buffer_length = get_message(
+            server_socket,
+            &client_address,
+            buffer
+        );
+        if (buffer_length > 0) {
+            printf("Skipping message of type %i\n", buffer[0]);
+            if (buffer[0] == 0x01) {
+                ++frame_message_count;
+            }
+        }
+    } while (buffer_length > 0);
+
+    LARGE_INTEGER frequency;
+    LARGE_INTEGER start, end;
+
+    // Repeat
+    for (; frame_message_count <= 1004; frame_message_count++) {
+        // printf("Starting with %i\n", frame_message_count);
+
+        bool per_frame_message_expected = true;
+        bool metadata_message_expected = false;
+        if (frame_message_count % 501 == 0) {
+            metadata_message_expected = true;
+        }
+
+        // Update shared memory
+        QueryPerformanceFrequency(&frequency);
+        
+        lm->fCameraPosition[0] = frame_message_count;
+    
+    
+        lm->uiTick = frame_message_count;
+        QueryPerformanceCounter(&start);
+        // Wait for a response over the network (with a timeout?)
+        do {
+            buffer_length = get_message(server_socket, &client_address, buffer);
+        } while (buffer_length == -2);
+        QueryPerformanceCounter(&end);
+
+
+        while (buffer_length > 0) {
+            // Sleep for a moment to allow network packets to fully send.
+            Sleep(10);
+            switch (buffer[0]) {
+                case 0x01: {
+                    struct BurritoFrameData* burrito_frame = (struct BurritoFrameData*)buffer; 
+                    // printf("!!FrameNumber: %f %i\n", burrito_frame->camera_position[0], frame_message_count);
+
+                    if (!per_frame_message_expected) {
+                        printf("Got an unexpected frame message\n");
+                        all_tests_passed = false;
+                    }
+                    per_frame_message_expected = false;
+
+                    size_t frame_message_index = burrito_frame->camera_position[0];
+                    if (frame_message_index != frame_message_count) {
+                        printf("Mismatched expected frame message and actual frame message %lli %i", frame_message_index, frame_message_count);
+                        all_tests_passed = false;
+                    }
+
+                    struct SizedBuffer test_buffer = get_testcase(frame_message_count);
+                    int same_buffers = compare((uint8_t*)buffer, buffer_length, test_buffer.buffer, test_buffer.size);
+                    if (!same_buffers) {
+                        printf("Expected per-frame message not the same as actual per-frame message %i\n", frame_message_count);
+                        all_tests_passed = false;
+                    }
+                    printf("%i\r", frame_message_count);
+                    break;
+                }
+                case 0x02: {
+                    if (!metadata_message_expected) {
+                        printf("Got an unexpected metadata message\n");
+                        all_tests_passed = false;
+                    }
+                    metadata_message_expected = false;
+
+                    mask_bytes(9, 4, (uint8_t*)buffer);
+
+                    int same_buffers = compare((uint8_t*)buffer, buffer_length, test_case_heavy.buffer, test_case_heavy.size);
+                    if (!same_buffers) {
+                        printf("Expected Heavy message no the same as actual heavy message\n");
+                        all_tests_passed = false;
+                    }
+
+                    break;
+                }
+                default:
+                    printf("Unknown messagetype %i\n", buffer[0]);
+                    all_tests_passed = false;
+            }
+
+            buffer_length = get_message(server_socket, &client_address, buffer);
+        }
+
+        double elapsed_time = (double)(end.QuadPart - start.QuadPart) / frequency.QuadPart * 1e3;
+        // printf("%.12fms\n", elapsed_time);
+        // printf("Buffer Length %i\n", buffer_length);
+
+        if (per_frame_message_expected) {
+            printf("Did not get an expected per-frame message");
+            all_tests_passed = false;
+        }
+        if (metadata_message_expected) {
+            printf("Did not get an expected metadata message");
+            all_tests_passed = false;
+        }
+
+        clear_all_messages(server_socket, &client_address, buffer);
+    }
+    printf("\n");
+
+    // Unload the burrito link dll
+    FreeLibrary(burrito_link_dll);
+
+    // Close the UDP socket
+    udp_close(server_socket);
+
+    return !all_tests_passed;
+}

--- a/burrito_link/integration_tests/main.c
+++ b/burrito_link/integration_tests/main.c
@@ -278,6 +278,10 @@ int main() {
     LARGE_INTEGER frequency;
     LARGE_INTEGER start, end;
 
+    const uint32_t MAX_VALUE = 1004;
+    uint32_t steps = MAX_VALUE - frame_message_count;
+    double average_time_taken = 0;
+
     // Repeat
     for (; frame_message_count <= 1004; frame_message_count++) {
         // printf("Starting with %i\n", frame_message_count);
@@ -356,7 +360,7 @@ int main() {
         }
 
         double elapsed_time = (double)(end.QuadPart - start.QuadPart) / frequency.QuadPart * 1e3;
-        // printf("%.12fms\n", elapsed_time);
+        average_time_taken += elapsed_time / steps;
         // printf("Buffer Length %i\n", buffer_length);
 
         if (per_frame_message_expected) {
@@ -371,6 +375,8 @@ int main() {
         clear_all_messages(server_socket, &client_address, buffer);
     }
     printf("\n");
+
+    printf("Average Latency: %.12fms\n", average_time_taken);
 
     // Unload the burrito link dll
     FreeLibrary(burrito_link_dll);

--- a/burrito_link/serializer.h
+++ b/burrito_link/serializer.h
@@ -1,10 +1,8 @@
 #ifndef BURRITO_LINK_SERIALIZER_H_
 #define BURRITO_LINK_SERIALIZER_H_
 // This file will contain macros or somesuch that helps identify how things should be serialized.
-#include <stddef.h>
-#include <string.h>
-
 #include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -17,7 +15,6 @@
 #include <windows.h>
 // clang-format on
 
-
 #include "linked_memory.h"
 
 // The max buffer size for data that is being sent to burrito over the UDP socket
@@ -29,7 +26,7 @@
 #define PACKET_LINK_TIMEOUT 3
 
 struct BurritoFrameData {
-    uint8_t message_type; // 0x01
+    uint8_t message_type;  // 0x01
     float camera_position[3];
     float camera_front[3];
     float avatar_position[3];
@@ -41,27 +38,24 @@ struct BurritoFrameData {
 } __attribute__((packed));
 static_assert(sizeof(struct BurritoFrameData) == 57, "BurritoFrameData is expected to be 57 bytes long.");
 
-
 struct MetadataMessage {
-    uint8_t message_type; // 0x02
+    uint8_t message_type;  // 0x02
     uint16_t compass_width;
     uint16_t compass_height;
     uint32_t map_id;
     uint32_t x11_window_id;
     uint32_t identity_size;
     uint8_t utf8_identity[1024];
-}__attribute__((packed));
+} __attribute__((packed));
 #define MetadataMessageFixedSize offsetof(struct MetadataMessage, utf8_identity)
 static_assert(MetadataMessageFixedSize == 17, "error");
-static_assert(sizeof(((struct MetadataMessage *)0)->utf8_identity) == 1024, "error");
+static_assert(sizeof(((struct MetadataMessage*)0)->utf8_identity) == 1024, "error");
 static_assert(sizeof(struct MetadataMessage) == 1041, "MetadataMessage is expected to be 1041 bytes long.");
 
-
 struct TimeoutMessage {
-    uint8_t message_type; // 0x03
+    uint8_t message_type;  // 0x03
 } __attribute__((packed));
 static_assert(sizeof(struct TimeoutMessage) == 1, "TimeoutMessage is expected to be 1 byte long.");
-
 
 // Sanity check our various datatypes on compile.
 static_assert(sizeof(float) == 4, "float is expected to be 32 bits long.");
@@ -76,7 +70,7 @@ void send_metadata_message(
     SOCKADDR_IN ReceiverAddr
 ) {
     uint32_t total_bytes_sent = 0;
-    total_bytes_sent = sendto(SendingSocket, (const char*)message, sizeof(*message), 0, (SOCKADDR *)&ReceiverAddr, sizeof(ReceiverAddr));
+    total_bytes_sent = sendto(SendingSocket, (const char*)message, sizeof(*message), 0, (SOCKADDR*)&ReceiverAddr, sizeof(ReceiverAddr));
     if (total_bytes_sent != sizeof(*message)) {
         printf("Not all Bytes Sent");
     }

--- a/burrito_link/serializer.h
+++ b/burrito_link/serializer.h
@@ -1,0 +1,85 @@
+#ifndef BURRITO_LINK_SERIALIZER_H_
+#define BURRITO_LINK_SERIALIZER_H_
+// This file will contain macros or somesuch that helps identify how things should be serialized.
+#include <stddef.h>
+#include <string.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+// winsock2.h must be imported before windows.h or a warning is thrown.
+// clang-format wants to order these alphabetically which would put winsock2.h
+// after windows.h so clang-format must be disabled for this import.
+// clang-format off
+#include <winsock2.h>
+#include <windows.h>
+// clang-format on
+
+
+#include "linked_memory.h"
+
+// The max buffer size for data that is being sent to burrito over the UDP socket
+#define MAX_BUFFER_SIZE 1024
+
+// Enumerations of the different packet types that can be sent
+#define PACKET_FRAME 1
+#define PACKET_METADATA 2
+#define PACKET_LINK_TIMEOUT 3
+
+struct BurritoFrameData {
+    uint8_t message_type; // 0x01
+    float camera_position[3];
+    float camera_front[3];
+    float avatar_position[3];
+    float map_offset_x;
+    float map_offset_y;
+    float map_scale;
+    float compass_rotation;
+    uint32_t ui_state;
+} __attribute__((packed));
+static_assert(sizeof(struct BurritoFrameData) == 57, "BurritoFrameData is expected to be 57 bytes long.");
+
+
+struct MetadataMessage {
+    uint8_t message_type; // 0x02
+    uint16_t compass_width;
+    uint16_t compass_height;
+    uint32_t map_id;
+    uint32_t x11_window_id;
+    uint32_t identity_size;
+    uint8_t utf8_identity[1024];
+}__attribute__((packed));
+#define MetadataMessageFixedSize offsetof(struct MetadataMessage, utf8_identity)
+static_assert(MetadataMessageFixedSize == 17, "error");
+static_assert(sizeof(((struct MetadataMessage *)0)->utf8_identity) == 1024, "error");
+static_assert(sizeof(struct MetadataMessage) == 1041, "MetadataMessage is expected to be 1041 bytes long.");
+
+
+struct TimeoutMessage {
+    uint8_t message_type; // 0x03
+} __attribute__((packed));
+static_assert(sizeof(struct TimeoutMessage) == 1, "TimeoutMessage is expected to be 1 byte long.");
+
+
+// Sanity check our various datatypes on compile.
+static_assert(sizeof(float) == 4, "float is expected to be 32 bits long.");
+static_assert(sizeof(uint8_t) == 1, "uint8_t is expected to be 8 bits long.");
+static_assert(sizeof(uint16_t) == 2, "uint16_t is expected to be 16 bits long.");
+static_assert(sizeof(uint32_t) == 4, "uint32_t is expected to be 32 bits long.");
+static_assert(sizeof(wchar_t) == 2, "wchar_t is expected to be 16 bits long.");
+
+void send_metadata_message(
+    struct MetadataMessage* message,
+    SOCKET SendingSocket,
+    SOCKADDR_IN ReceiverAddr
+) {
+    uint32_t total_bytes_sent = 0;
+    total_bytes_sent = sendto(SendingSocket, (const char*)message, sizeof(*message), 0, (SOCKADDR *)&ReceiverAddr, sizeof(ReceiverAddr));
+    if (total_bytes_sent != sizeof(*message)) {
+        printf("Not all Bytes Sent");
+    }
+}
+
+#endif  // BURRITO_LINK_SERIALIZER_H_


### PR DESCRIPTION
A first round of creating integration tests for burrito link.
Utilizes the dll output file. Test both the light messages and the heavy messages directly.
Also calculates average latency, though this number is not as useful as one might think because the latency is mostly dependent on when during the 1ms delay the shared memory is updated.

More tests and comments will be added to this over time but for now we have a guarantee that we are sending the messages we think we are sending, and that our latency is well within reasonable times (~0.6ms end to end).