### PR TITLE
Update input region based on visible dialogs

### DIFF
--- a/Settings.gd
+++ b/Settings.gd
@@ -45,6 +45,7 @@ var burrito_link_wine_path: String = ""
 var burrito_link_env_args: String = ""
 
 var enable_player_cutout: bool = false
+var allow_optimal_mouse_block: bool = false
 
 # We save the marker data in this directory when the files are have been split
 # by Map ID. All changes made by the editor are automatically saved in these
@@ -102,6 +103,8 @@ func _ready():
 		self.start_with_open_menu = self._config_data["start_with_open_menu"]
 	if "enable_player_cutout" in self._config_data:
 		self.enable_player_cutout = self._config_data["enable_player_cutout"]
+	if "allow_optimal_mouse_block" in self._config_data:
+		self.allow_optimal_mouse_block = self._config_data["allow_optimal_mouse_block"]
 
 
 func get_saved_markers_dir() -> String:
@@ -127,7 +130,8 @@ func save():
 		"burrito_link_env_args": burrito_link_env_args,
 		"local_category_data": local_category_data,
 		"start_with_open_menu": start_with_open_menu,
-		"enable_player_cutout": enable_player_cutout
+		"enable_player_cutout": enable_player_cutout,
+		"allow_optimal_mouse_block": allow_optimal_mouse_block
 	}
 
 	var file = File.new()

--- a/SettingsDialog.gd
+++ b/SettingsDialog.gd
@@ -29,6 +29,9 @@ func load_settings():
 	var enable_player_cutout: CheckButton = $ScrollContainer/GridContainer/EnablePlayerCutout
 	enable_player_cutout.pressed = Settings.enable_player_cutout
 
+	var allow_optimal_mouse_block: CheckButton = $ScrollContainer/GridContainer/AllowOptimalMouseBlock
+	allow_optimal_mouse_block.pressed = Settings.allow_optimal_mouse_block
+
 
 func save_settings(new_value=null):
 	var minimum_width: LineEdit = $ScrollContainer/GridContainer/MinimumWidth
@@ -65,6 +68,9 @@ func save_settings(new_value=null):
 
 	var enable_player_cutout: CheckButton = $ScrollContainer/GridContainer/EnablePlayerCutout
 	Settings.enable_player_cutout = enable_player_cutout.pressed
+
+	var allow_optimal_mouse_block: CheckButton = $ScrollContainer/GridContainer/AllowOptimalMouseBlock
+	Settings.allow_optimal_mouse_block = allow_optimal_mouse_block.pressed
 
 	Settings.save()
 

--- a/Spatial.gd
+++ b/Spatial.gd
@@ -67,6 +67,9 @@ var player_head_projected_y = 1080
 var player_projected_width = 100
 var player_cutout_showing = false
 
+# Tracking last mouse block type
+enum MouseBlockState { NONE, MINIMAL, MAXIMAL, OPTIMAL }
+var current_mouse_block_state = MouseBlockState.NONE
 
 ##########Node Connections###########
 onready var markers_ui := $Control/Dialogs/CategoriesDialog/MarkersUI as Tree
@@ -92,7 +95,6 @@ func _ready():
 
 	# Postion at top left corner
 	OS.set_window_position(Vector2(0,0))
-	set_minimal_mouse_block()
 
 	server.listen(4242)
 
@@ -101,6 +103,8 @@ func _ready():
 
 	if (Settings.start_with_open_menu):
 		_on_main_menu_toggle_pressed()
+
+	Settings.connect("settings_updated", self, "update_mouse_block")
 
 ################################################################################
 # show_error
@@ -150,6 +154,81 @@ func exit_burrito():
 		close_burrito_link()
 	get_tree().quit()
 
