### PR TITLE
Splitting out arguments into individual structs for better control

### DIFF
--- a/burrito_converter/src/argument_parser.cpp
+++ b/burrito_converter/src/argument_parser.cpp
@@ -9,19 +9,25 @@
 
 using namespace std;
 
-InputTacoCommand::InputTacoCommand() : path("") {
+InputTacoCommand::InputTacoCommand()
+    : path("") {
 }
-InputTacoCommand::InputTacoCommand(string path) : path(path) {
-}
-
-InputGuildpointCommand::InputGuildpointCommand() : path("") {
-}
-InputGuildpointCommand::InputGuildpointCommand(string path) : path(path) {
+InputTacoCommand::InputTacoCommand(string path)
+    : path(path) {
 }
 
-OutputTacoCommand::OutputTacoCommand() : path("") {
+InputGuildpointCommand::InputGuildpointCommand()
+    : path("") {
 }
-OutputTacoCommand::OutputTacoCommand(string path) : path(path) {
+InputGuildpointCommand::InputGuildpointCommand(string path)
+    : path(path) {
+}
+
+OutputTacoCommand::OutputTacoCommand()
+    : path("") {
+}
+OutputTacoCommand::OutputTacoCommand(string path)
+    : path(path) {
 }
 
 OutputGuildpointCommand::OutputGuildpointCommand()
@@ -33,20 +39,11 @@ OutputGuildpointCommand::OutputGuildpointCommand(
     std::string path,
     OptionalInt split_by_category_depth,
     bool split_by_map_id
-) : path(path),
-    split_by_category_depth(split_by_category_depth),
-    split_by_map_id(split_by_map_id) {
+)
+    : path(path),
+      split_by_category_depth(split_by_category_depth),
+      split_by_map_id(split_by_map_id) {
 }
-
-class ArgumentConfig {
- public:
-    BehaviorType type;
-    MarkerFormat format;
-
-    ArgumentConfig(BehaviorType type, MarkerFormat format)
-        : type(type), format(format) {
-    }
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 // ParsedArgReturn

--- a/burrito_converter/src/argument_parser.cpp
+++ b/burrito_converter/src/argument_parser.cpp
@@ -3,19 +3,39 @@
 #include <cstring>
 #include <iostream>
 #include <map>
+#include <memory>
+
+#include "int_helper.hpp"
 
 using namespace std;
 
-// Default constructor for the class
-MarkerPackConfig::MarkerPackConfig()
-    : type(BehaviorType::NONE),
-      format(MarkerFormat::NONE),
-      path("DEFAULT"),
-      split_by_map_id(false) {
+InputTacoCommand::InputTacoCommand() : path("") {
+}
+InputTacoCommand::InputTacoCommand(string path) : path(path) {
 }
 
-MarkerPackConfig::MarkerPackConfig(BehaviorType type, MarkerFormat format, std::string path, OptionalInt split_by_category, bool split_by_map_id)
-    : type(type), format(format), path(path), split_by_category(split_by_category), split_by_map_id(split_by_map_id) {
+InputGuildpointCommand::InputGuildpointCommand() : path("") {
+}
+InputGuildpointCommand::InputGuildpointCommand(string path) : path(path) {
+}
+
+OutputTacoCommand::OutputTacoCommand() : path("") {
+}
+OutputTacoCommand::OutputTacoCommand(string path) : path(path) {
+}
+
+OutputGuildpointCommand::OutputGuildpointCommand()
+    : path(""),
+      split_by_category_depth(),
+      split_by_map_id(false) {
+}
+OutputGuildpointCommand::OutputGuildpointCommand(
+    std::string path,
+    OptionalInt split_by_category_depth,
+    bool split_by_map_id
+) : path(path),
+    split_by_category_depth(split_by_category_depth),
+    split_by_map_id(split_by_map_id) {
 }
 
 class ArgumentConfig {
@@ -29,76 +49,225 @@ class ArgumentConfig {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// ParsedArgReturn
+//
+// A helper struct which works as a return type to return a list of commands
+// alongside some additional parsing information
+////////////////////////////////////////////////////////////////////////////////
+template <typename T>
+struct ParsedArgReturn {
+    vector<T*> command;
+    unsigned int arguments_parsed;
+    bool error;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// parse_input_taco_args
+//
+// All of the logic for parsing the --input-taco-path argument, and any
+// associated arguments it might have.
+////////////////////////////////////////////////////////////////////////////////
+ParsedArgReturn<InputTacoCommand> parse_input_taco_args(unsigned int argc, char* argv[]) {
+    // Figure out how many path arguments there are for this command
+    unsigned int number_of_path_args = 0;
+    while (number_of_path_args < argc && string(argv[number_of_path_args]).find("--") != 0) {
+        number_of_path_args++;
+    }
+    if (number_of_path_args < 1) {
+        cerr << "Error: --input-taco-path is missing a path" << endl;
+        return {{}, 0, true};
+    }
+
+    // Build all of the commands
+    vector<InputTacoCommand*> commands;
+    for (unsigned int i = 0; i < number_of_path_args; i++) {
+        commands.push_back(
+            new InputTacoCommand(
+                string(argv[i])
+            )
+        );
+    }
+
+    return {
+        commands,
+        number_of_path_args,
+        false,
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// parse_input_guildpoint_args
+//
+// All of the logic for parsing the --input-guildpoint-path argument, and any
+// associated arguments it might have.
+////////////////////////////////////////////////////////////////////////////////
+ParsedArgReturn<InputGuildpointCommand> parse_input_guildpoint_args(unsigned int argc, char* argv[]) {
+    // Figure out how many path arguments there are for this command
+    unsigned int number_of_path_args = 0;
+    while (number_of_path_args < argc && string(argv[number_of_path_args]).find("--") != 0) {
+        number_of_path_args++;
+    }
+    if (number_of_path_args < 1) {
+        cerr << "Error: --input-guildpoint-path is missing a path" << endl;
+        return {{}, 0, true};
+    }
+
+    // Build all of the commands
+    vector<InputGuildpointCommand*> commands;
+    for (unsigned int i = 0; i < number_of_path_args; i++) {
+        commands.push_back(
+            new InputGuildpointCommand(
+                string(argv[i])
+            )
+        );
+    }
+
+    return {
+        commands,
+        number_of_path_args,
+        false,
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// parse_output_taco_args
+//
+// All of the logic for parsing the --output-taco-path argument, and any
+// associated arguments it might have.
+////////////////////////////////////////////////////////////////////////////////
+ParsedArgReturn<OutputTacoCommand> parse_output_taco_args(unsigned int argc, char* argv[]) {
+    // Figure out how many path arguments there are for this command
+    unsigned int number_of_path_args = 0;
+    while (number_of_path_args < argc && string(argv[number_of_path_args]).find("--") != 0) {
+        number_of_path_args++;
+    }
+    if (number_of_path_args < 1) {
+        cerr << "Error: --output-taco-path is missing a path" << endl;
+        return {{}, 0, true};
+    }
+
+    // Build all of the commands
+    vector<OutputTacoCommand*> commands;
+    for (unsigned int i = 0; i < number_of_path_args; i++) {
+        commands.push_back(
+            new OutputTacoCommand(
+                string(argv[i])
+            )
+        );
+    }
+
+    return {
+        commands,
+        number_of_path_args,
+        false,
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// parse_output_guildpoint_args
+//
+// All of the logic for parsing the --output-guildpoint-path argument, and any
+// associated arguments it might have.
+////////////////////////////////////////////////////////////////////////////////
+ParsedArgReturn<OutputGuildpointCommand> parse_output_guildpoint_args(unsigned int argc, char* argv[]) {
+    // Figure out how many path arguments there are for this command
+    unsigned int number_of_path_args = 0;
+    while (number_of_path_args < argc && string(argv[number_of_path_args]).find("--") != 0) {
+        number_of_path_args++;
+    }
+    if (number_of_path_args < 1) {
+        cerr << "Error: --output-guildpoint-path is missing a path" << endl;
+        return {{}, 0, true};
+    }
+
+    // Parse the other arguments for this command
+    OptionalInt split_by_category_depth;
+    bool split_by_map_id = false;
+
+    unsigned int total_args_parsed;
+    for (total_args_parsed = number_of_path_args; total_args_parsed < argc; total_args_parsed++) {
+        if (string(argv[total_args_parsed]) == "--split-by-category") {
+            split_by_category_depth.set_value(0);
+            if (total_args_parsed + 1 < argc && string(argv[total_args_parsed + 1]).find("--") != 0) {
+                if (is_string_valid_integer(argv[total_args_parsed + 1])) {
+                    split_by_category_depth.set_value(std::stoi(argv[++total_args_parsed]));
+                }
+                else {
+                    cerr << "Error: expected an integer after --split-by-category but received " << argv[total_args_parsed + 1] << endl;
+                    return {{}, 0, true};
+                }
+            }
+        }
+        else if (string(argv[total_args_parsed]) == "--split-by-map-id") {
+            split_by_map_id = true;
+        }
+        else {
+            break;
+        }
+    }
+
+    // Build all of the commands
+    vector<OutputGuildpointCommand*> commands;
+    for (unsigned int i = 0; i < number_of_path_args; i++) {
+        commands.push_back(
+            new OutputGuildpointCommand(
+                string(argv[i]),
+                split_by_category_depth,
+                split_by_map_id
+            )
+        );
+    }
+
+    return {
+        commands,
+        total_args_parsed,
+        false,
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // parse_arguments
 //
 // Processes all of the command line data into a format the internal functions
 // want to receive.
 ////////////////////////////////////////////////////////////////////////////////
 ParsedArguments parse_arguments(int argc, char* argv[]) {
-    vector<MarkerPackConfig> marker_pack_configs;
-    map<string, ArgumentConfig> arg_map = {
-        {"--input-taco-path", ArgumentConfig(BehaviorType::IMPORT, MarkerFormat::XML)},
-        {"--output-taco-path", ArgumentConfig(BehaviorType::EXPORT, MarkerFormat::XML)},
-        {"--input-guildpoint-path", ArgumentConfig(BehaviorType::IMPORT, MarkerFormat::GUILDPOINT)},
-        {"--output-guildpoint-path", ArgumentConfig(BehaviorType::EXPORT, MarkerFormat::GUILDPOINT)}};
+    std::vector<BaseCommand*> marker_pack_configs;
     ParsedArguments parsed_arguments;
-    BehaviorType type = BehaviorType::NONE;
-    MarkerFormat format = MarkerFormat::NONE;
-    OptionalInt split_by_category_depth;
-    bool split_by_map_id = false;
-    string current_argument;
-    vector<string> current_paths;
 
     for (int i = 1; i < argc; i++) {
-        auto it = arg_map.find(argv[i]);
-        if (it != arg_map.end()) {
-            if (!current_paths.empty()) {
-                for (const string &path : current_paths) {
-                    marker_pack_configs.emplace_back(type, format, path, split_by_category_depth, split_by_map_id);
-                }
-                current_paths.clear();
-            }
-            current_argument = argv[i];
-            type = it->second.type;
-            format = it->second.format;
-            // All flags must be set to default value
-            split_by_category_depth.set_null();
-            split_by_map_id = false;
-
-            while (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
-                current_paths.push_back(argv[++i]);
-            }
-            if (current_paths.empty()) {
-                cerr << "Error: Expected a path to a directory after " << current_argument << endl;
-                return {};
-            }
+        if (string(argv[i]) == "--input-taco-path") {
+            ParsedArgReturn<InputTacoCommand> result = parse_input_taco_args(argc - 1 - i, argv + 1 + i);
+            if (result.error) return {};
+            marker_pack_configs.insert(marker_pack_configs.end(), result.command.begin(), result.command.end());
+            i += result.arguments_parsed;
         }
+
+        else if (string(argv[i]) == "--input-guildpoint-path") {
+            ParsedArgReturn<InputGuildpointCommand> result = parse_input_guildpoint_args(argc - 1 - i, argv + 1 + i);
+            if (result.error) return {};
+            marker_pack_configs.insert(marker_pack_configs.end(), result.command.begin(), result.command.end());
+            i += result.arguments_parsed;
+        }
+
+        else if (string(argv[i]) == "--output-taco-path") {
+            ParsedArgReturn<OutputTacoCommand> result = parse_output_taco_args(argc - 1 - i, argv + 1 + i);
+            if (result.error) return {};
+            marker_pack_configs.insert(marker_pack_configs.end(), result.command.begin(), result.command.end());
+            i += result.arguments_parsed;
+        }
+
+        else if (string(argv[i]) == "--output-guildpoint-path") {
+            ParsedArgReturn<OutputGuildpointCommand> result = parse_output_guildpoint_args(argc - 1 - i, argv + 1 + i);
+            if (result.error) return {};
+            marker_pack_configs.insert(marker_pack_configs.end(), result.command.begin(), result.command.end());
+            i += result.arguments_parsed;
+        }
+
         else if (string(argv[i]) == "--allow-duplicates") {
             parsed_arguments.allow_duplicates = true;
         }
-        else if (string(argv[i]) == "--split-by-category") {
-            if (type != BehaviorType::EXPORT) {
-                cerr << "Error: --split-by-category needs to follow an output argument" << endl;
-                return {};
-            }
-            split_by_category_depth.set_value(0);
-            if (i + 1 < argc && string(argv[i + 1]).find("--") != 0) {
-                if (is_string_valid_integer(argv[i + 1])) {
-                    split_by_category_depth.set_value(std::stoi(argv[++i]));
-                }
-                else {
-                    cerr << "Error: expected an integer after --split-by-category but received " << argv[i + 1] << endl;
-                    return {};
-                }
-            }
-        }
-        else if (string(argv[i]) == "--split-by-map-id") {
-            if (type != BehaviorType::EXPORT) {
-                cerr << "Error: --split-by-map-id needs to follow an output argument" << endl;
-                return {};
-            }
-            split_by_map_id = true;
-        }
+
         else if (string(argv[i]) == "--help") {
             cout << "usage: ./burrito_converter [--help] [--allow-duplicates]" << endl;
             cout << "                       [--input-taco-path <PATH> ...]" << endl;
@@ -115,13 +284,19 @@ ParsedArguments parse_arguments(int argc, char* argv[]) {
         }
     }
 
-    if (!current_paths.empty()) {
-        for (const auto &path : current_paths) {
-            marker_pack_configs.emplace_back(type, format, path, split_by_category_depth, split_by_map_id);
-        }
-    }
-
     parsed_arguments.marker_pack_configs = marker_pack_configs;
     parsed_arguments.is_valid = true;
     return parsed_arguments;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ~ParsedArguments
+//
+// Clean up all of the allocated marker pack commands when the parsed argument
+// object is deconstructed. TODO
+////////////////////////////////////////////////////////////////////////////////
+ParsedArguments::~ParsedArguments() {
+    // for (size_t i = 0; i < this->marker_pack_configs.size(); i++) {
+    //     delete marker_pack_configs[i];
+    // }
 }

--- a/burrito_converter/src/argument_parser.hpp
+++ b/burrito_converter/src/argument_parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -19,24 +20,49 @@ enum class MarkerFormat {
     NONE,
 };
 
-class MarkerPackConfig {
+class BaseCommand {
  public:
-    BehaviorType type;
-    MarkerFormat format;
+    virtual ~BaseCommand() = default;
+};
+
+class InputTacoCommand : public BaseCommand {
+ public:
+    InputTacoCommand();
+    explicit InputTacoCommand(std::string path);
     std::string path;
-    OptionalInt split_by_category;
-    bool split_by_map_id = false;
+};
 
-    MarkerPackConfig();
+class InputGuildpointCommand : public BaseCommand {
+ public:
+    InputGuildpointCommand();
+    explicit InputGuildpointCommand(std::string path);
+    std::string path;
+};
 
-    MarkerPackConfig(BehaviorType type, MarkerFormat format, std::string path, OptionalInt split_by_category, bool split_by_map_id = false);
+class OutputTacoCommand : public BaseCommand {
+ public:
+    OutputTacoCommand();
+    explicit OutputTacoCommand(std::string path);
+    std::string path;
+};
+
+class OutputGuildpointCommand : public BaseCommand {
+ public:
+    OutputGuildpointCommand();
+    OutputGuildpointCommand(std::string path, OptionalInt split_by_category_depth, bool split_by_map_id);
+    std::string path;
+    OptionalInt split_by_category_depth;
+    bool split_by_map_id;
+    bool output_full_category_list;
 };
 
 class ParsedArguments {
  public:
-    std::vector<MarkerPackConfig> marker_pack_configs;
+    std::vector<BaseCommand*> marker_pack_configs;
     bool allow_duplicates = false;
     bool is_valid = false;
+
+    ~ParsedArguments();
 };
 
 ParsedArguments parse_arguments(int argc, char* argv[]);

--- a/burrito_converter/src/burrito_converter.cpp
+++ b/burrito_converter/src/burrito_converter.cpp
@@ -209,24 +209,26 @@ void write_burrito_directory(
 // The universal entrypoint into burrito converter functionality. Both the CLI
 // and the library entrypoints direct here to do their actual processing.
 ////////////////////////////////////////////////////////////////////////////////
-void process_data(ParsedArguments parsed_arguments) {
+void process_data(const ParsedArguments &parsed_arguments) {
     // All of the loaded pois and categories
     vector<Parseable*> parsed_pois;
     map<string, Category> marker_categories;
     map<UniqueId, CategoryWithinMultiplePacks> top_level_category_file_locations_by_pack;
     map<UniqueId, CategoryWithinMultiplePacks> duplicate_categories;
-    vector<MarkerPackConfig> marker_pack_config = parsed_arguments.marker_pack_configs;
+    vector<BaseCommand*> marker_pack_config = parsed_arguments.marker_pack_configs;
 
     // Read in all the xml taco markerpacks
     auto begin = chrono::high_resolution_clock::now();
     for (size_t i = 0; i < marker_pack_config.size(); i++) {
-        if (marker_pack_config[i].type != BehaviorType::IMPORT || marker_pack_config[i].format != MarkerFormat::XML) {
+        auto* command = dynamic_cast<InputTacoCommand*>(marker_pack_config[i]);
+        if (command == nullptr) {
             continue;
         }
-        cout << "Loading taco pack " << marker_pack_config[i].path << endl;
+
+        cout << "Loading taco pack " << command->path << endl;
 
         map<UniqueId, CategoryWithinSinglePack> top_level_category_file_locations = read_taco_directory(
-            marker_pack_config[i].path,
+            command->path,
             &marker_categories,
             &parsed_pois
         );
@@ -242,13 +244,14 @@ void process_data(ParsedArguments parsed_arguments) {
     // Read in all the protobin guildpoint markerpacks
     begin = chrono::high_resolution_clock::now();
     for (size_t i = 0; i < marker_pack_config.size(); i++) {
-        if (marker_pack_config[i].type != BehaviorType::IMPORT || marker_pack_config[i].format != MarkerFormat::GUILDPOINT) {
+        auto* command = dynamic_cast<InputGuildpointCommand*>(marker_pack_config[i]);
+        if (command == nullptr) {
             continue;
         }
-        cout << "Loading guildpoint pack " << marker_pack_config[i].path << endl;
+        cout << "Loading guildpoint pack " << command->path << endl;
 
         map<UniqueId, CategoryWithinSinglePack> top_level_category_file_locations = read_burrito_directory(
-            marker_pack_config[i].path,
+            command->path,
             &marker_categories,
             &parsed_pois
         );
@@ -261,12 +264,14 @@ void process_data(ParsedArguments parsed_arguments) {
     ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
     cout << "The guildpoint parse function took " << ms << " milliseconds to run" << endl;
 
+    // Identify duplicate categories
     for (map<UniqueId, CategoryWithinMultiplePacks>::iterator it = top_level_category_file_locations_by_pack.begin(); it != top_level_category_file_locations_by_pack.end(); it++) {
         if (it->second.categories.size() > 1) {
             duplicate_categories[it->first] = it->second;
         }
     }
 
+    // Error and show debug information for duplicate categories
     if (duplicate_categories.size() > 0 && parsed_arguments.allow_duplicates == false) {
         cout << "Did not write due to duplicates in categories." << endl;
         cout << "This commonly occurs when attempting to read the same pack multiple times or when separate packs coincidentally have the same name." << endl;
@@ -303,10 +308,11 @@ void process_data(ParsedArguments parsed_arguments) {
     // Write all of the xml taco paths
     begin = chrono::high_resolution_clock::now();
     for (size_t i = 0; i < marker_pack_config.size(); i++) {
-        if (marker_pack_config[i].type != BehaviorType::EXPORT || marker_pack_config[i].format != MarkerFormat::XML) {
+        auto* command = dynamic_cast<OutputTacoCommand*>(marker_pack_config[i]);
+        if (command == nullptr) {
             continue;
         }
-        write_taco_directory(marker_pack_config[i].path, &marker_categories, &parsed_pois);
+        write_taco_directory(command->path, &marker_categories, &parsed_pois);
     }
     end = chrono::high_resolution_clock::now();
     dur = end - begin;
@@ -316,10 +322,17 @@ void process_data(ParsedArguments parsed_arguments) {
     // Write all of the protobin guildpoint paths
     begin = chrono::high_resolution_clock::now();
     for (size_t i = 0; i < marker_pack_config.size(); i++) {
-        if (marker_pack_config[i].type != BehaviorType::EXPORT || marker_pack_config[i].format != MarkerFormat::GUILDPOINT) {
+        auto* command = dynamic_cast<OutputGuildpointCommand*>(marker_pack_config[i]);
+        if (command == nullptr) {
             continue;
         }
-        write_burrito_directory(marker_pack_config[i].path, marker_pack_config[i].split_by_map_id, marker_pack_config[i].split_by_category, &marker_categories, &parsed_pois);
+        write_burrito_directory(
+            command->path,
+            command->split_by_map_id,
+            command->split_by_category_depth,
+            &marker_categories,
+            &parsed_pois
+        );
     }
     end = chrono::high_resolution_clock::now();
     dur = end - begin;

--- a/burrito_converter/src/burrito_converter.cpp
+++ b/burrito_converter/src/burrito_converter.cpp
@@ -312,7 +312,11 @@ void process_data(const ParsedArguments &parsed_arguments) {
         if (command == nullptr) {
             continue;
         }
-        write_taco_directory(command->path, &marker_categories, &parsed_pois);
+        write_taco_directory(
+            command->path,
+            &marker_categories,
+            &parsed_pois
+        );
     }
     end = chrono::high_resolution_clock::now();
     dur = end - begin;

--- a/burrito_converter/tests/test_argument_parser.cpp
+++ b/burrito_converter/tests/test_argument_parser.cpp
@@ -20,15 +20,13 @@ TEST_F(ParseArgumentsTest, ValidInputPaths){
 
     ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::XML);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
+    InputTacoCommand* command_0 = dynamic_cast<InputTacoCommand*>(parsed_arguments.marker_pack_configs[0]);
+    EXPECT_NE(command_0, nullptr);
+    EXPECT_EQ(command_0->path, "input1");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::XML);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
+    OutputTacoCommand* command_1 = dynamic_cast<OutputTacoCommand*>(parsed_arguments.marker_pack_configs[1]);
+    EXPECT_NE(command_1, nullptr);
+    EXPECT_EQ(command_1->path, "output1");
 }
 
 TEST_F(ParseArgumentsTest, ValidSplitMapID){
@@ -47,15 +45,15 @@ TEST_F(ParseArgumentsTest, ValidSplitMapID){
 
     ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
+    InputGuildpointCommand* command_0 = dynamic_cast<InputGuildpointCommand*>(parsed_arguments.marker_pack_configs[0]);
+    EXPECT_NE(command_0, nullptr);
+    EXPECT_EQ(command_0->path, "input1");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
-    EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
+    OutputGuildpointCommand* command_1 = dynamic_cast<OutputGuildpointCommand*>(parsed_arguments.marker_pack_configs[1]);
+    EXPECT_NE(command_1, nullptr);
+    EXPECT_EQ(command_1->path, "output1");
+    EXPECT_TRUE(command_1->split_by_map_id);
+    EXPECT_FALSE(command_1->split_by_category_depth.has_value());
 }
 
 TEST_F(ParseArgumentsTest, ValidSplitCategory){
@@ -74,18 +72,16 @@ TEST_F(ParseArgumentsTest, ValidSplitCategory){
 
     ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_category.has_value());
+    InputGuildpointCommand* command_0 = dynamic_cast<InputGuildpointCommand*>(parsed_arguments.marker_pack_configs[0]);
+    EXPECT_NE(command_0, nullptr);
+    EXPECT_EQ(command_0->path, "input1");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
-    EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_category.has_value());
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].split_by_category.get_value(), 0);
+    OutputGuildpointCommand* command_1 = dynamic_cast<OutputGuildpointCommand*>(parsed_arguments.marker_pack_configs[1]);
+    EXPECT_NE(command_1, nullptr);
+    EXPECT_EQ(command_1->path, "output1");
+    EXPECT_FALSE(command_1->split_by_map_id);
+    EXPECT_TRUE(command_1->split_by_category_depth.has_value());
+    EXPECT_EQ(command_1->split_by_category_depth.get_value(), 0);
 }
 
 TEST_F(ParseArgumentsTest, ValidSplitCategoryWithDepth){
@@ -105,18 +101,16 @@ TEST_F(ParseArgumentsTest, ValidSplitCategoryWithDepth){
 
     ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 2);
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_category.has_value());
+    InputGuildpointCommand* command_0 = dynamic_cast<InputGuildpointCommand*>(parsed_arguments.marker_pack_configs[0]);
+    EXPECT_NE(command_0, nullptr);
+    EXPECT_EQ(command_0->path, "input1");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::EXPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "output1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
-    EXPECT_TRUE(parsed_arguments.marker_pack_configs[1].split_by_category.has_value());
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].split_by_category.get_value(), 2);
+    OutputGuildpointCommand* command_1 = dynamic_cast<OutputGuildpointCommand*>(parsed_arguments.marker_pack_configs[1]);
+    EXPECT_NE(command_1, nullptr);
+    EXPECT_EQ(command_1->path, "output1");
+    EXPECT_FALSE(command_1->split_by_map_id);
+    EXPECT_TRUE(command_1->split_by_category_depth.has_value());
+    EXPECT_EQ(command_1->split_by_category_depth.get_value(), 2);
 }
 
 TEST_F(ParseArgumentsTest, ValidMultipleInputPaths){
@@ -138,27 +132,24 @@ TEST_F(ParseArgumentsTest, ValidMultipleInputPaths){
     ASSERT_EQ(parsed_arguments.marker_pack_configs.size(), 4);
     EXPECT_TRUE(parsed_arguments.allow_duplicates);
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].format, MarkerFormat::XML);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[0].path, "input1");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[0].split_by_map_id);
+    InputTacoCommand* command_0 = dynamic_cast<InputTacoCommand*>(parsed_arguments.marker_pack_configs[0]);
+    EXPECT_NE(command_0, nullptr);
+    EXPECT_EQ(command_0->path, "input1");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].format, MarkerFormat::XML);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[1].path, "input2");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[1].split_by_map_id);
+    InputTacoCommand* command_1 = dynamic_cast<InputTacoCommand*>(parsed_arguments.marker_pack_configs[1]);
+    EXPECT_NE(command_1, nullptr);
+    EXPECT_EQ(command_1->path, "input2");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[2].type, BehaviorType::IMPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[2].format, MarkerFormat::XML);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[2].path, "input3");
-    EXPECT_FALSE(parsed_arguments.marker_pack_configs[2].split_by_map_id);
+    InputTacoCommand* command_2 = dynamic_cast<InputTacoCommand*>(parsed_arguments.marker_pack_configs[2]);
+    EXPECT_NE(command_2, nullptr);
+    EXPECT_EQ(command_2->path, "input3");
 
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[3].type, BehaviorType::EXPORT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[3].format, MarkerFormat::GUILDPOINT);
-    EXPECT_EQ(parsed_arguments.marker_pack_configs[3].path, "output1");
-    EXPECT_TRUE(parsed_arguments.marker_pack_configs[3].split_by_map_id);
+    OutputGuildpointCommand* command_3 = dynamic_cast<OutputGuildpointCommand*>(parsed_arguments.marker_pack_configs[3]);
+    EXPECT_NE(command_3, nullptr);
+    EXPECT_EQ(command_3->path, "output1");
+    EXPECT_TRUE(command_3->split_by_map_id);
+    EXPECT_FALSE(command_3->split_by_category_depth.has_value());
 }
-
 
 TEST_F(ParseArgumentsTest, InvalidSplitMapIDAfterInput){
     char* argv[] = {
@@ -176,7 +167,7 @@ TEST_F(ParseArgumentsTest, InvalidSplitMapIDAfterInput){
     std::string std_err = testing::internal::GetCapturedStderr();
 
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
-    EXPECT_NE(std_err.find("Error: --split-by-map-id needs to follow an output argument"), std::string::npos);
+    EXPECT_NE(std_err.find("Error: Unknown argument --split-by-map-id"), std::string::npos);
 }
 
 TEST_F(ParseArgumentsTest, InvalidNoPathAfterInput){
@@ -193,7 +184,7 @@ TEST_F(ParseArgumentsTest, InvalidNoPathAfterInput){
     std::string std_err = testing::internal::GetCapturedStderr();
 
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
-    EXPECT_NE(std_err.find("Error: Expected a path to a directory after --input-taco-path"), std::string::npos);
+    EXPECT_NE(std_err.find("Error: --input-taco-path is missing a path"), std::string::npos);
 }
 
 TEST_F(ParseArgumentsTest, InvalidNoPathAfterOutput){
@@ -210,7 +201,7 @@ TEST_F(ParseArgumentsTest, InvalidNoPathAfterOutput){
     std::string std_err = testing::internal::GetCapturedStderr();
 
     EXPECT_TRUE(parsed_arguments.marker_pack_configs.empty());
-    EXPECT_NE(std_err.find("Error: Expected a path to a directory after --output-taco-path"), std::string::npos);
+    EXPECT_NE(std_err.find("Error: --output-taco-path is missing a path"), std::string::npos);
 }
 
 TEST_F(ParseArgumentsTest, InvalidFileAfterWrongArgument){
@@ -218,8 +209,8 @@ TEST_F(ParseArgumentsTest, InvalidFileAfterWrongArgument){
         (char*)"./burrito_converter",
         (char*)"--input-taco-path",
         (char*)"input1",
-        (char*)"--output-taco-path",
-        (char*)"output1",        
+        (char*)"--output-guildpoint-path",
+        (char*)"output1",
         (char*)"--split-by-map-id",
         (char*)"output2"
     };


### PR DESCRIPTION
Using structs gives us some better control over which flags can be assigned to which inputs and outputs, allowing us to do some more complex things with arguments in the future.