### PR TITLE
Defining strict pointer and reference alignment rules

### DIFF
--- a/burrito_converter/.clang-format
+++ b/burrito_converter/.clang-format
@@ -57,7 +57,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -106,6 +106,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1 # 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+ReferenceAlignment: Right
 RawStringFormats:
   - Language:        Cpp
     Delimiters:
@@ -156,7 +157,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-Standard:        Auto
+Standard: Auto
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION

--- a/burrito_converter/src/argument_parser.cpp
+++ b/burrito_converter/src/argument_parser.cpp
@@ -53,7 +53,7 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
         auto it = arg_map.find(argv[i]);
         if (it != arg_map.end()) {
             if (!current_paths.empty()) {
-                for (const string& path : current_paths) {
+                for (const string &path : current_paths) {
                     marker_pack_configs.emplace_back(type, format, path, split_by_category_depth, split_by_map_id);
                 }
                 current_paths.clear();
@@ -116,7 +116,7 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
     }
 
     if (!current_paths.empty()) {
-        for (const auto& path : current_paths) {
+        for (const auto &path : current_paths) {
             marker_pack_configs.emplace_back(type, format, path, split_by_category_depth, split_by_map_id);
         }
     }

--- a/burrito_converter/src/attribute/float.cpp
+++ b/burrito_converter/src/attribute/float.cpp
@@ -60,7 +60,7 @@ void Attribute::Float::from_proto_field(
 void Attribute::Float::to_proto_field(
     float value,
     ProtoWriterState*,
-    std::function<void(float&)> setter
+    std::function<void(float &)> setter
 ) {
     setter(value);
 }

--- a/burrito_converter/src/attribute/float.hpp
+++ b/burrito_converter/src/attribute/float.hpp
@@ -38,7 +38,7 @@ void from_proto_field(
 void to_proto_field(
     float value,
     ProtoWriterState* state,
-    std::function<void(float&)> setter
+    std::function<void(float &)> setter
 );
 
 }  // namespace Attribute::Float

--- a/burrito_converter/src/attribute/image.cpp
+++ b/burrito_converter/src/attribute/image.cpp
@@ -78,7 +78,7 @@ void Attribute::Image::from_proto_field(
 // written to the proto setter function.
 ////////////////////////////////////////////////////////////////////////////////
 void Attribute::Image::to_proto_field(
-    const Image& value,
+    const Image &value,
     ProtoWriterState* state,
     std::function<void(unsigned int)> setter
 ) {

--- a/burrito_converter/src/attribute/image.hpp
+++ b/burrito_converter/src/attribute/image.hpp
@@ -43,7 +43,7 @@ void from_proto_field(
 );
 
 void to_proto_field(
-    const Image& value,
+    const Image &value,
     ProtoWriterState* state,
     std::function<void(unsigned int)> setter
 );

--- a/burrito_converter/src/attribute/int.cpp
+++ b/burrito_converter/src/attribute/int.cpp
@@ -26,7 +26,7 @@ void Attribute::Int::from_xml_attribute(
         *value = stoi(get_attribute_value(input));
         *is_set = true;
     }
-    catch (std::invalid_argument const& exception) {
+    catch (std::invalid_argument const &exception) {
         errors->push_back(new XMLAttributeValueError("Invalid integer value", input));
     }
     // TODO(#99): Do we need an out_of_range exception catch when parsing integers?
@@ -73,7 +73,7 @@ void Attribute::Int::from_proto_field(
 void Attribute::Int::to_proto_field(
     int value,
     ProtoWriterState*,
-    std::function<void(int&)> setter
+    std::function<void(int &)> setter
 ) {
     setter(value);
 }

--- a/burrito_converter/src/attribute/int.hpp
+++ b/burrito_converter/src/attribute/int.hpp
@@ -38,7 +38,7 @@ void from_proto_field(
 void to_proto_field(
     int value,
     ProtoWriterState* state,
-    std::function<void(int&)> setter
+    std::function<void(int &)> setter
 );
 
 }  // namespace Attribute::Int

--- a/burrito_converter/src/attribute/unique_id.hpp
+++ b/burrito_converter/src/attribute/unique_id.hpp
@@ -24,7 +24,7 @@ class UniqueId {
  public:
     std::vector<uint8_t> guid;
 
-    bool operator<(const UniqueId& other) const {
+    bool operator<(const UniqueId &other) const {
         return guid < other.guid;
     }
 

--- a/burrito_converter/src/burrito_converter.cpp
+++ b/burrito_converter/src/burrito_converter.cpp
@@ -66,7 +66,7 @@ map<UniqueId, CategoryWithinSinglePack> read_taco_directory(
     map<UniqueId, map<string, vector<CategoryNameAndFilePath>>> id_to_category_name_to_filepaths;
     string directory_name = filesystem::path(input_path).filename();
     vector<MarkerPackFile> xml_files = get_files_by_suffix(input_path, ".xml");
-    for (const MarkerPackFile& path : xml_files) {
+    for (const MarkerPackFile &path : xml_files) {
         map<UniqueId, Category*> top_level_categories = parse_xml_file(path, marker_categories, parsed_pois);
         string file_path = join_file_paths(input_path, path.relative_filepath);
         for (map<UniqueId, Category*>::iterator it = top_level_categories.begin(); it != top_level_categories.end(); it++) {
@@ -119,7 +119,7 @@ map<UniqueId, CategoryWithinSinglePack> read_burrito_directory(
     map<UniqueId, map<string, vector<string>>> id_conflicts;
     string directory_name = filesystem::path(input_path).filename();
     vector<MarkerPackFile> burrito_files = get_files_by_suffix(input_path, ".guildpoint");
-    for (const MarkerPackFile& path : burrito_files) {
+    for (const MarkerPackFile &path : burrito_files) {
         map<UniqueId, Category*> top_level_categories = read_protobuf_file(path, marker_categories, parsed_pois);
         string file_path = join_file_paths(input_path, path.relative_filepath);
         for (map<UniqueId, Category*>::iterator it = top_level_categories.begin(); it != top_level_categories.end(); it++) {

--- a/burrito_converter/src/category_gen.cpp
+++ b/burrito_converter/src/category_gen.cpp
@@ -103,7 +103,7 @@ rapidxml::xml_node<char>* Category::as_xml(XMLWriterState* state) const {
         Attribute::String::to_xml_attribute(state, &this->tooltip_description, setter);
     }
 
-    for (const auto& [key, val] : this->children) {
+    for (const auto &[key, val] : this->children) {
         xml_node->append_node(val.as_xml(state));
     }
     return xml_node;

--- a/burrito_converter/src/file_helper.cpp
+++ b/burrito_converter/src/file_helper.cpp
@@ -79,7 +79,7 @@ const string MarkerPackFile::tmp_get_path() const {
 // Helper function to compare the full file paths of marker pack files so that
 // they can be sorted deterministically.
 ////////////////////////////////////////////////////////////////////////////////
-bool marker_pack_file_comp(const MarkerPackFile& a, const MarkerPackFile& b) {
+bool marker_pack_file_comp(const MarkerPackFile &a, const MarkerPackFile &b) {
     if (a.base == b.base) {
         return lowercase(a.relative_filepath) < lowercase(b.relative_filepath);
     }
@@ -93,9 +93,9 @@ bool marker_pack_file_comp(const MarkerPackFile& a, const MarkerPackFile& b) {
 // filepath `base`
 ////////////////////////////////////////////////////////////////////////////////
 vector<MarkerPackFile> get_files_by_suffix(
-    const string& base,
-    const string& suffix,
-    const string& subpath
+    const string &base,
+    const string &suffix,
+    const string &subpath
 ) {
     vector<MarkerPackFile> files;
 
@@ -164,7 +164,7 @@ vector<MarkerPackFile> get_files_by_suffix(
     return files;
 }
 
-vector<MarkerPackFile> get_files_by_suffix(const string& base, const string& suffix) {
+vector<MarkerPackFile> get_files_by_suffix(const string &base, const string &suffix) {
     return get_files_by_suffix(base, suffix, "");
 }
 
@@ -175,8 +175,8 @@ vector<MarkerPackFile> get_files_by_suffix(const string& base, const string& suf
 // a directory.
 ////////////////////////////////////////////////////////////////////////////////
 static unique_ptr<basic_istream<char>> _open_directory_file_for_read(
-    const string& base,
-    const string& filename
+    const string &base,
+    const string &filename
 ) {
     unique_ptr<ifstream> input_filestream = make_unique<ifstream>();
 
@@ -199,8 +199,8 @@ static unique_ptr<basic_istream<char>> _open_directory_file_for_read(
 // a zipfile.
 ////////////////////////////////////////////////////////////////////////////////
 static unique_ptr<basic_istream<char>> _open_zip_file_for_read(
-    const string& zipfile,
-    const string& filename
+    const string &zipfile,
+    const string &filename
 ) {
     mz_zip_archive zip_archive;
     memset(&zip_archive, 0, sizeof(zip_archive));
@@ -239,7 +239,7 @@ static unique_ptr<basic_istream<char>> _open_zip_file_for_read(
 // `filename` will be opened inside of it. If `base` is a directory then
 // `filename` inside of that directory will be opened instead.
 ////////////////////////////////////////////////////////////////////////////////
-unique_ptr<basic_istream<char>> read_file(const MarkerPackFile& file) {
+unique_ptr<basic_istream<char>> read_file(const MarkerPackFile &file) {
     // cout << "Open File for Read" << endl;
     if (!filesystem::exists(file.base)) {
         cout << "Error: " << file.base << " does not exist" << endl;
@@ -259,9 +259,9 @@ unique_ptr<basic_istream<char>> read_file(const MarkerPackFile& file) {
 }
 
 static bool _write_directory_file(
-    const string& base,
-    const string& filename,
-    const stringstream& file_content
+    const string &base,
+    const string &filename,
+    const stringstream &file_content
 ) {
     string filepath = join_file_paths(base, filename);
 
@@ -276,9 +276,9 @@ static bool _write_directory_file(
 }
 
 static bool _write_zip_file(
-    const string& zipfile,
-    const string& filename,
-    const stringstream& file_content
+    const string &zipfile,
+    const string &filename,
+    const stringstream &file_content
 ) {
     mz_zip_archive zip_archive;
     memset(&zip_archive, 0, sizeof(zip_archive));
@@ -310,7 +310,7 @@ static bool _write_zip_file(
     return true;
 }
 
-bool write_file(const MarkerPackFile& file, const stringstream& file_content) {
+bool write_file(const MarkerPackFile &file, const stringstream &file_content) {
     if (filesystem::exists(file.base) && filesystem::is_regular_file(file.base)) {
         return _write_zip_file(file.base, file.relative_filepath, file_content);
     }

--- a/burrito_converter/src/file_helper.hpp
+++ b/burrito_converter/src/file_helper.hpp
@@ -16,8 +16,8 @@ class MarkerPackFile {
 
 void copy_file(MarkerPackFile original_path, MarkerPackFile new_path);
 
-std::vector<MarkerPackFile> get_files_by_suffix(const std::string& base, const std::string& suffix);
+std::vector<MarkerPackFile> get_files_by_suffix(const std::string &base, const std::string &suffix);
 
-std::unique_ptr<std::basic_istream<char>> read_file(const MarkerPackFile& file);
+std::unique_ptr<std::basic_istream<char>> read_file(const MarkerPackFile &file);
 
-bool write_file(const MarkerPackFile& file, const std::stringstream& file_content);
+bool write_file(const MarkerPackFile &file, const std::stringstream &file_content);

--- a/burrito_converter/src/function_timers.hpp
+++ b/burrito_converter/src/function_timers.hpp
@@ -36,7 +36,7 @@
         call_count_##TIMER += 1; \
     } \
     void print_timer_##TIMER(); \
-    void print_timer_##TIMER(std::ostream&);
+    void print_timer_##TIMER(std::ostream &);
 
 TIMER_PROTOTYPE(0)
 TIMER_PROTOTYPE(1)

--- a/burrito_converter/src/hash_helpers.cpp
+++ b/burrito_converter/src/hash_helpers.cpp
@@ -17,7 +17,7 @@ void Hash64::update(const unsigned char* str, size_t length) {
     }
 }
 
-void Hash64::update(const std::string& str) {
+void Hash64::update(const std::string &str) {
     this->update((unsigned char*)str.c_str(), str.length());
 }
 
@@ -59,7 +59,7 @@ void Hash128::update(const unsigned char* str, size_t length) {
     }
 }
 
-void Hash128::update(const std::string& str) {
+void Hash128::update(const std::string &str) {
     this->update((unsigned char*)str.c_str(), str.length());
 }
 

--- a/burrito_converter/src/hash_helpers.hpp
+++ b/burrito_converter/src/hash_helpers.hpp
@@ -12,7 +12,7 @@ class Hash64 {
     Hash64();
     explicit Hash64(uint64_t init);
     void update(const unsigned char* str, size_t length);
-    void update(const std::string& str);
+    void update(const std::string &str);
     std::string hex() const;
 };
 
@@ -25,7 +25,7 @@ class Hash128 {
     Hash128();
     Hash128(uint64_t upper, uint64_t lower);
     void update(const unsigned char* str, size_t length);
-    void update(const std::string& str);
+    void update(const std::string &str);
     std::string hex() const;
     Attribute::UniqueId::UniqueId unique_id() const;
 };

--- a/burrito_converter/src/packaging_protobin.cpp
+++ b/burrito_converter/src/packaging_protobin.cpp
@@ -69,7 +69,7 @@ Category* parse_guildpoint_categories(
 // Reads a protobuf file into memory.
 ////////////////////////////////////////////////////////////////////////////////
 map<Attribute::UniqueId::UniqueId, Category*> read_protobuf_file(
-    const MarkerPackFile& proto_filepath,
+    const MarkerPackFile &proto_filepath,
     map<string, Category>* marker_categories,
     vector<Parseable*>* parsed_pois
 ) {
@@ -106,8 +106,8 @@ struct MaybeCategory {
 };
 MaybeCategory build_category_objects(
     const Category* category,
-    const StringHierarchy& category_filter,
-    const std::map<string, std::vector<Parseable*>>& category_to_pois,
+    const StringHierarchy &category_filter,
+    const std::map<string, std::vector<Parseable*>> &category_to_pois,
     vector<string>* category_vector,
     ProtoWriterState* state
 ) {
@@ -183,10 +183,10 @@ void proto_post_processing(ProtoWriterState* state, guildpoint::Guildpoint* prot
 }
 
 void _write_protobuf_file(
-    const MarkerPackFile& filepath,
-    const StringHierarchy& category_filter,
+    const MarkerPackFile &filepath,
+    const StringHierarchy &category_filter,
     const map<string, Category>* marker_categories,
-    const std::map<string, std::vector<Parseable*>>& category_to_pois,
+    const std::map<string, std::vector<Parseable*>> &category_to_pois,
     ProtoWriterState* state
 ) {
     guildpoint::Guildpoint output_message;
@@ -239,8 +239,8 @@ std::map<string, std::vector<Parseable*>> construct_category_to_pois_map(const v
 }
 
 void write_protobuf_file(
-    const string& marker_pack_root_directory,
-    const StringHierarchy& category_filter,
+    const string &marker_pack_root_directory,
+    const StringHierarchy &category_filter,
     const map<string, Category>* marker_categories,
     const vector<Parseable*>* parsed_pois
 ) {
@@ -260,8 +260,8 @@ void write_protobuf_file(
 
 // Write protobuf per map id
 void write_protobuf_file_per_map_id(
-    const string& marker_pack_root_directory,
-    const StringHierarchy& category_filter,
+    const string &marker_pack_root_directory,
+    const StringHierarchy &category_filter,
     const map<string, Category>* marker_categories,
     const vector<Parseable*>* parsed_pois
 ) {
@@ -326,7 +326,7 @@ map<string, StringHierarchy> category_filter_by_depth(
 
 // Write protobuf per category
 void write_protobuf_file_per_category(
-    const string& marker_pack_root_directory,
+    const string &marker_pack_root_directory,
     const int split_by_category_depth,
     const map<string, Category>* marker_categories,
     const vector<Parseable*>* parsed_pois

--- a/burrito_converter/src/packaging_protobin.hpp
+++ b/burrito_converter/src/packaging_protobin.hpp
@@ -13,27 +13,27 @@
 #include "string_hierarchy.hpp"
 
 std::map<Attribute::UniqueId::UniqueId, Category*> read_protobuf_file(
-    const MarkerPackFile& proto_filepath,
+    const MarkerPackFile &proto_filepath,
     std::map<std::string, Category>* marker_categories,
     std::vector<Parseable*>* parsed_pois
 );
 
 void write_protobuf_file(
-    const std::string& marker_pack_root_directory,
-    const StringHierarchy& category_filter,
+    const std::string &marker_pack_root_directory,
+    const StringHierarchy &category_filter,
     const std::map<std::string, Category>* marker_categories,
     const std::vector<Parseable*>* parsed_pois
 );
 
 void write_protobuf_file_per_map_id(
-    const std::string& marker_pack_root_directory,
-    const StringHierarchy& category_filter,
+    const std::string &marker_pack_root_directory,
+    const StringHierarchy &category_filter,
     const std::map<std::string, Category>* marker_categories,
     const std::vector<Parseable*>* parsed_pois
 );
 
 void write_protobuf_file_per_category(
-    const std::string& marker_pack_root_directory,
+    const std::string &marker_pack_root_directory,
     const int split_by_category_depth,
     const std::map<std::string, Category>* marker_categories,
     const std::vector<Parseable*>* parsed_pois

--- a/burrito_converter/src/packaging_xml.cpp
+++ b/burrito_converter/src/packaging_xml.cpp
@@ -232,7 +232,7 @@ class XMLFileData {
     string display_path;
     rapidxml::xml_document<char> xml_document;
 
-    XMLFileData(unique_ptr<basic_istream<char>> input, const MarkerPackFile& filepath) {
+    XMLFileData(unique_ptr<basic_istream<char>> input, const MarkerPackFile &filepath) {
         this->raw_file = std::move(input);
         this->xml_file = new rapidxml::file<char>(*this->raw_file);
         this->display_path = filepath.tmp_get_path();
@@ -248,7 +248,7 @@ vector<XMLFileData*> xml_files_to_cleanup;
 // A function which parses a single XML file into their corrisponding classes.
 ////////////////////////////////////////////////////////////////////////////////
 map<Attribute::UniqueId::UniqueId, Category*> parse_xml_file(
-    const MarkerPackFile& xml_filepath,
+    const MarkerPackFile &xml_filepath,
     map<string, Category>* marker_categories,
     vector<Parseable*>* parsed_pois
 ) {
@@ -319,13 +319,13 @@ void write_xml_file(const string marker_pack_root_directory, map<string, Categor
     rapidxml::xml_node<char>* root = doc.allocate_node(rapidxml::node_element, "OverlayData");
     doc.append_node(root);
 
-    for (const auto& category : *marker_categories) {
+    for (const auto &category : *marker_categories) {
         root->append_node(category.second.as_xml(&state));
     }
 
     rapidxml::xml_node<char>* pois = doc.allocate_node(rapidxml::node_element, "POIs");
     root->append_node(pois);
-    for (const auto& parsed_poi : *parsed_pois) {
+    for (const auto &parsed_poi : *parsed_pois) {
         pois->append_node(parsed_poi->as_xml(&state));
     }
 

--- a/burrito_converter/src/packaging_xml.hpp
+++ b/burrito_converter/src/packaging_xml.hpp
@@ -11,7 +11,7 @@
 #include "state_structs/xml_reader_state.hpp"
 
 std::map<Attribute::UniqueId::UniqueId, Category*> parse_xml_file(
-    const MarkerPackFile& xml_filepath,
+    const MarkerPackFile &xml_filepath,
     std::map<std::string, Category>* marker_categories,
     std::vector<Parseable*>* parsed_pois
 );

--- a/burrito_converter/src/state_structs/xml_writer_state.hpp
+++ b/burrito_converter/src/state_structs/xml_writer_state.hpp
@@ -17,7 +17,7 @@ struct XMLWriterState {
     std::string marker_pack_root_directory;
 
     // A reference to the rapidxml document that is being written to
-    rapidxml::xml_document<char> *doc;
+    rapidxml::xml_document<char>* doc;
 
     // A set of all the textures that have been written to this taco file already
     std::set<std::string> written_textures;

--- a/burrito_converter/src/string_helper.cpp
+++ b/burrito_converter/src/string_helper.cpp
@@ -49,7 +49,7 @@ vector<string> split(string input, string delimiter) {
     return output;
 }
 
-string join(const vector<string>& input, const string& delimiter) {
+string join(const vector<string> &input, const string &delimiter) {
     string result;
     size_t size = 0;
     for (size_t i = 0; i < input.size(); i++) {
@@ -220,7 +220,7 @@ static unsigned char base64_lookup[256] = {
 };
 // clang-format on
 
-std::vector<uint8_t> base64_decode(std::string const& encoded_string) {
+std::vector<uint8_t> base64_decode(std::string const &encoded_string) {
     int in_len = encoded_string.size();
 
     uint8_t char_array_4[4];
@@ -282,7 +282,7 @@ string get_base_dir(string filepath) {
     return filepath.substr(0, s);
 }
 
-bool has_suffix(std::string const& fullString, std::string const& ending) {
+bool has_suffix(std::string const &fullString, std::string const &ending) {
     if (fullString.length() >= ending.length()) {
         return (0 == fullString.compare(fullString.length() - ending.length(), ending.length(), ending));
     }
@@ -291,7 +291,7 @@ bool has_suffix(std::string const& fullString, std::string const& ending) {
     }
 }
 
-string join_file_paths(const string& path_a, const string& path_b) {
+string join_file_paths(const string &path_a, const string &path_b) {
     if (path_a.empty()) {
         return path_b;
     }
@@ -346,7 +346,7 @@ static const unsigned char hex_lookup[256] = {
 };
 // clang-format on
 
-bool is_hex(const string& value) {
+bool is_hex(const string &value) {
     for (size_t i = 0; i < value.length(); i++) {
         if (hex_lookup[(uint8_t)value[i]] == 255) {
             return false;

--- a/burrito_converter/src/string_helper.hpp
+++ b/burrito_converter/src/string_helper.hpp
@@ -13,17 +13,17 @@ bool normalized_matches_any(std::string test, std::vector<std::string> list);
 std::string lowercase(std::string);
 
 std::vector<std::string> split(std::string input, std::string delimiter);
-std::string join(const std::vector<std::string>& input, const std::string& delimiter);
+std::string join(const std::vector<std::string> &input, const std::string &delimiter);
 
 std::string normalize(std::string input_string);
 
 std::string base64_encode(uint8_t const* buf, unsigned int bufLen);
-std::vector<uint8_t> base64_decode(std::string const&);
+std::vector<uint8_t> base64_decode(std::string const &);
 
 std::string get_base_dir(std::string filepath);
-bool has_suffix(std::string const& fullString, std::string const& ending);
-std::string join_file_paths(const std::string& path_a, const std::string& path_b);
+bool has_suffix(std::string const &fullString, std::string const &ending);
+std::string join_file_paths(const std::string &path_a, const std::string &path_b);
 
 std::string long_to_hex_string(uint64_t number);
 
-bool is_hex(const std::string& value);
+bool is_hex(const std::string &value);

--- a/burrito_converter/src/string_hierarchy.cpp
+++ b/burrito_converter/src/string_hierarchy.cpp
@@ -79,7 +79,7 @@ bool StringHierarchy::_in_hierarchy(
 //
 // A helper function to grab a sub hierarchy one level down from the top.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy *StringHierarchy::sub_hierarchy(
+const StringHierarchy* StringHierarchy::sub_hierarchy(
     const std::string &node
 ) const {
     if (this->all_children_included) {
@@ -99,7 +99,7 @@ const StringHierarchy *StringHierarchy::sub_hierarchy(
 // An explicit version of sub_hierarchy that takes an initalizer list to
 // prevent ambiguity between the vector and string overloads of the function.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy *StringHierarchy::sub_hierarchy(
+const StringHierarchy* StringHierarchy::sub_hierarchy(
     const std::initializer_list<std::string> &input
 ) const {
     std::vector<std::string> vec;
@@ -114,10 +114,10 @@ const StringHierarchy *StringHierarchy::sub_hierarchy(
 // entire hierarchy in the case where the use case is traversing down a tree
 // anyways and does not want to keep track of the parent's values.
 ////////////////////////////////////////////////////////////////////////////////
-const StringHierarchy *StringHierarchy::sub_hierarchy(
+const StringHierarchy* StringHierarchy::sub_hierarchy(
     const std::vector<std::string> &path
 ) const {
-    const StringHierarchy *sub_hierarchy = this;
+    const StringHierarchy* sub_hierarchy = this;
     for (size_t i = 0; i < path.size(); i++) {
         sub_hierarchy = sub_hierarchy->sub_hierarchy(path[i]);
         // Escape before segfaulting.

--- a/burrito_converter/src/string_hierarchy.hpp
+++ b/burrito_converter/src/string_hierarchy.hpp
@@ -18,15 +18,15 @@ class StringHierarchy {
         const std::initializer_list<std::string> &input
     ) const;
 
-    const StringHierarchy *sub_hierarchy(
+    const StringHierarchy* sub_hierarchy(
         const std::string &node
     ) const;
 
-    const StringHierarchy *sub_hierarchy(
+    const StringHierarchy* sub_hierarchy(
         const std::initializer_list<std::string> &input
     ) const;
 
-    const StringHierarchy *sub_hierarchy(
+    const StringHierarchy* sub_hierarchy(
         const std::vector<std::string> &path
     ) const;
 

--- a/burrito_link/.clang-format
+++ b/burrito_link/.clang-format
@@ -57,7 +57,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -106,6 +106,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1 # 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+ReferenceAlignment: Right
 RawStringFormats:
   - Language:        Cpp
     Delimiters:

--- a/burrito_link/burrito_link.c
+++ b/burrito_link/burrito_link.c
@@ -42,7 +42,7 @@ struct rolling_average_5 {
     float points[5];
 };
 
-float get_rolling_average(struct rolling_average_5 *points) {
+float get_rolling_average(struct rolling_average_5* points) {
     float sum = 0;
     for (int i = 0; i < 5; i++) {
         sum += points->points[i];
@@ -50,7 +50,7 @@ float get_rolling_average(struct rolling_average_5 *points) {
     return sum / 5.0;
 }
 
-void replace_point_in_rolling_average(struct rolling_average_5 *points, float newvalue) {
+void replace_point_in_rolling_average(struct rolling_average_5* points, float newvalue) {
     points->points[points->index] = newvalue;
     points->index = points->index + 1;
     if (points->index > 4) {
@@ -74,11 +74,11 @@ LPCTSTR mapped_lm;
 
 // Pointer to the mapped LinkedMem object. Only available after initMumble()
 // is called.
-struct LinkedMem *lm = NULL;
+struct LinkedMem* lm = NULL;
 
 // Pointer to the mapped MumbleContext object found at `lm->context`. Only
 // available after initMumble() is called.
-struct MumbleContext *lc = NULL;
+struct MumbleContext* lc = NULL;
 
 // How many "clocks", as defined by CLOCKS_PER_SECOND and by the return value
 // of clock(), will elapse before the program should time out. If this is left
@@ -138,9 +138,9 @@ void initMumble() {
 
         return;
     }
-    lm = (struct LinkedMem *)mapped_lm;
+    lm = (struct LinkedMem*)mapped_lm;
 
-    lc = (struct MumbleContext *)lm->context;
+    lc = (struct MumbleContext*)lm->context;
     printf("successfully opened mumble link shared memory..\n");
 }
 
@@ -251,7 +251,7 @@ int connect_and_or_send() {
             SendBuf[0] = PACKET_LINK_TIMEOUT;
             BufLength = 1;
 
-            TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR *)&ReceiverAddr, sizeof(ReceiverAddr));
+            TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR*)&ReceiverAddr, sizeof(ReceiverAddr));
             if (TotalByteSent != BufLength) {
                 printf("Not all Bytes Sent");
             }
@@ -316,7 +316,7 @@ int connect_and_or_send() {
         // memcpy(SendBuf + BufLength, &lc->mountIndex, sizeof(lc->mountIndex));
         // BufLength += sizeof(lc->mountIndex);
 
-        TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR *)&ReceiverAddr, sizeof(ReceiverAddr));
+        TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR*)&ReceiverAddr, sizeof(ReceiverAddr));
         if (TotalByteSent != BufLength) {
             printf("Not all Bytes Sent");
         }
@@ -363,7 +363,7 @@ int connect_and_or_send() {
             memcpy(SendBuf + BufLength, utf8_identity, utf8_identity_size);
             BufLength += utf8_identity_size;
 
-            TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR *)&ReceiverAddr, sizeof(ReceiverAddr));
+            TotalByteSent = sendto(SendingSocket, SendBuf, BufLength, 0, (SOCKADDR*)&ReceiverAddr, sizeof(ReceiverAddr));
             if (TotalByteSent != BufLength) {
                 printf("Not all Bytes Sent");
             }
@@ -394,7 +394,6 @@ int connect_and_or_send() {
     else {
         printf("Client: WSACleanup() is OK\n");
     }
-
 
     // Back to the system
     return 0;
@@ -427,7 +426,7 @@ void run_link() {
 // data that needs to be configured for just command line executions, then
 // calls run_link() which sets up all other state necessary for burrito link.
 ////////////////////////////////////////////////////////////////////////////////
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     for (int i = 0; i < argc; i++) {
         // If a timeout flag is passed in then set the timeout value
         if (strcmp(argv[i], "--timeout") == 0) {


### PR DESCRIPTION
This is a simple syntax style cleanup.
We could not do this before due to an older version of clang-format not supporting reference alignment. But now we can!