+func update_mouse_block():
+	# First try to do an optimal mouse block, which is more convenient for the user
+	var mouse_block_done = false
+	if Settings.allow_optimal_mouse_block:
+		mouse_block_done = set_optimal_mouse_block()
+
+	# If we couldn't do optimal mouse block, fall back to the classical approach
+	if mouse_block_done:
+		current_mouse_block_state = MouseBlockState.OPTIMAL
+	else:
+		if is_any_dialog_visible():
+			if current_mouse_block_state != MouseBlockState.MAXIMAL:
+				set_maximal_mouse_block()
+				current_mouse_block_state = MouseBlockState.MAXIMAL
+		else:
+			if current_mouse_block_state != MouseBlockState.MINIMAL:
+				set_minimal_mouse_block()
+				current_mouse_block_state = MouseBlockState.MINIMAL
+
+func set_optimal_mouse_block() -> bool:
+	# Verify display backend support. Note that Godot 3 returns "X11" from OS.get_name() even for Linux+Wayland.
+	# Godot 4 has this fixed. It returns "Linux" as OS name and adds DisplayServer.get_name() to query X11/Wayland.
+	var is_linux = OS.get_name() == "X11"
+	if is_linux:
+		# Wayland support has to be implemented in burrito-fg.
+		var session := OS.get_environment("XDG_SESSION_TYPE").to_lower()
+		if session != "x11":
+			return false
+	else:
+		# Windows and Mac support has to be implemented in burrito-fg.
+		return false
+
+	var rects: Array = []
+
+	# Add rects that are not dialogs
+	var menu_button = $Control/GlobalMenuButton
+	rects.append({
+		"x": int(menu_button.get_position().x),
+		"y": int(menu_button.get_position().y),
+		"w": int(menu_button.get_size().x),
+		"h": int(menu_button.get_size().y),
+	})
+	var editor_quick_panel = $Control/GlobalMenuButton/EditorQuckPanel
+	if editor_quick_panel.visible:
+		rects.append({
+			"x": int(editor_quick_panel.get_global_rect().position.x),
+			"y": int(editor_quick_panel.get_global_rect().position.y),
+			"w": int(editor_quick_panel.get_size().x),
+			"h": int(editor_quick_panel.get_size().y),
+		})
+
+	# Add rects of dialogs
+	var dialogs = []
+	get_all_visible_dialogs($Control/Dialogs, dialogs)
+	for dialog in dialogs:
+		var pos = dialog.get_position()
+		var size = dialog.get_size()
+
+		var title_height = dialog.get_constant("title_height", "WindowDialog")
+		pos.y -= title_height
+		size.y += title_height
+
+		rects.append({
+			"x": int(pos.x),
+			"y": int(pos.y),
+			"w": int(size.x),
+			"h": int(size.y),
+		})
+
+	# Execute input set operation. Return result, so we can fallback to other approaches
+	# in case of any errors.
+	var success = x11_fg.set_input_shapes(x11_window_id_burrito, rects)
+	if success:
+		$Control/Border.hide()
+	return success
 
 func set_minimal_mouse_block():
 	var menu_button = $Control/GlobalMenuButton
@@ -374,9 +453,6 @@ func decode_context_packet(spb: StreamPeerBuffer):
 		Settings.ui_size = 1
 
 	$Control/GlobalMenuButton._update_global_menu_button_position()
-
-	if !is_any_dialog_visible():
-		set_minimal_mouse_block()
 
 	compass_width = compass_width * Settings.minimap_scale[Settings.ui_size]["factor"]
 	compass_height = compass_height * Settings.minimap_scale[Settings.ui_size]["factor"]
@@ -754,7 +830,6 @@ func read_hash(map_id: int) -> String:
 var adjusting = false
 func _on_AdjustNodesButton_pressed():
 	$Control/Dialogs/NodeEditorDialog.show()
-	set_maximal_mouse_block()
 	gen_adjustment_nodes()
 
 
@@ -973,9 +1048,11 @@ func toast(message: String):
 ################################################################################
 # Signal Functions
 ################################################################################
+func _on_dialog_change():
+	$InputRegionUpdateTimer.start()
+
 func _on_main_menu_toggle_pressed():
 	$Control/Dialogs/MainMenu.show()
-	set_maximal_mouse_block()
 
 func is_any_dialog_visible(node = $Control/Dialogs):
 	for dialog in node.get_children():
@@ -986,10 +1063,12 @@ func is_any_dialog_visible(node = $Control/Dialogs):
 			return true
 	return false
 
-func _on_Dialog_hide():
-	if !is_any_dialog_visible():
-		set_minimal_mouse_block()
-
+func get_all_visible_dialogs(node, array):
+	for sub_node in node.get_children():
+		if sub_node.get_class() == "Control":
+			get_all_visible_dialogs(sub_node, array)
+		elif sub_node.visible:
+			array.append(sub_node)
 
 func _on_LoadTrail_pressed():
 	if $Control/Dialogs/CategoriesDialog.is_visible():
