### PR TITLE
Adding initial player cutout tooling to show the player above trails

### DIFF
--- a/Settings.gd
+++ b/Settings.gd
@@ -44,6 +44,8 @@ var burrito_link_auto_launch_enabled: bool = false
 var burrito_link_wine_path: String = ""
 var burrito_link_env_args: String = ""
 
+var enable_player_cutout: bool = false
+
 # We save the marker data in this directory when the files are have been split
 # by Map ID. All changes made by the editor are automatically saved in these
 # files prior to export.
@@ -95,6 +97,9 @@ func _ready():
 		self.burrito_link_env_args = self._config_data["burrito_link_env_args"]
 	if "start_with_open_menu" in self._config_data:
 		self.start_with_open_menu = self._config_data["start_with_open_menu"]
+	if "enable_player_cutout" in self._config_data:
+		self.enable_player_cutout = self._config_data["enable_player_cutout"]
+
 
 func get_saved_markers_dir() -> String:
 	FileHandler.create_directory_if_missing(self.saved_markers_dir)
@@ -118,7 +123,8 @@ func save():
 		"burrito_link_wine_path": burrito_link_wine_path,
 		"burrito_link_env_args": burrito_link_env_args,
 		"local_category_data": local_category_data,
-		"start_with_open_menu": start_with_open_menu
+		"start_with_open_menu": start_with_open_menu,
+		"enable_player_cutout": enable_player_cutout
 	}
 
 	var file = File.new()

--- a/SettingsDialog.gd
+++ b/SettingsDialog.gd
@@ -26,6 +26,10 @@ func load_settings():
 	var environment_vars: TextEdit = $ScrollContainer/GridContainer/EnvironmentVars
 	environment_vars.text = Settings.burrito_link_env_args
 
+	var enable_player_cutout: CheckButton = $ScrollContainer/GridContainer/EnablePlayerCutout
+	enable_player_cutout.pressed = Settings.enable_player_cutout
+
+
 func save_settings(new_value=null):
 	var minimum_width: LineEdit = $ScrollContainer/GridContainer/MinimumWidth
 	Settings.minimum_width = int(minimum_width.text)
@@ -58,6 +62,9 @@ func save_settings(new_value=null):
 	Settings.burrito_link_wine_path = wine_path.text
 	var environment_vars: TextEdit = $ScrollContainer/GridContainer/EnvironmentVars
 	Settings.burrito_link_env_args = environment_vars.text
+
+	var enable_player_cutout: CheckButton = $ScrollContainer/GridContainer/EnablePlayerCutout
+	Settings.enable_player_cutout = enable_player_cutout.pressed
 
 	Settings.save()
 

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -675,7 +675,7 @@ __meta__ = {
 
 [node name="GridContainer" type="GridContainer" parent="Control/Dialogs/SettingsDialog/ScrollContainer"]
 margin_right = 384.0
-margin_bottom = 436.0
+margin_bottom = 480.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
@@ -786,61 +786,74 @@ margin_right = 372.0
 margin_bottom = 252.0
 size_flags_horizontal = 3
 
-[node name="HSeparator" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 256.0
+[node name="EnablePlayerCutoutLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_top = 269.0
 margin_right = 192.0
-margin_bottom = 260.0
+margin_bottom = 283.0
+text = "Enable Player Cutout"
+
+[node name="EnablePlayerCutout" type="CheckButton" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_left = 196.0
+margin_top = 256.0
+margin_right = 372.0
+margin_bottom = 296.0
+size_flags_horizontal = 3
+
+[node name="HSeparator" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_top = 300.0
+margin_right = 192.0
+margin_bottom = 304.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HSeparator2" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 256.0
+margin_top = 300.0
 margin_right = 372.0
-margin_bottom = 260.0
+margin_bottom = 304.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="AutoLaunchBurritoLinkLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 268.0
+margin_top = 312.0
 margin_right = 192.0
-margin_bottom = 299.0
+margin_bottom = 343.0
 text = "Auto Launch
 Burrito Link"
 
 [node name="AutoLaunchBurritoLink" type="CheckButton" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 264.0
+margin_top = 308.0
 margin_right = 372.0
-margin_bottom = 304.0
+margin_bottom = 348.0
 size_flags_horizontal = 3
 
 [node name="WinePathLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 313.0
+margin_top = 357.0
 margin_right = 192.0
-margin_bottom = 327.0
+margin_bottom = 371.0
 text = "Wine Path"
 
 [node name="WinePath" type="LineEdit" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 308.0
+margin_top = 352.0
 margin_right = 372.0
-margin_bottom = 332.0
+margin_bottom = 376.0
 size_flags_horizontal = 3
 
 [node name="EnvironmentVarsLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 379.0
+margin_top = 423.0
 margin_right = 192.0
-margin_bottom = 393.0
+margin_bottom = 437.0
 text = "Environment Vars"
 
 [node name="EnvironmentVars" type="TextEdit" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 336.0
+margin_top = 380.0
 margin_right = 372.0
-margin_bottom = 436.0
+margin_bottom = 480.0
 rect_min_size = Vector2( 0, 100 )
 size_flags_horizontal = 3
 
@@ -1012,6 +1025,7 @@ material/0 = SubResource( 4 )
 [connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideBurritoIconPosition" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideBurritoIconHorizontalPosition" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideBurritoIconVerticalPosition" to="Control/Dialogs/SettingsDialog" method="save_settings"]
+[connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/EnablePlayerCutout" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/AutoLaunchBurritoLink" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/WinePath" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/EnvironmentVars" to="Control/Dialogs/SettingsDialog" method="save_settings"]

--- a/Trail.tres
+++ b/Trail.tres
@@ -10,4 +10,5 @@ shader_param/map_size = Vector2( 0, 0 )
 shader_param/map_flipped = null
 shader_param/map_bottom_offset = 36.0
 shader_param/interval = 1.0
+shader_param/cutout_data = null
 shader_param/texture_albedo = ExtResource( 1 )

--- a/shaders/Trail3DMaterial.shader
+++ b/shaders/Trail3DMaterial.shader
@@ -9,6 +9,8 @@ uniform float map_bottom_offset = 36.0;
 
 uniform float interval = 1.0;
 
+uniform vec3 cutout_data;
+
 void vertex() {}
 
 
@@ -22,6 +24,14 @@ void fragment() {
 		if (!map_flipped && SCREEN_UV.y * VIEWPORT_SIZE.y < map_size.y + map_bottom_offset) {
 			return;
 		}
+	}
+
+	if (
+		abs(SCREEN_UV.x - 0.5)*VIEWPORT_SIZE.x < cutout_data.z
+		&& SCREEN_UV.y * VIEWPORT_SIZE.y > cutout_data.x
+		&& SCREEN_UV.y * VIEWPORT_SIZE.y < cutout_data.y
+	) {
+		return;
 	}
 
 	vec2 base_uv = vec2(UV.y, -UV.x * interval);


### PR DESCRIPTION
This lets us enable and disable player cutouts to prevent a trail from rendering over top the player. Right now it is calculated as a rectangle which dynamically encapsulates a game character of a fixed height. However in the future we can dynamically change the height of the cutout, or the width, adjust the bounding box to be a more feathered or dithered edge, obey the marker pack attributes that allow or prevent the trail cutout on that specific trail, and adjust the cutout for mounts or races.