### PR TITLE
Embedding the context message directly instead of casting to it

### DIFF
--- a/burrito_link/burrito_link.c
+++ b/burrito_link/burrito_link.c
@@ -140,7 +140,7 @@ void initMumble() {
     }
     lm = (struct LinkedMem*)mapped_lm;
 
-    lc = (struct MumbleContext*)lm->context;
+    lc = &lm->context;
     printf("successfully opened mumble link shared memory..\n");
 }
 

--- a/burrito_link/integration_tests/main.c
+++ b/burrito_link/integration_tests/main.c
@@ -164,7 +164,7 @@ void initMumble() {
     }
     lm = (struct LinkedMem*)mapped_lm;
 
-    lc = (struct MumbleContext*)lm->context;
+    lc = &lm->context;
     printf("successfully opened mumble link shared memory..\n");
 }
 

--- a/burrito_link/linked_memory.h
+++ b/burrito_link/linked_memory.h
@@ -9,56 +9,6 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// LinkedMem struct
-//
-// This struct represents the Mumble Link shared memory datum that Guild Wars 2
-// uses to communicate live player and camera data, as well as some other
-// bits of information that are useful for tools like burrito.
-//
-// https://wiki.guildwars2.com/wiki/API:MumbleLink
-// https://www.mumble.info/documentation/developer/positional-audio/link-plugin/
-////////////////////////////////////////////////////////////////////////////////
-struct LinkedMem {
-    uint32_t uiVersion;
-
-    // The current update tick
-    uint32_t uiTick;
-
-    // The XYZ location of the player
-    float fAvatarPosition[3];
-
-    // A 3D unit vector representing the forward direction of the player character
-    float fAvatarFront[3];
-
-    // A 3D unit vector representing the up direction of the player character
-    float fAvatarTop[3];
-
-    // The string "Guild Wars 2"
-    wchar_t name[256];
-
-    // The XYZ Position of the camera
-    float fCameraPosition[3];
-
-    // A 3D unit vector representing the forward direction of the camera
-    float fCameraFront[3];
-
-    // A 3D unit vector representing the up direction of the camera
-    float fCameraTop[3];
-
-    // A json string containing json data. See https://wiki.guildwars2.com/wiki/API:MumbleLink#identity
-    wchar_t identity[256];
-
-    // A value that is always 48
-    uint32_t context_len;
-
-    // A binary chunk containing another struct. See the MumbleContext struct below
-    uint8_t context[256];
-
-    // An Empty Array, this field is not used by guild wars 2
-    wchar_t description[2048];
-};
-
-////////////////////////////////////////////////////////////////////////////////
 // MumbleContext struct
 //
 // This struct represents the LinkedMem.context datum that is passed in
@@ -120,6 +70,56 @@ struct MumbleContext {
 
     // Extra bytes that are not currently accounted for or are unused in the context
     uint8_t _padding[171];
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// LinkedMem struct
+//
+// This struct represents the Mumble Link shared memory datum that Guild Wars 2
+// uses to communicate live player and camera data, as well as some other
+// bits of information that are useful for tools like burrito.
+//
+// https://wiki.guildwars2.com/wiki/API:MumbleLink
+// https://www.mumble.info/documentation/developer/positional-audio/link-plugin/
+////////////////////////////////////////////////////////////////////////////////
+struct LinkedMem {
+    uint32_t uiVersion;
+
+    // The current update tick
+    uint32_t uiTick;
+
+    // The XYZ location of the player
+    float fAvatarPosition[3];
+
+    // A 3D unit vector representing the forward direction of the player character
+    float fAvatarFront[3];
+
+    // A 3D unit vector representing the up direction of the player character
+    float fAvatarTop[3];
+
+    // The string "Guild Wars 2"
+    wchar_t name[256];
+
+    // The XYZ Position of the camera
+    float fCameraPosition[3];
+
+    // A 3D unit vector representing the forward direction of the camera
+    float fCameraFront[3];
+
+    // A 3D unit vector representing the up direction of the camera
+    float fCameraTop[3];
+
+    // A json string containing json data. See https://wiki.guildwars2.com/wiki/API:MumbleLink#identity
+    wchar_t identity[256];
+
+    // A value that is always 48
+    uint32_t context_len;
+
+    // A binary chunk containing another struct. See the MumbleContext struct above
+    struct MumbleContext context;
+
+    // An Empty Array, this field is not used by guild wars 2
+    wchar_t description[2048];
 };
 
 // Sanity check our memory map structs on compile.


### PR DESCRIPTION
Effectively no change, just makes it easier to access the context variables if all you have is a pointer to the linked memory.