@@ -1024,7 +1103,6 @@ func _on_ChangeTexture_pressed():
 	$Control/Dialogs/TexturePathOpen.show()
 	var texture_path_dialog:FileDialog = $Control/Dialogs/TexturePathOpen
 	texture_path_dialog.set_current_dir(texture_path_dialog.current_dir)
-	set_maximal_mouse_block()
 
 ################################################################################
 # Set the file that will be used to create a new trail or icon when a new trail
@@ -1104,7 +1182,6 @@ func _on_NewTrailPoint_pressed():
 func _on_NodeEditorDialog_hide():
 	on_gizmo_deselected()
 	clear_adjustment_nodes()
-	_on_Dialog_hide()
 
 
 func _on_DeleteNode_pressed():

--- a/Spatial.tscn
+++ b/Spatial.tscn
@@ -53,6 +53,10 @@ shader_param/custom_7_value = 500.0
 [node name="Spatial" type="Spatial"]
 script = ExtResource( 1 )
 
+[node name="InputRegionUpdateTimer" type="Timer" parent="."]
+wait_time = 0.1
+one_shot = true
+
 [node name="Markers3D" type="Spatial" parent="."]
 script = ExtResource( 13 )
 
@@ -675,7 +679,7 @@ __meta__ = {
 
 [node name="GridContainer" type="GridContainer" parent="Control/Dialogs/SettingsDialog/ScrollContainer"]
 margin_right = 384.0
-margin_bottom = 480.0
+margin_bottom = 524.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
@@ -799,61 +803,74 @@ margin_right = 372.0
 margin_bottom = 296.0
 size_flags_horizontal = 3
 
-[node name="HSeparator" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 300.0
+[node name="AllowOptimalMouseBlockLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_top = 313.0
 margin_right = 192.0
-margin_bottom = 304.0
+margin_bottom = 327.0
+text = "Allow optimal mouse block"
+
+[node name="AllowOptimalMouseBlock" type="CheckButton" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_left = 196.0
+margin_top = 300.0
+margin_right = 372.0
+margin_bottom = 340.0
+size_flags_horizontal = 3
+
+[node name="HSeparator" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
+margin_top = 344.0
+margin_right = 192.0
+margin_bottom = 348.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HSeparator2" type="HSeparator" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 300.0
+margin_top = 344.0
 margin_right = 372.0
-margin_bottom = 304.0
+margin_bottom = 348.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="AutoLaunchBurritoLinkLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 312.0
+margin_top = 356.0
 margin_right = 192.0
-margin_bottom = 343.0
+margin_bottom = 387.0
 text = "Auto Launch
 Burrito Link"
 
 [node name="AutoLaunchBurritoLink" type="CheckButton" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 308.0
+margin_top = 352.0
 margin_right = 372.0
-margin_bottom = 348.0
+margin_bottom = 392.0
 size_flags_horizontal = 3
 
 [node name="WinePathLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 357.0
+margin_top = 401.0
 margin_right = 192.0
-margin_bottom = 371.0
+margin_bottom = 415.0
 text = "Wine Path"
 
 [node name="WinePath" type="LineEdit" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 352.0
+margin_top = 396.0
 margin_right = 372.0
-margin_bottom = 376.0
+margin_bottom = 420.0
 size_flags_horizontal = 3
 
 [node name="EnvironmentVarsLabel" type="Label" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
-margin_top = 423.0
+margin_top = 467.0
 margin_right = 192.0
-margin_bottom = 437.0
+margin_bottom = 481.0
 text = "Environment Vars"
 
 [node name="EnvironmentVars" type="TextEdit" parent="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer"]
 margin_left = 196.0
-margin_top = 380.0
+margin_top = 424.0
 margin_right = 372.0
-margin_bottom = 480.0
+margin_bottom = 524.0
 rect_min_size = Vector2( 0, 100 )
 size_flags_horizontal = 3
 
@@ -967,7 +984,12 @@ color = Color( 0, 0, 0, 1 )
 mesh = SubResource( 3 )
 material/0 = SubResource( 4 )
 
+[connection signal="timeout" from="InputRegionUpdateTimer" to="." method="update_mouse_block"]
+[connection signal="item_rect_changed" from="Control/GlobalMenuButton" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/GlobalMenuButton" to="." method="_on_dialog_change"]
 [connection signal="pressed" from="Control/GlobalMenuButton/main_menu_toggle" to="." method="_on_main_menu_toggle_pressed"]
+[connection signal="item_rect_changed" from="Control/GlobalMenuButton/EditorQuckPanel" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/GlobalMenuButton/EditorQuckPanel" to="." method="_on_dialog_change"]
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/CloseEditorQuickPanel" to="." method="_on_CloseEditorQuickPanel_pressed"]
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/ChangeTexture" to="." method="_on_ChangeTexture_pressed"]
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/NewTrail" to="." method="_on_NewTrail_pressed"]
@@ -976,12 +998,17 @@ material/0 = SubResource( 4 )
 [connection signal="pressed" from="Control/GlobalMenuButton/EditorQuckPanel/HBoxContainer/AdjustPoints" to="." method="_on_AdjustNodesButton_pressed"]
 [connection signal="dir_selected" from="Control/Dialogs/ImportPackDialogs/ImportBurritoPackDialog" to="." method="_on_ImportBurritoPackDialog_dir_selected"]
 [connection signal="file_selected" from="Control/Dialogs/ImportPackDialogs/ImportBurritoPackDialog" to="." method="_on_ImportBurritoPackDialog_file_selected"]
-[connection signal="hide" from="Control/Dialogs/ImportPackDialogs/ImportBurritoPackDialog" to="." method="_on_Dialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/ImportPackDialogs/ImportBurritoPackDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/ImportPackDialogs/ImportBurritoPackDialog" to="." method="_on_dialog_change"]
 [connection signal="dir_selected" from="Control/Dialogs/ImportPackDialogs/ImportTacoPackDialog" to="." method="_on_ImportTacoPackDialog_dir_selected"]
 [connection signal="file_selected" from="Control/Dialogs/ImportPackDialogs/ImportTacoPackDialog" to="." method="_on_ImportTacoPackDialog_file_selected"]
-[connection signal="hide" from="Control/Dialogs/ImportPackDialogs/ImportTacoPackDialog" to="." method="_on_Dialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/ImportPackDialogs/ImportTacoPackDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/ImportPackDialogs/ImportTacoPackDialog" to="." method="_on_dialog_change"]
+[connection signal="item_rect_changed" from="Control/Dialogs/ImportPackDialogs/OverwriteConfirm" to="." method="_on_dialog_change"]
 [connection signal="popup_hide" from="Control/Dialogs/ImportPackDialogs/OverwriteConfirm" to="Control/Dialogs/ImportPackDialogs/OverwriteConfirm" method="_on_OverwriteConfirm_popup_hide"]
-[connection signal="hide" from="Control/Dialogs/MainMenu" to="." method="_on_Dialog_hide"]
+[connection signal="visibility_changed" from="Control/Dialogs/ImportPackDialogs/OverwriteConfirm" to="." method="_on_dialog_change"]
+[connection signal="item_rect_changed" from="Control/Dialogs/MainMenu" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/MainMenu" to="." method="_on_dialog_change"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/LoadTrail" to="." method="_on_LoadTrail_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/ImportTaco" to="." method="_on_ImportTaco_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/ImportBurrito" to="." method="_on_ImportBurrito_pressed"]
@@ -990,7 +1017,8 @@ material/0 = SubResource( 4 )
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/Ranges" to="." method="_on_RangesButton_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/Settings" to="." method="_on_Settings_pressed"]
 [connection signal="pressed" from="Control/Dialogs/MainMenu/ScrollContainer/VBoxContainer/ExitButton" to="." method="_on_ExitButton_pressed"]
-[connection signal="hide" from="Control/Dialogs/RangesDialog" to="." method="_on_Dialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/RangesDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/RangesDialog" to="." method="_on_dialog_change"]
 [connection signal="pressed" from="Control/Dialogs/RangesDialog/GridContainer/CheckButton" to="Control/Dialogs/RangesDialog" method="on_change"]
 [connection signal="value_changed" from="Control/Dialogs/RangesDialog/GridContainer/SpinBox" to="Control/Dialogs/RangesDialog" method="on_change"]
 [connection signal="pressed" from="Control/Dialogs/RangesDialog/GridContainer/CheckButton2" to="Control/Dialogs/RangesDialog" method="on_change"]
@@ -1006,9 +1034,12 @@ material/0 = SubResource( 4 )
 [connection signal="pressed" from="Control/Dialogs/RangesDialog/GridContainer/CheckButton7" to="Control/Dialogs/RangesDialog" method="on_change"]
 [connection signal="value_changed" from="Control/Dialogs/RangesDialog/GridContainer/SpinBox7" to="Control/Dialogs/RangesDialog" method="on_change"]
 [connection signal="file_selected" from="Control/Dialogs/TexturePathOpen" to="." method="_on_TexturePathOpen_file_selected"]
-[connection signal="hide" from="Control/Dialogs/TexturePathOpen" to="." method="_on_Dialog_hide"]
-[connection signal="hide" from="Control/Dialogs/SaveDialog" to="." method="_on_Dialog_hide"]
-[connection signal="hide" from="Control/Dialogs/NodeEditorDialog" to="." method="_on_NodeEditorDialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/TexturePathOpen" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/TexturePathOpen" to="." method="_on_dialog_change"]
+[connection signal="item_rect_changed" from="Control/Dialogs/SaveDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/SaveDialog" to="." method="_on_dialog_change"]
+[connection signal="item_rect_changed" from="Control/Dialogs/NodeEditorDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/NodeEditorDialog" to="." method="_on_dialog_change"]
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/DeleteNode" to="." method="_on_DeleteNode_pressed"]
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/NewTrailPointAfter" to="." method="_on_NewTrailPointAfter_pressed"]
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/SnapSelectedToPlayer" to="." method="_on_SnapSelectedToPlayer_pressed"]
@@ -1016,7 +1047,8 @@ material/0 = SubResource( 4 )
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/YSnapToPlayer" to="." method="_on_YSnapToPlayer_pressed"]
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/SetActiveTrail" to="." method="_on_SetActiveTrail_pressed"]
 [connection signal="pressed" from="Control/Dialogs/NodeEditorDialog/ScrollContainer/VBoxContainer/ReverseTrailDirection" to="." method="_on_ReverseTrailDirection_pressed"]
-[connection signal="hide" from="Control/Dialogs/SettingsDialog" to="." method="_on_NodeEditorDialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/SettingsDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/SettingsDialog" to="." method="_on_dialog_change"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/MinimumWidth" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/MinimumHeight" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideSize" to="Control/Dialogs/SettingsDialog" method="save_settings"]
@@ -1026,9 +1058,11 @@ material/0 = SubResource( 4 )
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideBurritoIconHorizontalPosition" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/OverrideBurritoIconVerticalPosition" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/EnablePlayerCutout" to="Control/Dialogs/SettingsDialog" method="save_settings"]
+[connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/AllowOptimalMouseBlock" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="pressed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/AutoLaunchBurritoLink" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/WinePath" to="Control/Dialogs/SettingsDialog" method="save_settings"]
 [connection signal="text_changed" from="Control/Dialogs/SettingsDialog/ScrollContainer/GridContainer/EnvironmentVars" to="Control/Dialogs/SettingsDialog" method="save_settings"]
-[connection signal="hide" from="Control/Dialogs/CategoriesDialog" to="." method="_on_Dialog_hide"]
+[connection signal="item_rect_changed" from="Control/Dialogs/CategoriesDialog" to="." method="_on_dialog_change"]
+[connection signal="visibility_changed" from="Control/Dialogs/CategoriesDialog" to="." method="_on_dialog_change"]
 [connection signal="cell_selected" from="Control/Dialogs/CategoriesDialog/MarkersUI" to="." method="_on_MarkersUI_cell_selected"]
 [connection signal="item_edited" from="Control/Dialogs/CategoriesDialog/MarkersUI" to="." method="_on_MarkersUI_item_edited"]

--- a/burrito-fg/src/lib.rs
+++ b/burrito-fg/src/lib.rs
@@ -4,10 +4,61 @@ use breadx::{
     Display, DisplayBase, DisplayConnection, Window,
 };
 use gdnative::prelude::*;
+use std::os::raw::c_int;
+
+#[link(name = "X11")]
+#[link(name = "Xext")]
+extern "C" {
+    pub fn XOpenDisplay(name: *const i8) -> *mut XDisplay;
+    pub fn XPolygonRegion(
+        points: *const XPoint,
+        npoints: i32,
+        fill_rule: i32,
+    ) -> XRegion;
+    pub fn XShapeCombineRegion(
+        dpy: *mut XDisplay,
+        dest: XWindow,
+        dest_kind: i32,
+        xoff: i32,
+        yoff: i32,
+        region: XRegion,
+        op: i32,
+    );
+    pub fn XDestroyRegion(region: XRegion);
+    pub fn XFlush(dpy: *mut XDisplay) -> i32;
+}
+
+pub enum XDisplay {}
+pub type XWindow = u64;
+pub type XRegion = *mut std::ffi::c_void;
+
+#[repr(C)]
+pub struct XPoint {
+    pub x: i16,
+    pub y: i16,
+}
+
+#[repr(C)]
+#[derive(ToVariant, FromVariant)]
+pub struct GdRect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+}
+
+#[allow(non_upper_case_globals)]
+const ShapeInput: c_int = 2;
+#[allow(non_upper_case_globals)]
+const ShapeSet: c_int = 0;
+#[allow(non_upper_case_globals)]
+const ShapeUnion: c_int = 1;
 
 #[derive(NativeClass)]
 #[inherit(Node)]
-pub struct X11_FG;
+pub struct X11_FG {
+    dpy: *mut XDisplay,
+}
 // Function that registers all exposed classes to Godot
 fn init(handle: InitHandle) {
     handle.add_class::<X11_FG>();
@@ -16,7 +67,8 @@ fn init(handle: InitHandle) {
 impl X11_FG {
     /// The "constructor" of the class.
     fn new(_owner: &Node) -> Self {
-        X11_FG
+        let dpy = unsafe { XOpenDisplay(std::ptr::null()) };
+        X11_FG { dpy }
     }
 }
 
@@ -26,6 +78,44 @@ impl X11_FG {
     fn _ready(&self, _owner: &Node) {
         godot_print!("Hello,X11!");
         return;
+    }
+
+    #[export]
+    fn set_input_shapes(&self, _node: &Node, burrito_id: i32, rects: Vec<GdRect>) -> bool {
+        let window = burrito_id as XWindow;
+        if self.dpy.is_null() {
+            return false;
+        }
+
+        unsafe {
+            for (i, r) in rects.iter().enumerate() {
+                let pts = [
+                    XPoint { x: r.x         as i16,  y: r.y         as i16 },
+                    XPoint { x: (r.x + r.w) as i16,  y: r.y         as i16 },
+                    XPoint { x: (r.x + r.w) as i16,  y: (r.y + r.h) as i16 },
+                    XPoint { x: r.x         as i16,  y: (r.y + r.h) as i16 },
+                ];
+
+                let region = XPolygonRegion(pts.as_ptr(), pts.len() as c_int, 0);
+                let op = if i == 0 { ShapeSet } else { ShapeUnion };
+
+                XShapeCombineRegion(
+                    self.dpy,
+                    window,
+                    ShapeInput,
+                    0,
+                    0,
+                    region,
+                    op,
+                );
+
+                XDestroyRegion(region);
+                godot_print!("set_input_shapes called ({},{}) -> ({}, {})", pts[0].x, pts[0].y, pts[3].x, pts[3].y);
+            }
+            godot_print!("");
+            XFlush(self.dpy);
+        }
+        true
     }
 
     #[export]


### PR DESCRIPTION
This commit implements input region setting in burrito-fg instead of relying on Godot's API, which only allows a single rect. It enhances Burrito usability - it's not needed to close all dialogs to interact with the game.

- add `set_optimal_mouse_block`, which iterates over all dialogs and applies their bounding rects as input rects. Only supported for x11 for now. For other backend it will return false.
- add `update_mouse_block` as a frontend function for  `set_minimal_mouse_block`, `set_maximal_mouse_block` and the newly added `set_optimal_mouse_block`. It will first try to use optimal mouse block and if it fails, is not supported or is disabled with a setting, it will fallback to min/max mouse block.
- Connect the `item_rect_changed` and `visibility_changed` of all visible controls to `update_mouse_block` (although not directly, but via a timer). There's no reason to call this function in code.
- `InputRegionUpdateTimer` is added to limit the number of calls to `update_mouse_block`. When any dialog changes visibility or bounding rect, it restarts this timer. When the timer elapses, it calls `update_mouse_block`. 
